### PR TITLE
Fix hardcoded version string in Settings (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Task detail screen shows total focus time and session count for tasks you've used the Focus Timer on (#61).
 - Focus History Sync (Settings → iOS only): configure a focus-service URL and bearer token to sync completed focus sessions to your homelab service for cross-task analysis (#62). Blank URL keeps everything on-device. Pre-existing focus history is backfilled on first activation.
 
+### Fixed
+- Settings now displays the actual app version and build number instead of a hardcoded "1.0.0" (#65).
+
 ## [1.1.2] - 2026-05-13
 
 ### Added

--- a/mDone/Views/Settings/SettingsScreen.swift
+++ b/mDone/Views/Settings/SettingsScreen.swift
@@ -73,7 +73,7 @@ struct SettingsScreen: View {
                     VStack(spacing: 4) {
                         Text("mDone")
                             .font(.caption.bold())
-                        Text("Version 1.0.0")
+                        Text(Self.versionString)
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
                     }
@@ -94,5 +94,12 @@ struct SettingsScreen: View {
         } message: {
             Text("This will remove your server configuration. You'll need to reconnect.")
         }
+    }
+
+    private static var versionString: String {
+        let info = Bundle.main.infoDictionary
+        let short = info?["CFBundleShortVersionString"] as? String ?? "—"
+        let build = info?["CFBundleVersion"] as? String ?? "—"
+        return "Version \(short) (\(build))"
     }
 }


### PR DESCRIPTION
## Summary
- Settings was displaying a hardcoded `Version 1.0.0` literal regardless of the actual shipped build.
- Read `CFBundleShortVersionString` and `CFBundleVersion` from the bundle so the real version/build number shows up (e.g. `Version 1.3.0 (21)`).

Fixes #65.

## Test plan
- [ ] Open Settings → scroll to bottom → version matches the build (e.g. `1.3.0 (21)`)
- [ ] After future version bumps, the string updates without code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)