### PR TITLE
Fix stale due date after +24h swipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Widget: tasks whose due time has passed but were due today no longer appear twice — once in the overdue (red) section and once in the today list (#64).
 - Settings now displays the actual app version and build number instead of a hardcoded "1.0.0" (#65).
+- Swiping a task left for +24h now updates the displayed due date instantly instead of waiting for the server to respond.
 
 ## [1.1.2] - 2026-05-13
 

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -401,7 +401,27 @@ final class AppState {
     func postponeTask(_ task: VTask, byHours hours: Int) async {
         let baseDate = task.effectiveDueDate ?? Date()
         let newDate = Calendar.current.date(byAdding: .hour, value: hours, to: baseDate) ?? baseDate
-        await updateTask(id: task.id, request: TaskUpdateRequest(dueDate: newDate))
+
+        let originalDueDate: Date?
+        if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+            originalDueDate = tasks[index].dueDate
+            tasks[index].dueDate = newDate
+        } else {
+            originalDueDate = nil
+        }
+
+        do {
+            let updated = try await taskService.updateTask(id: task.id, request: TaskUpdateRequest(dueDate: newDate))
+            if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
+                tasks[index] = updated
+            }
+            WidgetCenter.shared.reloadAllTimelines()
+        } catch {
+            if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+                tasks[index].dueDate = originalDueDate
+            }
+            handleError(error)
+        }
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Swiping a task left for +24h kept showing the old due date until the Vikunja PATCH returned, because `AppState.postponeTask` awaited the network round-trip before mutating the local `tasks` array that the row reads from.
- `postponeTask` now does an optimistic update: mutates `tasks[index].dueDate` immediately, replaces with the server's authoritative `VTask` on success, and rolls back to the original `dueDate` on failure.

## Test plan
- [ ] Swipe a task left → tap **+24h** → due-date label updates to the new date with no perceptible delay.
- [ ] Repeat against a task that previously had no due date → label appears immediately set to ~24h from now.
- [ ] Simulate a failed update (e.g. airplane mode mid-swipe) → row's due date reverts to the original value and the error banner appears.
- [ ] Toggle the same task done/undone afterwards → no stale-state regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)