### PR TITLE
Select which calendars are displayed (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Settings → Calendar → "Calendars in mDone" lets you choose which device calendars contribute events to mDone's Calendar and Today views. Turn off shared family or work calendars you don't want cluttering your task context; new calendars show by default until you hide them (#69).
+
 ## [1.3.0] - 2026-05-17
 
 ### Added

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -35,6 +35,11 @@ final class AppState {
     var calendarAccessGranted: Bool = false
     private let calendarService = CalendarService()
 
+    /// Changes whenever the visible-calendar selection changes. Calendar
+    /// views key their event fetch on this so toggling a calendar refreshes
+    /// the grid and day list immediately, not just the Today view.
+    private(set) var calendarFilterToken = UUID()
+
     var onTaskCompleted: ((Int64) -> Void)?
     var onTaskDeleted: ((Int64) -> Void)?
 
@@ -549,6 +554,20 @@ final class AppState {
     func calendarEventsForMonth(_ date: Date) async -> [Date: [CalendarEvent]] {
         guard calendarAccessGranted else { return [:] }
         return await calendarService.eventsForMonth(date)
+    }
+
+    /// Event calendars available for the "Show in mDone" selection screen.
+    func availableCalendars() async -> [CalendarInfo] {
+        guard calendarAccessGranted else { return [] }
+        return await calendarService.availableCalendars()
+    }
+
+    /// Call after the user changes which calendars are visible. Bumps the
+    /// token so calendar views re-query, and refreshes the Today window.
+    @MainActor
+    func calendarSelectionDidChange() async {
+        calendarFilterToken = UUID()
+        await refreshCalendarEvents()
     }
 
     var todayCalendarEvents: [CalendarEvent] {

--- a/mDone/App/CalendarSelection.swift
+++ b/mDone/App/CalendarSelection.swift
@@ -1,0 +1,97 @@
+import CoreGraphics
+import EventKit
+import Foundation
+
+/// Lightweight, EventKit-free description of a calendar, suitable for the
+/// selection UI and for unit tests.
+struct CalendarInfo: Identifiable, Hashable {
+    let id: String // EKCalendar.calendarIdentifier
+    let title: String
+    let color: CGColor?
+
+    init(id: String, title: String, color: CGColor? = nil) {
+        self.id = id
+        self.title = title
+        self.color = color
+    }
+
+    init(from ekCalendar: EKCalendar) {
+        id = ekCalendar.calendarIdentifier
+        title = ekCalendar.title
+        color = ekCalendar.cgColor
+    }
+
+    // MARK: - Hashable (identity by id only — CGColor isn't Hashable)
+
+    static func == (lhs: CalendarInfo, rhs: CalendarInfo) -> Bool {
+        lhs.id == rhs.id && lhs.title == rhs.title
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+/// Persists the set of calendars the user has chosen to *hide* from mDone.
+///
+/// We store the hidden set rather than the visible set so that the natural
+/// empty default means "show everything", and any calendar the user adds
+/// later shows up automatically until they explicitly hide it.
+struct HiddenCalendarStore {
+    static let storageKey = "hiddenCalendarIdentifiers"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var hiddenIdentifiers: Set<String> {
+        let stored = defaults.stringArray(forKey: Self.storageKey) ?? []
+        return Set(stored)
+    }
+
+    func isHidden(_ identifier: String) -> Bool {
+        hiddenIdentifiers.contains(identifier)
+    }
+
+    /// Hide or unhide a single calendar.
+    func setHidden(_ hidden: Bool, for identifier: String) {
+        var ids = hiddenIdentifiers
+        if hidden {
+            ids.insert(identifier)
+        } else {
+            ids.remove(identifier)
+        }
+        persist(ids)
+    }
+
+    /// Replace the entire hidden set (used by "Show all" / "Hide all").
+    func replace(with identifiers: Set<String>) {
+        persist(identifiers)
+    }
+
+    /// Drop hidden entries for calendars that no longer exist so the set
+    /// can't grow unbounded as calendars come and go.
+    func prune(toExisting existing: Set<String>) {
+        let pruned = hiddenIdentifiers.intersection(existing)
+        if pruned != hiddenIdentifiers {
+            persist(pruned)
+        }
+    }
+
+    /// Pure filter: returns only the events whose calendar isn't hidden.
+    func visibleEvents(_ events: [CalendarEvent]) -> [CalendarEvent] {
+        let hidden = hiddenIdentifiers
+        guard !hidden.isEmpty else { return events }
+        return events.filter { !hidden.contains($0.calendarIdentifier) }
+    }
+
+    private func persist(_ ids: Set<String>) {
+        if ids.isEmpty {
+            defaults.removeObject(forKey: Self.storageKey)
+        } else {
+            defaults.set(Array(ids).sorted(), forKey: Self.storageKey)
+        }
+    }
+}

--- a/mDone/App/CalendarSelection.swift
+++ b/mDone/App/CalendarSelection.swift
@@ -21,7 +21,13 @@ struct CalendarInfo: Identifiable, Hashable {
         color = ekCalendar.cgColor
     }
 
-    // MARK: - Hashable (identity by id only — CGColor isn't Hashable)
+    // MARK: - Hashable
+
+    // Equality and hashing both use id + title (CGColor isn't Hashable, so
+    // colour is intentionally excluded). Comparing title as well as id means
+    // a renamed calendar is treated as changed, which the selection UI relies
+    // on to re-render. `==` and `hash` stay in sync: equal values always hash
+    // equally.
 
     static func == (lhs: CalendarInfo, rhs: CalendarInfo) -> Bool {
         lhs.id == rhs.id && lhs.title == rhs.title
@@ -29,6 +35,7 @@ struct CalendarInfo: Identifiable, Hashable {
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
+        hasher.combine(title)
     }
 }
 

--- a/mDone/Models/CalendarEvent.swift
+++ b/mDone/Models/CalendarEvent.swift
@@ -7,6 +7,7 @@ struct CalendarEvent: Identifiable, Hashable {
     let startDate: Date
     let endDate: Date
     let isAllDay: Bool
+    let calendarIdentifier: String
     let calendarName: String
     let calendarColor: CGColor?
     let location: String?
@@ -17,9 +18,33 @@ struct CalendarEvent: Identifiable, Hashable {
         startDate = ekEvent.startDate
         endDate = ekEvent.endDate
         isAllDay = ekEvent.isAllDay
+        calendarIdentifier = ekEvent.calendar?.calendarIdentifier ?? ""
         calendarName = ekEvent.calendar?.title ?? ""
         calendarColor = ekEvent.calendar?.cgColor
         location = ekEvent.location
+    }
+
+    /// Memberwise initialiser used by tests and previews (no EventKit dependency).
+    init(
+        id: String,
+        title: String,
+        startDate: Date,
+        endDate: Date,
+        isAllDay: Bool = false,
+        calendarIdentifier: String,
+        calendarName: String = "",
+        calendarColor: CGColor? = nil,
+        location: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.startDate = startDate
+        self.endDate = endDate
+        self.isAllDay = isAllDay
+        self.calendarIdentifier = calendarIdentifier
+        self.calendarName = calendarName
+        self.calendarColor = calendarColor
+        self.location = location
     }
 
     // MARK: - Hashable

--- a/mDone/Services/CalendarService.swift
+++ b/mDone/Services/CalendarService.swift
@@ -21,12 +21,10 @@ actor CalendarService {
         }
     }
 
-    /// All event calendars the user has, for the selection UI. Also prunes
-    /// hidden entries for calendars that no longer exist.
+    /// All event calendars the user has, for the selection UI. Pure read —
+    /// pruning of stale hidden ids is done explicitly by the caller.
     func availableCalendars() -> [CalendarInfo] {
-        let calendars = eventStore.calendars(for: .event)
-        hiddenStore.prune(toExisting: Set(calendars.map(\.calendarIdentifier)))
-        return calendars
+        eventStore.calendars(for: .event)
             .map(CalendarInfo.init(from:))
             .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
     }

--- a/mDone/Services/CalendarService.swift
+++ b/mDone/Services/CalendarService.swift
@@ -3,6 +3,11 @@ import Foundation
 
 actor CalendarService {
     private let eventStore = EKEventStore()
+    private let hiddenStore: HiddenCalendarStore
+
+    init(hiddenStore: HiddenCalendarStore = HiddenCalendarStore()) {
+        self.hiddenStore = hiddenStore
+    }
 
     var authorizationStatus: EKAuthorizationStatus {
         EKEventStore.authorizationStatus(for: .event)
@@ -16,11 +21,22 @@ actor CalendarService {
         }
     }
 
+    /// All event calendars the user has, for the selection UI. Also prunes
+    /// hidden entries for calendars that no longer exist.
+    func availableCalendars() -> [CalendarInfo] {
+        let calendars = eventStore.calendars(for: .event)
+        hiddenStore.prune(toExisting: Set(calendars.map(\.calendarIdentifier)))
+        return calendars
+            .map(CalendarInfo.init(from:))
+            .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+    }
+
     func fetchEvents(from startDate: Date, to endDate: Date) -> [CalendarEvent] {
         let predicate = eventStore.predicateForEvents(withStart: startDate, end: endDate, calendars: nil)
         let ekEvents = eventStore.events(matching: predicate)
-        return ekEvents.map { CalendarEvent(from: $0) }
+        let events = ekEvents.map { CalendarEvent(from: $0) }
             .sorted { $0.startDate < $1.startDate }
+        return hiddenStore.visibleEvents(events)
     }
 
     /// Fetch events for a single day

--- a/mDone/Views/Calendar/CalendarScreen.swift
+++ b/mDone/Views/Calendar/CalendarScreen.swift
@@ -55,6 +55,10 @@ struct CalendarScreen: View {
         .task(id: displayedMonth) {
             monthCalendarEvents = await appState.calendarEventsForMonth(displayedMonth)
         }
+        .task(id: appState.calendarFilterToken) {
+            dayCalendarEvents = await appState.calendarEventsForDate(selectedDate)
+            monthCalendarEvents = await appState.calendarEventsForMonth(displayedMonth)
+        }
     }
 
     private var calendarAccessBanner: some View {

--- a/mDone/Views/Calendar/CalendarScreen.swift
+++ b/mDone/Views/Calendar/CalendarScreen.swift
@@ -49,14 +49,14 @@ struct CalendarScreen: View {
         .task {
             await appState.requestCalendarAccess()
         }
-        .task(id: selectedDate) {
+        // Folding the filter token into each id means the day refetches only
+        // when the day or the calendar selection changes (likewise the month),
+        // and every task fires exactly once on first appear — no duplicate
+        // EventKit reads.
+        .task(id: CalendarFetchKey(date: selectedDate, token: appState.calendarFilterToken)) {
             dayCalendarEvents = await appState.calendarEventsForDate(selectedDate)
         }
-        .task(id: displayedMonth) {
-            monthCalendarEvents = await appState.calendarEventsForMonth(displayedMonth)
-        }
-        .task(id: appState.calendarFilterToken) {
-            dayCalendarEvents = await appState.calendarEventsForDate(selectedDate)
+        .task(id: CalendarFetchKey(date: displayedMonth, token: appState.calendarFilterToken)) {
             monthCalendarEvents = await appState.calendarEventsForMonth(displayedMonth)
         }
     }
@@ -91,4 +91,11 @@ struct CalendarScreen: View {
         .padding(.vertical, 8)
         .background(.ultraThinMaterial)
     }
+}
+
+/// Composite `.task(id:)` key so an event fetch re-runs when either the
+/// date (day or month) or the visible-calendar selection changes.
+private struct CalendarFetchKey: Hashable {
+    let date: Date
+    let token: UUID
 }

--- a/mDone/Views/Settings/CalendarSelectionView.swift
+++ b/mDone/Views/Settings/CalendarSelectionView.swift
@@ -60,6 +60,10 @@ struct CalendarSelectionView: View {
             }
             .task {
                 calendars = await appState.availableCalendars()
+                // Drop hidden entries for calendars that no longer exist, then
+                // read the persisted set back so the toggles always reflect
+                // exactly what the store holds.
+                store.prune(toExisting: Set(calendars.map(\.id)))
                 hidden = store.hiddenIdentifiers
                 isLoading = false
             }

--- a/mDone/Views/Settings/CalendarSelectionView.swift
+++ b/mDone/Views/Settings/CalendarSelectionView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// Lets the user choose which device calendars contribute events to mDone.
+/// Selections are persisted via `HiddenCalendarStore`; toggling one refreshes
+/// the in-memory event list immediately.
+struct CalendarSelectionView: View {
+    @Environment(AppState.self) private var appState
+
+    private let store = HiddenCalendarStore()
+
+    @State private var calendars: [CalendarInfo] = []
+    @State private var hidden: Set<String> = []
+    @State private var isLoading = true
+
+    var body: some View {
+        List {
+            if isLoading {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                .listRowBackground(Color.clear)
+            } else if calendars.isEmpty {
+                ContentUnavailableView(
+                    "No Calendars",
+                    systemImage: "calendar",
+                    description: Text(
+                        "mDone has no calendars to show. Grant calendar access in the Calendar tab first."
+                    )
+                )
+            } else {
+                Section {
+                    ForEach(calendars) { calendar in
+                        Toggle(isOn: binding(for: calendar)) {
+                            HStack(spacing: 10) {
+                                Circle()
+                                    .fill(Color(cgColor: calendar.color ?? Self.fallbackColor))
+                                    .frame(width: 10, height: 10)
+                                    .accessibilityHidden(true)
+                                Text(calendar.title)
+                            }
+                        }
+                    }
+                } footer: {
+                    Text("Only events from the calendars you turn on appear in mDone's Calendar and Today views.")
+                }
+            }
+        }
+        .navigationTitle("Calendars")
+        #if os(iOS)
+            .listStyle(.insetGrouped)
+        #endif
+            .toolbar {
+                if !calendars.isEmpty {
+                    Button(allShown ? "Hide All" : "Show All") {
+                        toggleAll()
+                    }
+                }
+            }
+            .task {
+                calendars = await appState.availableCalendars()
+                hidden = store.hiddenIdentifiers
+                isLoading = false
+            }
+    }
+
+    private static let fallbackColor = CGColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1.0)
+
+    private var allShown: Bool {
+        hidden.isEmpty
+    }
+
+    private func binding(for calendar: CalendarInfo) -> Binding<Bool> {
+        Binding(
+            get: { !hidden.contains(calendar.id) },
+            set: { shown in
+                if shown {
+                    hidden.remove(calendar.id)
+                } else {
+                    hidden.insert(calendar.id)
+                }
+                store.setHidden(!shown, for: calendar.id)
+                Task { await appState.calendarSelectionDidChange() }
+            }
+        )
+    }
+
+    private func toggleAll() {
+        if allShown {
+            hidden = Set(calendars.map(\.id))
+        } else {
+            hidden = []
+        }
+        store.replace(with: hidden)
+        Task { await appState.calendarSelectionDidChange() }
+    }
+}

--- a/mDone/Views/Settings/SettingsScreen.swift
+++ b/mDone/Views/Settings/SettingsScreen.swift
@@ -35,6 +35,14 @@ struct SettingsScreen: View {
                 }
             }
 
+            Section("Calendar") {
+                NavigationLink {
+                    CalendarSelectionView()
+                } label: {
+                    Label("Calendars in mDone", systemImage: "calendar")
+                }
+            }
+
             Section("Notifications") {
                 Toggle("Enable Reminders", isOn: $notificationsEnabled)
                     .onChange(of: notificationsEnabled) { _, newValue in

--- a/mDoneTests/AppStateTests.swift
+++ b/mDoneTests/AppStateTests.swift
@@ -35,6 +35,27 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(AppState.uniquedById([]).count, 0)
     }
 
+    // MARK: - Calendar selection (#69)
+
+    func testCalendarSelectionDidChangeBumpsFilterToken() async {
+        let appState = AppState()
+        let before = appState.calendarFilterToken
+        await appState.calendarSelectionDidChange()
+        XCTAssertNotEqual(
+            appState.calendarFilterToken,
+            before,
+            "Toggling a calendar must change the token so calendar views re-query"
+        )
+    }
+
+    func testCalendarSelectionTokenChangesEachCall() async {
+        let appState = AppState()
+        await appState.calendarSelectionDidChange()
+        let first = appState.calendarFilterToken
+        await appState.calendarSelectionDidChange()
+        XCTAssertNotEqual(appState.calendarFilterToken, first)
+    }
+
     // MARK: - tasksForProject with duplicate-cache regression (issue #54)
 
     /// Reproduces the crash that issue #54 reported. Before the fix, `tasksForProject`

--- a/mDoneTests/CalendarSelectionTests.swift
+++ b/mDoneTests/CalendarSelectionTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import mDone
+
+final class CalendarSelectionTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "CalendarSelectionTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    private func makeStore() -> HiddenCalendarStore {
+        HiddenCalendarStore(defaults: defaults)
+    }
+
+    private func event(_ id: String, calendar: String) -> CalendarEvent {
+        CalendarEvent(
+            id: id,
+            title: "Event \(id)",
+            startDate: Date(timeIntervalSince1970: 0),
+            endDate: Date(timeIntervalSince1970: 3600),
+            calendarIdentifier: calendar
+        )
+    }
+
+    // MARK: - Defaults / empty state
+
+    func testEmptyStoreHidesNothing() {
+        let store = makeStore()
+        XCTAssertTrue(store.hiddenIdentifiers.isEmpty)
+        XCTAssertFalse(store.isHidden("work"))
+    }
+
+    func testVisibleEventsReturnsAllWhenNothingHidden() {
+        let store = makeStore()
+        let events = [event("1", calendar: "work"), event("2", calendar: "home")]
+        XCTAssertEqual(store.visibleEvents(events).map(\.id), ["1", "2"])
+    }
+
+    // MARK: - setHidden
+
+    func testSetHiddenPersistsAndFilters() {
+        let store = makeStore()
+        store.setHidden(true, for: "work")
+
+        XCTAssertTrue(store.isHidden("work"))
+        XCTAssertEqual(store.hiddenIdentifiers, ["work"])
+
+        let events = [event("1", calendar: "work"), event("2", calendar: "home")]
+        XCTAssertEqual(store.visibleEvents(events).map(\.id), ["2"])
+    }
+
+    func testSetHiddenFalseUnhides() {
+        let store = makeStore()
+        store.setHidden(true, for: "work")
+        store.setHidden(false, for: "work")
+
+        XCTAssertFalse(store.isHidden("work"))
+        XCTAssertTrue(store.hiddenIdentifiers.isEmpty)
+    }
+
+    func testSetHiddenIsIdempotent() {
+        let store = makeStore()
+        store.setHidden(true, for: "work")
+        store.setHidden(true, for: "work")
+        XCTAssertEqual(store.hiddenIdentifiers, ["work"])
+    }
+
+    func testHiddenSetSurvivesAcrossStoreInstances() {
+        makeStore().setHidden(true, for: "shared")
+        // A fresh store reading the same defaults sees the persisted value.
+        XCTAssertTrue(makeStore().isHidden("shared"))
+    }
+
+    // MARK: - replace
+
+    func testReplaceSetsEntireSet() {
+        let store = makeStore()
+        store.setHidden(true, for: "work")
+        store.replace(with: ["a", "b"])
+        XCTAssertEqual(store.hiddenIdentifiers, ["a", "b"])
+    }
+
+    func testReplaceWithEmptyClearsStorage() {
+        let store = makeStore()
+        store.replace(with: ["a", "b"])
+        store.replace(with: [])
+        XCTAssertTrue(store.hiddenIdentifiers.isEmpty)
+        XCTAssertNil(defaults.array(forKey: HiddenCalendarStore.storageKey))
+    }
+
+    // MARK: - prune
+
+    func testPruneDropsStaleIdentifiers() {
+        let store = makeStore()
+        store.replace(with: ["work", "stale", "home"])
+        store.prune(toExisting: ["work", "home"])
+        XCTAssertEqual(store.hiddenIdentifiers, ["home", "work"])
+    }
+
+    func testPruneKeepsAllWhenAllStillExist() {
+        let store = makeStore()
+        store.replace(with: ["work", "home"])
+        store.prune(toExisting: ["work", "home", "extra"])
+        XCTAssertEqual(store.hiddenIdentifiers, ["home", "work"])
+    }
+
+    func testPruneOnEmptyStoreIsNoOp() {
+        let store = makeStore()
+        store.prune(toExisting: ["work"])
+        XCTAssertTrue(store.hiddenIdentifiers.isEmpty)
+    }
+
+    // MARK: - visibleEvents filtering
+
+    func testVisibleEventsFiltersMultipleHiddenCalendars() {
+        let store = makeStore()
+        store.replace(with: ["work", "spam"])
+        let events = [
+            event("1", calendar: "work"),
+            event("2", calendar: "home"),
+            event("3", calendar: "spam"),
+            event("4", calendar: "home")
+        ]
+        XCTAssertEqual(store.visibleEvents(events).map(\.id), ["2", "4"])
+    }
+
+    func testVisibleEventsKeepsEmptyCalendarIdentifierUnlessHidden() {
+        let store = makeStore()
+        store.setHidden(true, for: "work")
+        let events = [event("1", calendar: ""), event("2", calendar: "work")]
+        XCTAssertEqual(store.visibleEvents(events).map(\.id), ["1"])
+    }
+
+    // MARK: - CalendarInfo
+
+    func testCalendarInfoEqualityByIdAndTitle() {
+        let a = CalendarInfo(id: "x", title: "Work")
+        let b = CalendarInfo(id: "x", title: "Work")
+        let c = CalendarInfo(id: "x", title: "Renamed")
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+        XCTAssertEqual(a.hashValue, b.hashValue)
+    }
+
+    // MARK: - CalendarEvent memberwise init
+
+    func testCalendarEventMemberwiseInitAndIdentity() {
+        let e1 = event("evt", calendar: "work")
+        let e2 = event("evt", calendar: "home")
+        XCTAssertEqual(e1.calendarIdentifier, "work")
+        XCTAssertEqual(e1.title, "Event evt")
+        // Hashable identity is by event id only.
+        XCTAssertEqual(e1, e2)
+        XCTAssertEqual(Set([e1, e2]).count, 1)
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Settings → Calendar → "Calendars in mDone"**, letting users choose which device calendars contribute events to mDone's Calendar and Today views. Previously mDone showed events from *every* calendar, so users with shared family/work calendars had no way to keep that noise out of their task context.

- Toggle list of the device's event calendars (with colour dots) + **Show All / Hide All**.
- Selections persist via a UserDefaults-backed `HiddenCalendarStore`.
- The store persists the **hidden** set (not the visible set), so the empty default means "show everything" and any newly added calendar appears automatically until explicitly hidden. Stale ids for deleted calendars are pruned.
- Filtering logic lives entirely in the pure, injectable `HiddenCalendarStore` rather than the EventKit-backed `CalendarService`, so it is fully unit-testable.
- `AppState` exposes an observable `calendarFilterToken`; the Calendar screen keys an event refetch on it, so toggling a calendar refreshes the month grid and selected-day list immediately — not just the Today view.

### Files

| File | Change |
|---|---|
| `mDone/App/CalendarSelection.swift` *(new)* | `CalendarInfo` + `HiddenCalendarStore` (pure filter, prune, persistence) |
| `mDone/App/AppState.swift` | `availableCalendars()`, observable `calendarFilterToken`, `calendarSelectionDidChange()` |
| `mDone/Services/CalendarService.swift` | `availableCalendars()`; filtering applied in `fetchEvents` (day/month inherit it) |
| `mDone/Models/CalendarEvent.swift` | Added `calendarIdentifier`; EventKit-free memberwise init for tests |
| `mDone/Views/Settings/CalendarSelectionView.swift` *(new)* | The toggle UI |
| `mDone/Views/Settings/SettingsScreen.swift` | New "Calendar" section linking to it |
| `mDone/Views/Calendar/CalendarScreen.swift` | Refetch keyed on `calendarFilterToken` |
| Tests + `CHANGELOG.md` | See below |

## Related Issues

Fixes #69

## Testing

- New `mDoneTests/CalendarSelectionTests.swift` — 15 tests covering the store (default/empty semantics, set/unset, idempotency, cross-instance persistence, replace, prune, multi-calendar filtering, empty-identifier edge case) and `CalendarInfo`/`CalendarEvent` equality. Uses an isolated `UserDefaults` suite so `.standard` is never polluted.
- `mDoneTests/AppStateTests.swift` — +2 tests for `calendarFilterToken` bumping.
- Full unit suite green: **264/264** (the only failure in a full run is the pre-existing, unrelated `mDoneUITests.testAppLaunchesToSetupScreen`).
- Coverage: the new `CalendarSelection.swift` is at **91.5%** (above the 85% service target; the uncovered lines are the `EKCalendar` initialiser, which can't be unit-tested without a live EventKit store). `CalendarService`'s EventKit methods remain untestable in-harness by design — which is exactly why the filter logic was factored into the pure store.
- Verified end-to-end on the iOS Simulator: hiding UK Holidays removed its bank-holiday events from both the month-grid dots and the day list; re-enabling it and navigating straight back to the Calendar tab (without changing the date) brought them back immediately, confirming the live-refresh.

## Checklist

- [x] Builds and runs on iOS (verified on iPhone 17 simulator). macOS not separately built, but no iOS-only APIs were introduced — the new core/service/model code is platform-neutral and the one `#if os(iOS)` guard (list style) follows existing patterns.
- [x] Tests pass (264 unit tests; new tests included)
- [x] `swiftlint lint --quiet` clean on changed files; `swiftformat` applied to changed files (run selectively rather than repo-wide to avoid unrelated trailing-comma churn — pre-existing arrays were kept in the repo's no-trailing-comma style)
- [x] No breaking changes — additive only (new optional `init` param with default, new methods, new screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)