### PR TITLE
Improve error handling UX with friendly messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Tests for cached model round-trips, updates, and label preservation
 - Automatic retry with exponential backoff for transient API failures (timeouts, rate limits, server errors)
 
+### Changed
+- Error messages are now user-friendly with clear guidance instead of technical details
+- Added error banner component that displays contextual icons, recovery suggestions, and retry actions
+- Network, auth, and server errors are mapped to actionable messages (e.g., "You're offline. Your changes will sync when you're back online.")
+
 ### Fixed
 - VoiceOver accessibility across all screens: added descriptive labels to interactive controls, task rows, calendar cells, focus timer, and notification bell
 - Added accessibility grouping to task rows, project rows, notification rows, and empty states so VoiceOver reads them as coherent elements

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -8,6 +8,7 @@ final class AppState {
     var isAuthenticated: Bool = false
     var isLoading: Bool = false
     var errorMessage: String?
+    var activeError: NetworkError?
 
     var tasks: [VTask] = []
     var projects: [Project] = []
@@ -271,6 +272,7 @@ final class AppState {
             }
 
             errorMessage = nil
+            activeError = nil
             #if DEBUG
             print("[mDone] refreshAll: SUCCESS")
             #endif
@@ -289,12 +291,12 @@ final class AppState {
                 #endif
                 await logout()
             }
-            errorMessage = error.errorDescription
+            handleError(error)
         } catch {
             #if DEBUG
             print("[mDone] refreshAll: other error: \(error)")
             #endif
-            errorMessage = error.localizedDescription
+            handleError(error)
         }
     }
 
@@ -311,13 +313,14 @@ final class AppState {
             )
             tasks = results
             errorMessage = nil
+            activeError = nil
         } catch let error as NetworkError {
             if case .unauthorized = error {
                 await logout()
             }
-            errorMessage = error.errorDescription
+            handleError(error)
         } catch {
-            errorMessage = error.localizedDescription
+            handleError(error)
         }
     }
 
@@ -331,13 +334,14 @@ final class AppState {
             )
             tasks = results
             errorMessage = nil
+            activeError = nil
         } catch let error as NetworkError {
             if case .unauthorized = error {
                 await logout()
             }
-            errorMessage = error.errorDescription
+            handleError(error)
         } catch {
-            errorMessage = error.localizedDescription
+            handleError(error)
         }
     }
 
@@ -356,7 +360,7 @@ final class AppState {
             #endif
             WidgetCenter.shared.reloadAllTimelines()
         } catch {
-            errorMessage = error.localizedDescription
+            handleError(error)
         }
     }
 
@@ -371,7 +375,7 @@ final class AppState {
             #endif
             WidgetCenter.shared.reloadAllTimelines()
         } catch {
-            errorMessage = error.localizedDescription
+            handleError(error)
         }
     }
 
@@ -391,7 +395,7 @@ final class AppState {
             }
             WidgetCenter.shared.reloadAllTimelines()
         } catch {
-            errorMessage = error.localizedDescription
+            handleError(error)
         }
     }
 
@@ -407,7 +411,7 @@ final class AppState {
             #endif
             WidgetCenter.shared.reloadAllTimelines()
         } catch {
-            errorMessage = error.localizedDescription
+            handleError(error)
         }
     }
 
@@ -567,7 +571,7 @@ final class AppState {
                 projectTaskCache[task.projectId] = cached.sorted { ($0.position ?? 0) < ($1.position ?? 0) }
             }
         } catch {
-            errorMessage = error.localizedDescription
+            handleError(error)
         }
     }
 
@@ -587,6 +591,15 @@ final class AppState {
             }
         }
         return result
+    }
+
+    // MARK: - Error Handling
+
+    @MainActor
+    private func handleError(_ error: Error) {
+        let friendlyError = NetworkError.friendly(from: error)
+        errorMessage = friendlyError.errorDescription
+        activeError = friendlyError
     }
 
     // MARK: - Widget Data

