### PR TITLE
Render HTML task descriptions instead of raw markup (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Network, auth, and server errors are mapped to actionable messages (e.g., "You're offline. Your changes will sync when you're back online.")
 
 ### Fixed
+- Task descriptions created in Vikunja's web UI now render as formatted text (lists, links, bold) instead of raw HTML markup; description preview is shown by default when a description is present (#56)
 - macOS: Clicking a task in the Inbox now opens the detail view
 - iOS: App no longer drops server connections when briefly switching to another app; in-flight requests now finish in the background (#49)
 - App automatically refreshes data when returning to the foreground

--- a/mDone/Views/Mac/MacTaskDetailView.swift
+++ b/mDone/Views/Mac/MacTaskDetailView.swift
@@ -13,7 +13,7 @@ struct MacTaskDetailView: View {
     @State private var repeatInterval: Int64
     @State private var reminders: [TaskReminder]
     @State private var showDeleteConfirm = false
-    @State private var isPreviewingMarkdown: Bool
+    @State private var isShowingDescriptionPreview: Bool
 
     init(task: VTask) {
         self.task = task
@@ -26,7 +26,7 @@ struct MacTaskDetailView: View {
         _selectedProjectId = State(initialValue: task.projectId)
         _repeatInterval = State(initialValue: task.repeatAfter ?? 0)
         _reminders = State(initialValue: task.reminders ?? [])
-        _isPreviewingMarkdown = State(initialValue: !initialDescription.isEmpty)
+        _isShowingDescriptionPreview = State(initialValue: !initialDescription.isEmpty)
     }
 
     var body: some View {
@@ -45,17 +45,17 @@ struct MacTaskDetailView: View {
                             .foregroundStyle(.secondary)
                         Spacer()
                         Button {
-                            isPreviewingMarkdown.toggle()
+                            isShowingDescriptionPreview.toggle()
                         } label: {
-                            Image(systemName: isPreviewingMarkdown ? "pencil" : "eye")
+                            Image(systemName: isShowingDescriptionPreview ? "pencil" : "eye")
                                 .font(.caption)
                         }
                         .buttonStyle(.borderless)
-                        .help(isPreviewingMarkdown ? "Edit" : "Preview Markdown")
-                        .accessibilityLabel(isPreviewingMarkdown ? "Edit description" : "Preview description")
+                        .help(isShowingDescriptionPreview ? "Edit" : "Preview description")
+                        .accessibilityLabel(isShowingDescriptionPreview ? "Edit description" : "Preview description")
                     }
 
-                    if isPreviewingMarkdown {
+                    if isShowingDescriptionPreview {
                         if descriptionText.isEmpty {
                             Text("No description")
                                 .font(.body)
@@ -193,7 +193,7 @@ struct MacTaskDetailView: View {
             selectedProjectId = newTask.projectId
             repeatInterval = newTask.repeatAfter ?? 0
             reminders = newTask.reminders ?? []
-            isPreviewingMarkdown = !newDescription.isEmpty
+            isShowingDescriptionPreview = !newDescription.isEmpty
         }
     }
 

--- a/mDone/Views/Mac/MacTaskDetailView.swift
+++ b/mDone/Views/Mac/MacTaskDetailView.swift
@@ -13,18 +13,20 @@ struct MacTaskDetailView: View {
     @State private var repeatInterval: Int64
     @State private var reminders: [TaskReminder]
     @State private var showDeleteConfirm = false
-    @State private var isPreviewingMarkdown = false
+    @State private var isPreviewingMarkdown: Bool
 
     init(task: VTask) {
         self.task = task
+        let initialDescription = task.description ?? ""
         _title = State(initialValue: task.title)
-        _descriptionText = State(initialValue: task.description ?? "")
+        _descriptionText = State(initialValue: initialDescription)
         _dueDate = State(initialValue: task.dueDate)
         _hasDueDate = State(initialValue: task.dueDate != nil)
         _priority = State(initialValue: task.priority)
         _selectedProjectId = State(initialValue: task.projectId)
         _repeatInterval = State(initialValue: task.repeatAfter ?? 0)
         _reminders = State(initialValue: task.reminders ?? [])
+        _isPreviewingMarkdown = State(initialValue: !initialDescription.isEmpty)
     }
 
     var body: some View {
@@ -61,10 +63,13 @@ struct MacTaskDetailView: View {
                                 .italic()
                                 .frame(minHeight: 100, alignment: .topLeading)
                         } else {
-                            Text(markdownAttributedString(from: descriptionText))
-                                .font(.body)
-                                .textSelection(.enabled)
-                                .frame(minHeight: 100, maxHeight: 200, alignment: .topLeading)
+                            ScrollView {
+                                Text(RichTextRenderer.render(descriptionText))
+                                    .font(.body)
+                                    .textSelection(.enabled)
+                                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                            }
+                            .frame(minHeight: 100, maxHeight: 200)
                         }
                     } else {
                         TextEditor(text: $descriptionText)
@@ -180,23 +185,16 @@ struct MacTaskDetailView: View {
         }
         .onChange(of: task) { _, newTask in
             title = newTask.title
-            descriptionText = newTask.description ?? ""
+            let newDescription = newTask.description ?? ""
+            descriptionText = newDescription
             dueDate = newTask.dueDate
             hasDueDate = newTask.dueDate != nil
             priority = newTask.priority
             selectedProjectId = newTask.projectId
             repeatInterval = newTask.repeatAfter ?? 0
             reminders = newTask.reminders ?? []
+            isPreviewingMarkdown = !newDescription.isEmpty
         }
-    }
-
-    private func markdownAttributedString(from markdown: String) -> AttributedString {
-        (
-            try? AttributedString(markdown: markdown, options: .init(
-                interpretedSyntax: .inlineOnlyPreservingWhitespace
-            ))
-        ) ??
-            AttributedString(markdown)
     }
 
     private func saveTask() {

--- a/mDone/Views/Tasks/RichTextRendering.swift
+++ b/mDone/Views/Tasks/RichTextRendering.swift
@@ -1,0 +1,74 @@
+import Foundation
+import SwiftUI
+
+#if canImport(UIKit)
+    import UIKit
+#elseif canImport(AppKit)
+    import AppKit
+#endif
+
+enum RichTextRenderer {
+    static func render(_ source: String) -> AttributedString {
+        if containsHTML(source), let rendered = renderHTML(source) {
+            return rendered
+        }
+        return renderMarkdown(source)
+    }
+
+    static func containsHTML(_ source: String) -> Bool {
+        guard let regex = try? NSRegularExpression(pattern: "<[a-zA-Z/][^>]*>") else { return false }
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        return regex.firstMatch(in: source, options: [], range: range) != nil
+    }
+
+    private static func renderMarkdown(_ source: String) -> AttributedString {
+        (
+            try? AttributedString(markdown: source, options: .init(
+                interpretedSyntax: .inlineOnlyPreservingWhitespace
+            ))
+        ) ?? AttributedString(source)
+    }
+
+    private static func renderHTML(_ html: String) -> AttributedString? {
+        let styled = """
+        <meta charset="utf-8">
+        <style>
+          body { font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif; font-size: 16px; line-height: 1.4; }
+          p, ul, ol { margin: 0 0 8px 0; }
+          ul, ol { padding-left: 1.4em; }
+          code { font-family: ui-monospace, Menlo, monospace; }
+        </style>
+        \(html)
+        """
+        guard let data = styled.data(using: .utf8) else { return nil }
+        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+            .documentType: NSAttributedString.DocumentType.html,
+            .characterEncoding: String.Encoding.utf8.rawValue
+        ]
+        guard let nsAttr = try? NSMutableAttributedString(data: data, options: options, documentAttributes: nil) else {
+            return nil
+        }
+        let fullRange = NSRange(location: 0, length: nsAttr.length)
+        nsAttr.removeAttribute(.foregroundColor, range: fullRange)
+        nsAttr.removeAttribute(.backgroundColor, range: fullRange)
+        trimTrailingNewlines(nsAttr)
+        return AttributedString(nsAttr)
+    }
+
+    private static func trimTrailingNewlines(_ attr: NSMutableAttributedString) {
+        let string = attr.string
+        var end = string.endIndex
+        while end > string.startIndex {
+            let previous = string.index(before: end)
+            if string[previous].isNewline {
+                end = previous
+            } else {
+                break
+            }
+        }
+        let trimmedLength = string.distance(from: string.startIndex, to: end)
+        if trimmedLength < attr.length {
+            attr.deleteCharacters(in: NSRange(location: trimmedLength, length: attr.length - trimmedLength))
+        }
+    }
+}

--- a/mDone/Views/Tasks/RichTextRendering.swift
+++ b/mDone/Views/Tasks/RichTextRendering.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 #if canImport(UIKit)
     import UIKit
@@ -15,8 +14,12 @@ enum RichTextRenderer {
         return renderMarkdown(source)
     }
 
+    // Closing tag like </p> or </strong>. Markdown autolinks (<https://example.com>)
+    // have no closing form, so requiring one keeps them on the Markdown path.
+    private static let htmlClosingTagPattern = try? NSRegularExpression(pattern: "</[a-zA-Z][a-zA-Z0-9]*\\s*>")
+
     static func containsHTML(_ source: String) -> Bool {
-        guard let regex = try? NSRegularExpression(pattern: "<[a-zA-Z/][^>]*>") else { return false }
+        guard let regex = htmlClosingTagPattern else { return false }
         let range = NSRange(source.startIndex..<source.endIndex, in: source)
         return regex.firstMatch(in: source, options: [], range: range) != nil
     }
@@ -30,17 +33,17 @@ enum RichTextRenderer {
     }
 
     private static func renderHTML(_ html: String) -> AttributedString? {
-        let styled = """
+        let wrapped = """
         <meta charset="utf-8">
         <style>
-          body { font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif; font-size: 16px; line-height: 1.4; }
+          body { font-family: -apple-system, system-ui, sans-serif; }
           p, ul, ol { margin: 0 0 8px 0; }
           ul, ol { padding-left: 1.4em; }
           code { font-family: ui-monospace, Menlo, monospace; }
         </style>
         \(html)
         """
-        guard let data = styled.data(using: .utf8) else { return nil }
+        guard let data = wrapped.data(using: .utf8) else { return nil }
         let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
             .documentType: NSAttributedString.DocumentType.html,
             .characterEncoding: String.Encoding.utf8.rawValue
@@ -51,8 +54,35 @@ enum RichTextRenderer {
         let fullRange = NSRange(location: 0, length: nsAttr.length)
         nsAttr.removeAttribute(.foregroundColor, range: fullRange)
         nsAttr.removeAttribute(.backgroundColor, range: fullRange)
+        rewriteFontsForDynamicType(nsAttr)
         trimTrailingNewlines(nsAttr)
         return AttributedString(nsAttr)
+    }
+
+    private static func rewriteFontsForDynamicType(_ attr: NSMutableAttributedString) {
+        let fullRange = NSRange(location: 0, length: attr.length)
+        #if canImport(UIKit)
+            let baseFont = UIFont.preferredFont(forTextStyle: .body)
+            attr.enumerateAttribute(.font, in: fullRange, options: []) { value, range, _ in
+                let traits = (value as? UIFont)?.fontDescriptor.symbolicTraits ?? []
+                var keptTraits: UIFontDescriptor.SymbolicTraits = []
+                if traits.contains(.traitBold) { keptTraits.insert(.traitBold) }
+                if traits.contains(.traitItalic) { keptTraits.insert(.traitItalic) }
+                let descriptor = baseFont.fontDescriptor.withSymbolicTraits(keptTraits) ?? baseFont.fontDescriptor
+                attr.addAttribute(.font, value: UIFont(descriptor: descriptor, size: 0), range: range)
+            }
+        #elseif canImport(AppKit)
+            let baseFont = NSFont.preferredFont(forTextStyle: .body)
+            attr.enumerateAttribute(.font, in: fullRange, options: []) { value, range, _ in
+                let traits = (value as? NSFont)?.fontDescriptor.symbolicTraits ?? []
+                var keptTraits: NSFontDescriptor.SymbolicTraits = []
+                if traits.contains(.bold) { keptTraits.insert(.bold) }
+                if traits.contains(.italic) { keptTraits.insert(.italic) }
+                let descriptor = baseFont.fontDescriptor.withSymbolicTraits(keptTraits)
+                let font = NSFont(descriptor: descriptor, size: 0) ?? baseFont
+                attr.addAttribute(.font, value: font, range: range)
+            }
+        #endif
     }
 
     private static func trimTrailingNewlines(_ attr: NSMutableAttributedString) {

--- a/mDone/Views/Tasks/TaskDetailSheet.swift
+++ b/mDone/Views/Tasks/TaskDetailSheet.swift
@@ -17,7 +17,7 @@ struct TaskDetailSheet: View {
     @State private var repeatInterval: Int64
     @State private var reminders: [TaskReminder]
     @State private var showDeleteConfirm = false
-    @State private var isPreviewingMarkdown: Bool
+    @State private var isShowingDescriptionPreview: Bool
 
     init(task: VTask) {
         self.task = task
@@ -30,7 +30,7 @@ struct TaskDetailSheet: View {
         _selectedProjectId = State(initialValue: task.projectId)
         _repeatInterval = State(initialValue: task.repeatAfter ?? 0)
         _reminders = State(initialValue: task.reminders ?? [])
-        _isPreviewingMarkdown = State(initialValue: !initialDescription.isEmpty)
+        _isShowingDescriptionPreview = State(initialValue: !initialDescription.isEmpty)
     }
 
     var body: some View {
@@ -47,16 +47,16 @@ struct TaskDetailSheet: View {
                                 .foregroundStyle(.secondary)
                             Spacer()
                             Button {
-                                isPreviewingMarkdown.toggle()
+                                isShowingDescriptionPreview.toggle()
                             } label: {
-                                Image(systemName: isPreviewingMarkdown ? "pencil" : "eye")
+                                Image(systemName: isShowingDescriptionPreview ? "pencil" : "eye")
                                     .font(.caption)
                             }
                             .buttonStyle(.borderless)
-                            .accessibilityLabel(isPreviewingMarkdown ? "Edit description" : "Preview description")
+                            .accessibilityLabel(isShowingDescriptionPreview ? "Edit description" : "Preview description")
                         }
 
-                        if isPreviewingMarkdown {
+                        if isShowingDescriptionPreview {
                             if description.isEmpty {
                                 Text("No description")
                                     .font(.body)

--- a/mDone/Views/Tasks/TaskDetailSheet.swift
+++ b/mDone/Views/Tasks/TaskDetailSheet.swift
@@ -17,18 +17,20 @@ struct TaskDetailSheet: View {
     @State private var repeatInterval: Int64
     @State private var reminders: [TaskReminder]
     @State private var showDeleteConfirm = false
-    @State private var isPreviewingMarkdown = false
+    @State private var isPreviewingMarkdown: Bool
 
     init(task: VTask) {
         self.task = task
+        let initialDescription = task.description ?? ""
         _title = State(initialValue: task.title)
-        _description = State(initialValue: task.description ?? "")
+        _description = State(initialValue: initialDescription)
         _dueDate = State(initialValue: task.effectiveDueDate)
         _hasDueDate = State(initialValue: task.effectiveDueDate != nil)
         _priority = State(initialValue: task.priority)
         _selectedProjectId = State(initialValue: task.projectId)
         _repeatInterval = State(initialValue: task.repeatAfter ?? 0)
         _reminders = State(initialValue: task.reminders ?? [])
+        _isPreviewingMarkdown = State(initialValue: !initialDescription.isEmpty)
     }
 
     var body: some View {
@@ -61,7 +63,7 @@ struct TaskDetailSheet: View {
                                     .foregroundStyle(.secondary)
                                     .italic()
                             } else {
-                                Text(markdownAttributedString(from: description))
+                                Text(RichTextRenderer.render(description))
                                     .font(.body)
                                     .textSelection(.enabled)
                             }
@@ -193,15 +195,6 @@ struct TaskDetailSheet: View {
         #if os(iOS)
         .presentationDetents([.medium, .large])
         #endif
-    }
-
-    private func markdownAttributedString(from markdown: String) -> AttributedString {
-        (
-            try? AttributedString(markdown: markdown, options: .init(
-                interpretedSyntax: .inlineOnlyPreservingWhitespace
-            ))
-        ) ??
-            AttributedString(markdown)
     }
 
     private func saveTask() {

--- a/mDoneTests/RichTextRendererTests.swift
+++ b/mDoneTests/RichTextRendererTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import mDone
+
+final class RichTextRendererTests: XCTestCase {
+    // MARK: - containsHTML
+
+    func testContainsHTMLDetectsParagraphTag() {
+        XCTAssertTrue(RichTextRenderer.containsHTML("<p>hello</p>"))
+    }
+
+    func testContainsHTMLDetectsListMarkup() {
+        XCTAssertTrue(RichTextRenderer.containsHTML("<ul><li>one</li><li>two</li></ul>"))
+    }
+
+    func testContainsHTMLIgnoresPlainText() {
+        XCTAssertFalse(RichTextRenderer.containsHTML("Just a normal description with no tags."))
+    }
+
+    func testContainsHTMLIgnoresMarkdownAutolink() {
+        // Markdown autolinks have no closing tag, so they must not be routed to the HTML parser.
+        XCTAssertFalse(RichTextRenderer.containsHTML("See <https://example.com> for details."))
+    }
+
+    func testContainsHTMLIgnoresPlainAngleBrackets() {
+        XCTAssertFalse(RichTextRenderer.containsHTML("2 < 3 and 5 > 4"))
+        XCTAssertFalse(RichTextRenderer.containsHTML("I <3 cats"))
+    }
+
+    func testContainsHTMLIgnoresOpeningTagWithoutClose() {
+        // A lone opening tag (no closing tag anywhere) is treated as plain text.
+        XCTAssertFalse(RichTextRenderer.containsHTML("<br> by itself"))
+    }
+
+    // MARK: - render
+
+    func testRenderHTMLExtractsVisibleText() {
+        let result = RichTextRenderer.render("<p>Hello <strong>world</strong></p>")
+        let plain = String(result.characters)
+        XCTAssertTrue(plain.contains("Hello"), "Expected rendered text to contain 'Hello', got: \(plain)")
+        XCTAssertTrue(plain.contains("world"), "Expected rendered text to contain 'world', got: \(plain)")
+        XCTAssertFalse(plain.contains("<strong>"), "Rendered output should not contain raw tags")
+    }
+
+    func testRenderMarkdownAutolinkPreservesText() {
+        let result = RichTextRenderer.render("Visit <https://example.com> today")
+        let plain = String(result.characters)
+        XCTAssertTrue(
+            plain.contains("https://example.com"),
+            "Markdown autolink should be preserved in rendered output, got: \(plain)"
+        )
+    }
+
+    func testRenderPlainTextRoundTrips() {
+        let source = "Just a plain description."
+        let result = RichTextRenderer.render(source)
+        XCTAssertEqual(String(result.characters), source)
+    }
+
+    func testRenderHTMLPreservesListItems() {
+        let result = RichTextRenderer.render("<ul><li>alpha</li><li>beta</li></ul>")
+        let plain = String(result.characters)
+        XCTAssertTrue(plain.contains("alpha"))
+        XCTAssertTrue(plain.contains("beta"))
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #56. Vikunja's web UI stores task descriptions as HTML (its Tiptap editor outputs `<ul>`, `<p>`, `<strong>`, etc.), but mDone only ever rendered descriptions as Markdown — so tasks edited on the web showed raw markup in both the preview and the editor.
- New `RichTextRenderer.render(_:)` helper detects HTML vs Markdown and renders each appropriately. HTML is parsed with `NSAttributedString(data:options:)` plus a small CSS preamble for the system font; foreground/background colors are stripped so dark mode still works. Non-HTML strings fall through to the existing inline-Markdown path.
- `TaskDetailSheet` (iOS) and `MacTaskDetailView` (macOS) now use the helper and default to preview mode when a description is present, so users see formatted content first and can toggle to edit the raw source.
- macOS preview is wrapped in a `ScrollView` so long descriptions don't clip.

## Test plan
- [x] `xcodegen generate`
- [x] iOS build (`xcodebuild -scheme mDone -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' build`)
- [x] macOS build (`xcodebuild -scheme mDone-macOS build`)
- [x] SwiftLint clean on changed files
- [ ] Manual: open a task created in Vikunja's web UI with a bulleted-list description on iOS and macOS — verify list renders, toggle to edit reveals raw HTML, save still roundtrips the original content
- [ ] Manual: open a task with a plain-text/Markdown description — verify Markdown still renders as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)