### PR TITLE
Add test coverage rules and enable coverage by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,26 @@ View → AppState (method call) → Service (TaskService/ProjectService)
 
 Update `CHANGELOG.md` whenever making user-facing changes (features, fixes, UI changes). Add entries under the `[Unreleased]` section using Keep a Changelog categories: Added, Changed, Fixed, Removed. Keep entries concise and written from the user's perspective.
 
+## Test Coverage
+
+Code coverage is gathered by default — `gatherCoverageData: true` is set on both schemes in `project.yml`. Read coverage from any test run with `xcrun xccov view --report <path-to-.xcresult>`.
+
+Apply tiered coverage targets by layer rather than chasing a single overall percentage:
+
+| Layer | Target |
+|---|---|
+| Services (`mDone/Services/`) | 85%+ (never drop a service below 70% without a reason) |
+| Models with logic (e.g. `VTask`) | 90%+ |
+| `AppState` | 75%+ |
+| Widgets (`mDoneShared/`, `mDoneWidgets/`) | 70%+ |
+| SwiftUI views | no line-coverage target — use snapshot tests |
+
+Rules of practice:
+- New code in services, models, or `AppState` ships with tests in the same PR. Coverage-of-the-diff matters more than overall %.
+- Verify a test file actually exercises its target with `xccov` — a file's existence isn't proof of coverage. `SyncServiceTests` once had 12 tests but only hit 3.78% of `SyncService` because it mocked the wrong layer.
+- Don't pad the overall % with shallow view tests. SwiftUI view files at 0% line coverage are normal.
+- If a service in a diff is below 70%, flag it as a good moment to add tests.
+
 ## Linting & Formatting
 
 SwiftLint runs as a post-build script (configured in `project.yml`). Config in `.swiftlint.yml` — notably disables `line_length`, `trailing_whitespace`, `type_body_length`, `file_length`, `function_body_length`, and `cyclomatic_complexity`.

--- a/project.yml
+++ b/project.yml
@@ -46,6 +46,7 @@ targets:
       testTargets:
         - mDoneTests
         - mDoneUITests
+      gatherCoverageData: true
 
   mDone-macOS:
     type: application
@@ -73,6 +74,7 @@ targets:
     scheme:
       testTargets:
         - mDoneMacUITests
+      gatherCoverageData: true
 
   mDoneMacUITests:
     type: bundle.ui-testing


### PR DESCRIPTION
## Summary
- Document tiered test-coverage targets in `CLAUDE.md` so the rules apply on any machine and to any contributor (services 85%+, models with logic 90%+, AppState 75%+, widgets 70%+; no line-coverage target for SwiftUI views).
- Enable `gatherCoverageData: true` on both schemes in `project.yml` — `xcodebuild test` now produces coverage data with no extra flags, and the Xcode UI checkbox is pre-ticked.
- Include the lesson from today's audit: verify with `xcrun xccov view --report` rather than treating the existence of a test file as proof of coverage (`SyncServiceTests` had 12 tests but only hit 3.78% of `SyncService`).

## Test plan
- [ ] `xcodegen generate` — confirm both schemes still build
- [ ] `xcodebuild -project mDone.xcodeproj -scheme mDone -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' test` — confirm coverage data is gathered without `-enableCodeCoverage YES`
- [ ] `xcrun xccov view --report --only-targets <xcresult>` — confirm percentages are produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)