--- a/mDone/Models/APIModels.swift
+++ b/mDone/Models/APIModels.swift
@@ -21,24 +21,120 @@ enum NetworkError: LocalizedError {
     case decodingError(Error)
     case networkUnavailable
     case rateLimited
+    case timeout
+    case serverUnreachable
     case unknown(Error)
 
     var errorDescription: String? {
         switch self {
         case .invalidURL:
-            "Invalid server URL"
+            "The server URL doesn't look right. Please check it in Settings."
         case .unauthorized:
-            "Authentication failed. Please check your API token."
-        case let .serverError(code, message):
-            message ?? "Server error (\(code))"
+            "Your session has expired. Please log in again."
+        case let .serverError(code, _):
+            if code >= 500 {
+                "The server is having trouble. Please try again in a moment."
+            } else {
+                "Something went wrong with that request. Please try again."
+            }
         case .decodingError:
-            "Failed to parse server response"
+            "We received an unexpected response from the server. Please try again."
         case .networkUnavailable:
-            "No internet connection"
+            "You're offline. Your changes will sync when you're back online."
         case .rateLimited:
             "Server is busy. Please try again later."
-        case let .unknown(error):
-            error.localizedDescription
+        case .timeout:
+            "The request timed out. Please check your connection and try again."
+        case .serverUnreachable:
+            "Can't reach the server. Please check your connection and server URL."
+        case .unknown:
+            "Something went wrong. Please check your connection and try again."
+        }
+    }
+
+    var recoverySuggestion: String? {
+        switch self {
+        case .invalidURL:
+            "Open Settings and verify your server URL starts with https:// or http://."
+        case .unauthorized:
+            "Go to Settings and sign in with your credentials or a new API token."
+        case let .serverError(code, _):
+            if code >= 500 {
+                "The server may be temporarily unavailable. Wait a moment and try again."
+            } else {
+                "If this keeps happening, try logging out and back in."
+            }
+        case .decodingError:
+            "Make sure your server is running a compatible version of Vikunja."
+        case .networkUnavailable:
+            "Check that Wi-Fi or cellular data is turned on."
+        case .rateLimited:
+            "The server is rate limiting requests. Wait a moment and try again."
+        case .timeout:
+            "Try moving closer to your router or switching to a different network."
+        case .serverUnreachable:
+            "Verify the server is running and the URL in Settings is correct."
+        case .unknown:
+            "Try again. If the problem persists, check your internet connection or restart the app."
+        }
+    }
+
+    /// The SF Symbol icon name appropriate for this error type.
+    var iconName: String {
+        switch self {
+        case .invalidURL:
+            "link.badge.plus"
+        case .unauthorized:
+            "lock.slash"
+        case .serverError:
+            "exclamationmark.icloud"
+        case .decodingError:
+            "doc.questionmark"
+        case .networkUnavailable:
+            "wifi.slash"
+        case .rateLimited:
+            "hourglass"
+        case .timeout:
+            "clock.badge.exclamationmark"
+        case .serverUnreachable:
+            "server.rack"
+        case .unknown:
+            "exclamationmark.triangle"
+        }
+    }
+
+    /// Whether this error is critical and requires user action (should not auto-dismiss).
+    var isCritical: Bool {
+        switch self {
+        case .unauthorized, .invalidURL:
+            true
+        default:
+            false
+        }
+    }
+
+    /// Creates a `NetworkError` from a `URLError`, mapping common codes to friendly variants.
+    static func from(_ urlError: URLError) -> NetworkError {
+        switch urlError.code {
+        case .notConnectedToInternet, .networkConnectionLost:
+            .networkUnavailable
+        case .timedOut:
+            .timeout
+        case .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed:
+            .serverUnreachable
+        default:
+            .unknown(urlError)
+        }
+    }
+
+    /// Creates a user-friendly `NetworkError` from any `Error`.
+    static func friendly(from error: Error) -> NetworkError {
+        if let networkError = error as? NetworkError {
+            networkError
+        } else if let urlError = error as? URLError {
+            NetworkError.from(urlError)
+        } else {
+            .unknown(error)
         }
     }
 }

