### PR TITLE
Fix task description edits not appearing until app restart (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Settings → Calendar → "Calendars in mDone" lets you choose which device calendars contribute events to mDone's Calendar and Today views. Turn off shared family or work calendars you don't want cluttering your task context; new calendars show by default until you hide them (#69).
 
+### Fixed
+- Edits to a task's description (and other fields) now appear immediately. Previously the task detail sheet would still show the old value until the app was force-quit and reopened, because `VTask` equality only compared by ID — SwiftUI saw "no change" and skipped re-rendering. The local SwiftData cache is also now written on every task mutation, so cold launches see the latest data even before the first refresh completes (#84).
+
 ## [1.3.0] - 2026-05-17
 
 ### Added

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -380,6 +380,7 @@ final class AppState {
             if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
                 tasks[index] = updated
             }
+            syncService?.updateCachedTask(updated)
             if updated.done {
                 onTaskCompleted?(updated.id)
             }
@@ -408,6 +409,7 @@ final class AppState {
         do {
             let newTask = try await taskService.createTask(projectId: projectId, request: request)
             tasks.append(newTask)
+            syncService?.updateCachedTask(newTask)
             #if os(iOS)
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
             #endif
@@ -437,6 +439,7 @@ final class AppState {
             if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
                 tasks[index] = updated
             }
+            syncService?.updateCachedTask(updated)
             WidgetCenter.shared.reloadAllTimelines()
         } catch {
             if let index = tasks.firstIndex(where: { $0.id == task.id }) {
@@ -453,6 +456,7 @@ final class AppState {
             if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
                 tasks[index] = updated
             }
+            syncService?.updateCachedTask(updated)
             WidgetCenter.shared.reloadAllTimelines()
         } catch {
             handleError(error)
@@ -465,6 +469,7 @@ final class AppState {
             let taskId = task.id
             try await taskService.deleteTask(id: taskId)
             tasks.removeAll { $0.id == taskId }
+            syncService?.deleteCachedTask(id: taskId)
             onTaskDeleted?(taskId)
             #if os(iOS)
             UINotificationFeedbackGenerator().notificationOccurred(.warning)

--- a/mDone/Models/VTask.swift
+++ b/mDone/Models/VTask.swift
@@ -29,14 +29,6 @@ struct VTask: Codable, Identifiable, Hashable {
     var bucketId: Int64?
     var coverImageAttachmentId: Int64?
 
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
-
-    static func == (lhs: VTask, rhs: VTask) -> Bool {
-        lhs.id == rhs.id
-    }
-
     var priorityLevel: PriorityLevel {
         PriorityLevel(rawValue: Int(priority)) ?? .none
     }

--- a/mDoneTests/NetworkErrorTests.swift
+++ b/mDoneTests/NetworkErrorTests.swift
@@ -321,6 +321,6 @@ final class NetworkErrorTests: XCTestCase {
         set.insert(task2)
         set.insert(task1Copy)
 
-        XCTAssertEqual(set.count, 2, "Tasks differing in any field hash differently; identical copies dedupe")
+        XCTAssertEqual(set.count, 2, "Tasks differing in any field are distinct Set members; identical copies dedupe")
     }
 }

--- a/mDoneTests/NetworkErrorTests.swift
+++ b/mDoneTests/NetworkErrorTests.swift
@@ -288,22 +288,39 @@ final class NetworkErrorTests: XCTestCase {
 
     // MARK: - VTask Equality and Hashing
 
-    func testVTaskEquality() {
+    func testVTaskEqualityComparesAllFields() {
+        // Regression for #84: id-only equality made SwiftUI treat description
+        // (and every other field) edits as no-ops, so the task detail sheet
+        // would not re-render after a save until a cold app launch.
         let task1 = VTask(id: 1, title: "First", done: false, priority: 0, projectId: 1)
         let task2 = VTask(id: 1, title: "Different", done: true, priority: 5, projectId: 2)
         let task3 = VTask(id: 2, title: "First", done: false, priority: 0, projectId: 1)
+        let task4 = VTask(id: 1, title: "First", done: false, priority: 0, projectId: 1)
 
-        XCTAssertEqual(task1, task2, "Tasks with same ID should be equal")
-        XCTAssertNotEqual(task1, task3, "Tasks with different IDs should not be equal")
+        XCTAssertNotEqual(task1, task2, "Tasks differing in any field must not be equal")
+        XCTAssertNotEqual(task1, task3, "Tasks with different IDs are not equal")
+        XCTAssertEqual(task1, task4, "Tasks with identical fields are equal")
+    }
+
+    func testVTaskDescriptionChangeBreaksEquality() {
+        // Specific scenario from #84: edit a task to add a description, save,
+        // re-open. The "before" and "after" VTask values must compare unequal
+        // so SwiftUI re-evaluates views holding the task.
+        let before = VTask(id: 1, title: "Task", description: nil, done: false, priority: 0, projectId: 1)
+        let after = VTask(id: 1, title: "Task", description: "Added later", done: false, priority: 0, projectId: 1)
+
+        XCTAssertNotEqual(before, after, "A description change must produce an unequal VTask (#84)")
     }
 
     func testVTaskHashable() {
         let task1 = VTask(id: 1, title: "First", done: false, priority: 0, projectId: 1)
         let task2 = VTask(id: 1, title: "Different", done: true, priority: 5, projectId: 2)
+        let task1Copy = VTask(id: 1, title: "First", done: false, priority: 0, projectId: 1)
 
         var set: Set<VTask> = [task1]
         set.insert(task2)
+        set.insert(task1Copy)
 
-        XCTAssertEqual(set.count, 1, "Tasks with same ID should hash equally")
+        XCTAssertEqual(set.count, 2, "Tasks differing in any field hash differently; identical copies dedupe")
     }
 }


### PR DESCRIPTION
## Summary

Fixes the bug where edits to a task's description (or any other field) were not visible in the task detail sheet until the app was force-quit and reopened.

**Root cause.** `VTask` declared id-only `==` and `hash(into:)` overrides. SwiftUI uses `Equatable` to decide whether to re-evaluate views that receive a value-typed model — so when `AppState.updateTask` replaced `tasks[index]` with the server response, the new `VTask` still compared `==` to the old one (same id) and views holding `task: VTask` never re-evaluated. `TaskDetailSheet`'s `@State private var description` is set once in `init`, so without a view rebuild it kept showing the old text. A cold app launch "fixed" it because the view tree was reconstructed from scratch via `refreshAll()`.

Two-part fix:
- Drop the manual `Equatable` / `Hashable` conformances on `VTask` so the compiler synthesises field-aware versions. All sub-types (`User`, `VLabel`, `TaskReminder`) already conform.
- Add the missing `SyncService.updateCachedTask(_:)` / `deleteCachedTask(id:)` calls to `AppState.updateTask`, `toggleTaskDone`, `postponeTask`, `createTask`, and `deleteTask`. Without these the SwiftData cache went stale after any local edit; a cold launch from cache (before the API refresh completes) would briefly show pre-edit values.

The only consumer of `VTask` hashing was the existing `testVTaskHashable` test — production sets/dictionaries key on `id`, so this change is safe.

## Related Issues

Fixes #84

## Testing

- `xcodebuild ... -only-testing:mDoneTests test` — all 267 unit tests pass, including:
  - Updated `testVTaskEqualityComparesAllFields` (was previously asserting the buggy id-only behaviour)
  - New `testVTaskDescriptionChangeBreaksEquality` regression test
  - Updated `testVTaskHashable` to assert field-aware hashing
- iOS and macOS targets build clean.
- Manual reproduction of the original report (create task → edit to add description → save → re-open) needs to be verified on a device/simulator with a real Vikunja backend.

## Checklist

- [x] Builds on iOS and macOS
- [x] Tests pass
- [ ] Ran `swiftlint lint --quiet` and `swiftformat .`
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)