### PR TITLE
Widget: fix duplicate overdue task on same day (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Task detail screen shows total focus time and session count for tasks you've used the Focus Timer on (#61).
 - Focus History Sync (Settings → iOS only): configure a focus-service URL and bearer token to sync completed focus sessions to your homelab service for cross-task analysis (#62). Blank URL keeps everything on-device. Pre-existing focus history is backfilled on first activation.
 
+### Fixed
+- Widget: tasks whose due time has passed but were due today no longer appear twice — once in the overdue (red) section and once in the today list (#64).
+
 ## [1.1.2] - 2026-05-13
 
 ### Added

--- a/mDoneShared/WidgetDataProvider.swift
+++ b/mDoneShared/WidgetDataProvider.swift
@@ -123,7 +123,9 @@ final class WidgetDataProvider: @unchecked Sendable {
 
     private func fetchOverdueTasks() async throws -> [WidgetTask] {
         let nowStr = formatDate(Date())
-        let filter = "due_date < \"\(nowStr)\" && due_date > \"0001-01-02T00:00:00Z\" && done = false"
+        // Inclusive lower bound: a task whose due_date is exactly now is overdue, not upcoming.
+        // Pairs with fetchTodayTasks' strict `due_date > now` so every timestamp falls in one bucket.
+        let filter = "due_date <= \"\(nowStr)\" && due_date > \"0001-01-02T00:00:00Z\" && done = false"
 
         return try await fetchTasks(
             filter: filter,

--- a/mDoneShared/WidgetDataProvider.swift
+++ b/mDoneShared/WidgetDataProvider.swift
@@ -90,12 +90,14 @@ final class WidgetDataProvider: @unchecked Sendable {
 
     private func fetchTodayTasks() async throws -> [WidgetTask] {
         let calendar = Calendar.current
-        let startOfDay = calendar.startOfDay(for: Date())
-        guard let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) else {
+        let now = Date()
+        guard let endOfDay = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now)) else {
             return []
         }
 
-        let startStr = formatDate(startOfDay)
+        // Only tasks still upcoming today — anything already past its due time is returned by
+        // fetchOverdueTasks instead, otherwise the same task would appear in both lists.
+        let startStr = formatDate(now)
         let endStr = formatDate(endOfDay)
         let filter = "due_date > \"\(startStr)\" && due_date < \"\(endStr)\" && done = false"
 


### PR DESCRIPTION
## Summary
- Fixes [#64](https://github.com/marco308/mdone/issues/64): a task whose due time had already passed today appeared twice in the Today widget — once in the red overdue section and once in the white today list.
- Root cause: `fetchTodayTasks` filtered with `due_date > startOfDay`, while `fetchOverdueTasks` filtered with `due_date < now`. Between the task's due time and midnight, both queries matched the same task, and the widget renders the two arrays independently with no dedup.
- Fix: narrow `fetchTodayTasks` to `due_date > now` so passed-due tasks only come from `fetchOverdueTasks`. Lock-screen widgets concatenate the two arrays so they benefit automatically.

## Test plan
- [x] iOS build (`xcodebuild ... iPhone 17`) passes
- [ ] In the simulator/device, create a task due earlier today, refresh the widget, confirm only one red row appears
- [ ] Create a task due later today, confirm a single white row appears in the "today" list
- [ ] Wait until after midnight (or change clock), confirm task still appears once in red

🤖 Generated with [Claude Code](https://claude.com/claude-code)