--- a/mDone/Views/Components/ErrorBanner.swift
+++ b/mDone/Views/Components/ErrorBanner.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+struct ErrorBanner: View {
+    let error: NetworkError
+    var onDismiss: () -> Void
+    var onRetry: (() -> Void)?
+
+    @State private var isVisible = false
+
+    private var backgroundColor: Color {
+        switch error {
+        case .unauthorized, .invalidURL:
+            .red
+        case .networkUnavailable, .timeout, .serverUnreachable:
+            .orange
+        default:
+            .red
+        }
+    }
+
+    var body: some View {
+        if isVisible {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: error.iconName)
+                        .font(.title3)
+                        .foregroundStyle(.white)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(error.errorDescription ?? "Something went wrong.")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.white)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        if let suggestion = error.recoverySuggestion {
+                            Text(suggestion)
+                                .font(.caption)
+                                .foregroundStyle(.white.opacity(0.85))
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+
+                    Spacer()
+
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            isVisible = false
+                        }
+                        onDismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(.white.opacity(0.8))
+                            .padding(6)
+                            .background(.white.opacity(0.2), in: Circle())
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if let onRetry {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            isVisible = false
+                        }
+                        onDismiss()
+                        onRetry()
+                    } label: {
+                        Text("Try Again")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(backgroundColor)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(.white, in: Capsule())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(12)
+            .background(backgroundColor.gradient, in: RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal)
+            .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .onAppear {
+                if !error.isCritical {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 6) {
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            isVisible = false
+                        }
+                        onDismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    init(error: NetworkError, onDismiss: @escaping () -> Void, onRetry: (() -> Void)? = nil) {
+        self.error = error
+        self.onDismiss = onDismiss
+        self.onRetry = onRetry
+        _isVisible = State(initialValue: true)
+    }
+}
+
+// MARK: - View Modifier
+
+struct ErrorBannerModifier: ViewModifier {
+    @Binding var error: NetworkError?
+    var onRetry: (() -> Void)?
+
+    func body(content: Content) -> some View {
+        content.overlay(alignment: .top) {
+            if let currentError = error {
+                ErrorBanner(
+                    error: currentError,
+                    onDismiss: { error = nil },
+                    onRetry: onRetry
+                )
+                .padding(.top, 4)
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: error != nil)
+    }
+}
+
+extension View {
+    func errorBanner(_ error: Binding<NetworkError?>, onRetry: (() -> Void)? = nil) -> some View {
+        modifier(ErrorBannerModifier(error: error, onRetry: onRetry))
+    }
+}

--- a/mDone/Views/Mac/MacContentView.swift
+++ b/mDone/Views/Mac/MacContentView.swift
@@ -57,5 +57,8 @@ struct MacContentView: View {
             await appState.refreshAll()
             await appState.fetchNotifications()
         }
+        .errorBanner(Bindable(appState).activeError) {
+            Task { await appState.refreshAll() }
+        }
     }
 }

--- a/mDone/Views/MainTabView.swift
+++ b/mDone/Views/MainTabView.swift
@@ -55,6 +55,9 @@ struct MainTabView: View {
         .fullScreenCover(isPresented: Bindable(focusManager).showFocusView) {
             FocusSessionView()
         }
+        .errorBanner(Bindable(appState).activeError) {
+            Task { await appState.refreshAll() }
+        }
         #else
         Text("macOS")
         #endif


### PR DESCRIPTION
## Summary
- Rewrites all `NetworkError` descriptions with user-friendly language and actionable guidance
- Adds `timeout` and `serverUnreachable` error cases with `recoverySuggestion` property
- Creates `ErrorBanner` view component with contextual icons, auto-dismiss, retry button, and color coding
- Updates all 8 catch blocks in AppState to use `handleError()` instead of raw `error.localizedDescription`
- Integrates ErrorBanner into both MainTabView (iOS) and MacContentView (macOS)

## Test plan
- [x] All 27 unit tests pass
- [x] Build succeeds (iOS simulator)
- [ ] Trigger network errors and verify friendly messages appear
- [ ] Verify ErrorBanner auto-dismisses for non-critical errors
- [ ] Verify auth errors (red) require manual dismiss

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)