### PR TITLE
release: cut 1.3.1 (build 30) for TestFlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-05-24
+
 ### Added
 - Settings → Calendar → "Calendars in mDone" lets you choose which device calendars contribute events to mDone's Calendar and Today views. Turn off shared family or work calendars you don't want cluttering your task context; new calendars show by default until you hide them (#69).
 - Settings → Tasks: "Default due time" picks the time of day applied to tasks you add to Today without typing a time (9 AM / noon / 5 PM / 6 PM / 9 PM / End of day). Defaults to 6 PM, matching Vikunja's web client (#81).

--- a/project.yml
+++ b/project.yml
@@ -16,8 +16,8 @@ settings:
     # not feature-related — see PR "decisions".
     PRODUCT_NAME: "$(TARGET_NAME)"
     SWIFT_VERSION: "5.9"
-    MARKETING_VERSION: "1.3.0"
-    CURRENT_PROJECT_VERSION: "28"
+    MARKETING_VERSION: "1.3.1"
+    CURRENT_PROJECT_VERSION: "30"
     DEVELOPMENT_TEAM: "Z62E7MGREE"
     CODE_SIGN_IDENTITY: "Apple Development"
     CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary

- Bumps `MARKETING_VERSION` to **1.3.1** — 1.3.0 has been approved on the App Store and the train is closed for new builds, so the next TestFlight upload must use a higher version.
- Bumps `CURRENT_PROJECT_VERSION` to **30**. Build 29 was uploaded under 1.3.1 from an orphan branch (`claude/festive-hodgkin-5fb67d`) with an earlier free-`DatePicker` implementation; it should be **expired in App Store Connect** so testers converge on the preset-picker UI from #83.
- Cuts CHANGELOG [Unreleased] into [1.3.1] - 2026-05-24.

## Test plan
- [ ] After merge: archive iOS Release, export, upload via altool.
- [ ] App Store Connect: expire build 29 (1.3.1).
- [ ] Smoke on TestFlight: add a task to Today on iPhone with no time → due date renders grey, not red.
- [ ] Smoke on TestFlight: Settings → Tasks → Default due time → "End of day" → repeat → task created at 23:59, grey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)