### PR TITLE
Fix crash opening projects with duplicate task_positions rows (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Network, auth, and server errors are mapped to actionable messages (e.g., "You're offline. Your changes will sync when you're back online.")
 
 ### Fixed
+- Crash when opening a project whose tasks have duplicate `task_positions` rows on the Vikunja server; the duplicates are now ignored on the client (#54)
 - macOS: Clicking a task in the Inbox now opens the detail view
 - iOS: App no longer drops server connections when briefly switching to another app; in-flight requests now finish in the background (#49)
 - App automatically refreshes data when returning to the foreground

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -34,7 +34,7 @@ final class AppState {
     var onTaskDeleted: ((Int64) -> Void)?
 
     /// Per-project ordered task lists fetched from the view endpoint (preserves positions).
-    private var projectTaskCache: [Int64: [VTask]] = [:]
+    var projectTaskCache: [Int64: [VTask]] = [:]
 
     var unreadNotificationCount: Int {
         notifications.filter { $0.read != true }.count
@@ -438,7 +438,13 @@ final class AppState {
         // Use the cache only for position ordering.
         let projectTasks = tasks.filter { $0.projectId == projectId && !$0.done }
         if let cached = projectTaskCache[projectId] {
-            let orderMap = Dictionary(uniqueKeysWithValues: cached.enumerated().map { ($1.id, $0) })
+            // Keep the earliest index when an id appears twice; Vikunja can return
+            // duplicate task rows from the view endpoint if task_positions has
+            // duplicate (task_id, project_view_id) rows.
+            let orderMap = Dictionary(
+                cached.enumerated().map { ($1.id, $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
             return projectTasks.sorted { a, b in
                 (orderMap[a.id] ?? Int.max) < (orderMap[b.id] ?? Int.max)
             }
@@ -454,8 +460,10 @@ final class AppState {
             let viewTasks: [VTask] = try await taskService.fetchProjectTasks(
                 projectId: project.id, viewId: viewId
             )
-            // Store in cache — these have correct per-view positions
-            projectTaskCache[project.id] = viewTasks
+            // Store in cache — these have correct per-view positions.
+            // Dedupe by id: Vikunja's view-tasks endpoint can return the same task
+            // more than once when task_positions has duplicate rows for the view.
+            projectTaskCache[project.id] = Self.uniquedById(viewTasks)
             // Also update the global task list with any new tasks
             for viewTask in viewTasks {
                 if let index = tasks.firstIndex(where: { $0.id == viewTask.id }) {
@@ -469,6 +477,12 @@ final class AppState {
             print("[mDone] fetchProjectTasks error: \(error)")
             #endif
         }
+    }
+
+    /// Returns the input with duplicate `id`s removed, preserving the first occurrence.
+    static func uniquedById(_ tasks: [VTask]) -> [VTask] {
+        var seen = Set<Int64>()
+        return tasks.filter { seen.insert($0.id).inserted }
     }
 
     // MARK: - Calendar Events

--- a/mDoneTests/AppStateTests.swift
+++ b/mDoneTests/AppStateTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import mDone
+
+@MainActor
+final class AppStateTests: XCTestCase {
+    // MARK: - uniquedById
+
+    func testUniquedByIdRemovesDuplicates() {
+        let tasks = [
+            VTask(id: 1, title: "First", done: false, priority: 0, projectId: 10),
+            VTask(id: 2, title: "Second", done: false, priority: 0, projectId: 10),
+            VTask(id: 1, title: "First (dup)", done: false, priority: 0, projectId: 10),
+            VTask(id: 3, title: "Third", done: false, priority: 0, projectId: 10)
+        ]
+
+        let unique = AppState.uniquedById(tasks)
+
+        XCTAssertEqual(unique.map(\.id), [1, 2, 3], "Should preserve order and keep the first occurrence")
+        XCTAssertEqual(unique[0].title, "First", "Should keep the first occurrence, not a later duplicate")
+    }
+
+    func testUniquedByIdPreservesOrderWhenAllUnique() {
+        let tasks = [
+            VTask(id: 5, title: "A", done: false, priority: 0, projectId: 10),
+            VTask(id: 3, title: "B", done: false, priority: 0, projectId: 10),
+            VTask(id: 7, title: "C", done: false, priority: 0, projectId: 10)
+        ]
+
+        let unique = AppState.uniquedById(tasks)
+
+        XCTAssertEqual(unique.map(\.id), [5, 3, 7])
+    }
+
+    func testUniquedByIdEmpty() {
+        XCTAssertEqual(AppState.uniquedById([]).count, 0)
+    }
+
+    // MARK: - tasksForProject with duplicate-cache regression (issue #54)
+
+    /// Reproduces the crash that issue #54 reported. Before the fix, `tasksForProject`
+    /// fed the cached task list (which can contain duplicate ids when Vikunja's
+    /// view-tasks endpoint returns the same task more than once) into
+    /// `Dictionary(uniqueKeysWithValues:)`, which traps with a `_MergeError` and
+    /// brings down the whole UI.
+    func testTasksForProjectDoesNotCrashWithDuplicateCache() {
+        let projectId: Int64 = 99
+        let appState = AppState()
+
+        appState.tasks = [
+            VTask(id: 1, title: "A", done: false, priority: 0, projectId: projectId),
+            VTask(id: 2, title: "B", done: false, priority: 0, projectId: projectId),
+            VTask(id: 3, title: "C", done: false, priority: 0, projectId: projectId)
+        ]
+
+        // Simulate the bad cache state Vikunja can produce: id 1 appears twice.
+        appState.projectTaskCache[projectId] = [
+            VTask(id: 1, title: "A", done: false, priority: 0, projectId: projectId),
+            VTask(id: 2, title: "B", done: false, priority: 0, projectId: projectId),
+            VTask(id: 3, title: "C", done: false, priority: 0, projectId: projectId),
+            VTask(id: 1, title: "A (dup row)", done: false, priority: 0, projectId: projectId)
+        ]
+
+        // Before the fix this call traps. After the fix it returns the three tasks
+        // ordered by their first appearance in the cache.
+        let result = appState.tasksForProject(projectId)
+
+        XCTAssertEqual(result.map(\.id), [1, 2, 3])
+    }
+
+    func testTasksForProjectOrdersFromCachePosition() {
+        let projectId: Int64 = 42
+        let appState = AppState()
+
+        appState.tasks = [
+            VTask(id: 10, title: "A", done: false, priority: 0, projectId: projectId),
+            VTask(id: 20, title: "B", done: false, priority: 0, projectId: projectId),
+            VTask(id: 30, title: "C", done: false, priority: 0, projectId: projectId)
+        ]
+
+        // Cache order is reversed compared to the canonical tasks array.
+        appState.projectTaskCache[projectId] = [
+            VTask(id: 30, title: "C", done: false, priority: 0, projectId: projectId),
+            VTask(id: 20, title: "B", done: false, priority: 0, projectId: projectId),
+            VTask(id: 10, title: "A", done: false, priority: 0, projectId: projectId)
+        ]
+
+        XCTAssertEqual(appState.tasksForProject(projectId).map(\.id), [30, 20, 10])
+    }
+
+    func testTasksForProjectExcludesDoneTasks() {
+        let projectId: Int64 = 7
+        let appState = AppState()
+
+        appState.tasks = [
+            VTask(id: 1, title: "Open", done: false, priority: 0, projectId: projectId),
+            VTask(id: 2, title: "Done", done: true, priority: 0, projectId: projectId),
+            VTask(id: 3, title: "Other project", done: false, priority: 0, projectId: 999)
+        ]
+
+        XCTAssertEqual(appState.tasksForProject(projectId).map(\.id), [1])
+    }
+}


### PR DESCRIPTION
## Summary

- Vikunja's view-tasks endpoint returns the same task more than once when its `task_positions` table has duplicate `(task_id, project_view_id)` rows. The client stored that response verbatim in the per-project task cache, and the next render of `AppState.tasksForProject` fed it into `Dictionary(uniqueKeysWithValues:)`, which traps. The crashing frame is the task-count badge in the Projects list re-rendering as a side effect, so to the user it looks like tapping the project crashes the app.
- Fix: dedupe by id before caching, and switch `tasksForProject` to `Dictionary(_:uniquingKeysWith:)` so collisions can't trap.

Fixes #54.

## Test plan

- [x] Reproduced the crash end-to-end on iOS 26 Simulator against a Dockerised Vikunja with a duplicate `task_positions` row, captured a crash log with the same `Dictionary(uniqueKeysWithValues:)` / `_MergeError` signature the reporter saw
- [x] New regression test `testTasksForProjectDoesNotCrashWithDuplicateCache` traps with `Fatal error: Duplicate values for key: '1'` on pre-fix code and passes on post-fix
- [x] All 6 `AppStateTests` pass
- [x] Full `mDoneTests` suite passes (pre-existing `NetworkErrorTests` failures are unrelated)
- [x] iOS + macOS builds succeed
- [x] SwiftLint clean on changed files
- [x] End-to-end retest in iOS Simulator with same duplicated data: project opens cleanly, duplicates filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)