### PR TITLE
Add iPhone shake-to-undo for task completion (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Shake your iPhone right after completing a task to undo it. mDone shows a confirmation prompt naming the task ("Undo completing "…"?") so an accidental shake never silently reverses anything, and only the most recent completion can be undone (#82).
+
 ## [1.3.1] - 2026-05-24
 
 ### Added

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -59,7 +59,13 @@ final class AppState {
         notifications.filter { $0.read != true }.count
     }
 
-    private let taskService = TaskService()
+    /// `taskService` is injectable so tests can drive the network paths
+    /// (e.g. `undoLastCompletion`) through a mocked `APIClient`.
+    init(taskService: TaskService = TaskService()) {
+        self.taskService = taskService
+    }
+
+    private let taskService: TaskService
     private let projectService = ProjectService()
     private let authService = AuthService.shared
     private let notificationService = NotificationService.shared
@@ -503,7 +509,12 @@ final class AppState {
             #endif
             WidgetCenter.shared.reloadAllTimelines()
         } catch {
-            undoableCompletion = target
+            // Only restore the old target if no newer completion was recorded
+            // while this request was in flight — otherwise we'd clobber the more
+            // recent undo target and break "undo the most recent completion".
+            if undoableCompletion == nil {
+                undoableCompletion = target
+            }
             handleError(error)
         }
     }

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -483,8 +483,13 @@ final class AppState {
         undoableCompletion = nil
         do {
             let updated = try await taskService.updateTask(id: target.id, request: TaskUpdateRequest(done: false))
+            // The completed task may have been dropped from `tasks` by a refresh
+            // (the all-tasks fetch returns only undone tasks), so re-insert it
+            // when it's no longer present rather than silently doing nothing.
             if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
                 tasks[index] = updated
+            } else {
+                tasks.append(updated)
             }
             syncService?.updateCachedTask(updated)
             #if os(iOS)

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -43,6 +43,15 @@ final class AppState {
     var onTaskCompleted: ((Int64) -> Void)?
     var onTaskDeleted: ((Int64) -> Void)?
 
+    /// The most recently completed task, eligible for shake-to-undo on iPhone.
+    /// Holds the task as it was *before* completion so undo can restore it.
+    /// Replaced when a newer task is completed, and cleared once undone or if
+    /// the same task is un-completed by other means.
+    private(set) var undoableCompletion: VTask?
+
+    var canUndoLastCompletion: Bool { undoableCompletion != nil }
+    var undoableCompletionTitle: String? { undoableCompletion?.title }
+
     /// Per-project ordered task lists fetched from the view endpoint (preserves positions).
     var projectTaskCache: [Int64: [VTask]] = [:]
 
@@ -451,7 +460,10 @@ final class AppState {
             }
             syncService?.updateCachedTask(updated)
             if updated.done {
+                recordCompletionForUndo(task)
                 onTaskCompleted?(updated.id)
+            } else {
+                clearUndoIfMatches(id: updated.id)
             }
             #if os(iOS)
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -459,6 +471,41 @@ final class AppState {
             WidgetCenter.shared.reloadAllTimelines()
         } catch {
             handleError(error)
+        }
+    }
+
+    /// Restores the most recently completed task to its incomplete state.
+    /// Invoked by the iPhone shake-to-undo prompt. No-op when nothing is
+    /// pending undo. On failure the undo target is kept so the user can retry.
+    @MainActor
+    func undoLastCompletion() async {
+        guard let target = undoableCompletion else { return }
+        undoableCompletion = nil
+        do {
+            let updated = try await taskService.updateTask(id: target.id, request: TaskUpdateRequest(done: false))
+            if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
+                tasks[index] = updated
+            }
+            syncService?.updateCachedTask(updated)
+            #if os(iOS)
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            #endif
+            WidgetCenter.shared.reloadAllTimelines()
+        } catch {
+            undoableCompletion = target
+            handleError(error)
+        }
+    }
+
+    /// Records `task` (in its pre-completion state) as the pending shake-to-undo
+    /// target. Exposed for testing the tracking logic without a network round-trip.
+    func recordCompletionForUndo(_ task: VTask) {
+        undoableCompletion = task
+    }
+
+    func clearUndoIfMatches(id: Int64) {
+        if undoableCompletion?.id == id {
+            undoableCompletion = nil
         }
     }
 

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -482,16 +482,22 @@ final class AppState {
         guard let target = undoableCompletion else { return }
         undoableCompletion = nil
         do {
-            let updated = try await taskService.updateTask(id: target.id, request: TaskUpdateRequest(done: false))
-            // The completed task may have been dropped from `tasks` by a refresh
-            // (the all-tasks fetch returns only undone tasks), so re-insert it
-            // when it's no longer present rather than silently doing nothing.
-            if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
-                tasks[index] = updated
+            _ = try await taskService.updateTask(id: target.id, request: TaskUpdateRequest(done: false))
+            // Restore the task to its exact pre-completion state. We rebuild from
+            // the stored snapshot rather than the update response because the
+            // response can omit fields like the due date, which would land the
+            // task in the wrong Inbox section (e.g. "No Date" instead of "Today").
+            // The completed task may also have been dropped from `tasks` by a
+            // refresh (the all-tasks fetch returns only undone tasks), so re-insert
+            // it when it's no longer present rather than silently doing nothing.
+            var restored = target
+            restored.done = false
+            if let index = tasks.firstIndex(where: { $0.id == restored.id }) {
+                tasks[index] = restored
             } else {
-                tasks.append(updated)
+                tasks.append(restored)
             }
-            syncService?.updateCachedTask(updated)
+            syncService?.updateCachedTask(restored)
             #if os(iOS)
             UINotificationFeedbackGenerator().notificationOccurred(.success)
             #endif

--- a/mDone/Views/Components/ShakeDetector.swift
+++ b/mDone/Views/Components/ShakeDetector.swift
@@ -20,6 +20,8 @@ private struct DeviceShakeViewModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content.onReceive(NotificationCenter.default.publisher(for: UIDevice.deviceDidShakeNotification)) { _ in
+            // iPhone-only feature (issue #82); ignore shakes on iPad.
+            guard UIDevice.current.userInterfaceIdiom == .phone else { return }
             action()
         }
     }

--- a/mDone/Views/Components/ShakeDetector.swift
+++ b/mDone/Views/Components/ShakeDetector.swift
@@ -1,0 +1,34 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+extension UIDevice {
+    static let deviceDidShakeNotification = Notification.Name("mDone.deviceDidShake")
+}
+
+extension UIWindow {
+    override open func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        super.motionEnded(motion, with: event)
+        if motion == .motionShake {
+            NotificationCenter.default.post(name: UIDevice.deviceDidShakeNotification, object: nil)
+        }
+    }
+}
+
+private struct DeviceShakeViewModifier: ViewModifier {
+    let action: () -> Void
+
+    func body(content: Content) -> some View {
+        content.onReceive(NotificationCenter.default.publisher(for: UIDevice.deviceDidShakeNotification)) { _ in
+            action()
+        }
+    }
+}
+
+extension View {
+    /// Runs `action` when the device is physically shaken. iPhone only.
+    func onShake(perform action: @escaping () -> Void) -> some View {
+        modifier(DeviceShakeViewModifier(action: action))
+    }
+}
+#endif

--- a/mDone/Views/MainTabView.swift
+++ b/mDone/Views/MainTabView.swift
@@ -7,6 +7,9 @@ struct MainTabView: View {
     #endif
     @State private var selectedTab: Tab = .inbox
     @State private var showNotifications = false
+    #if os(iOS)
+    @State private var showUndoCompletionPrompt = false
+    #endif
 
     enum Tab: Hashable {
         case inbox, projects, calendar, settings
@@ -63,10 +66,34 @@ struct MainTabView: View {
         .errorBanner(Bindable(appState).activeError) {
             Task { await appState.refreshAll() }
         }
+        .onShake {
+            if appState.canUndoLastCompletion {
+                showUndoCompletionPrompt = true
+            }
+        }
+        .confirmationDialog(
+            undoPromptTitle,
+            isPresented: $showUndoCompletionPrompt,
+            titleVisibility: .visible
+        ) {
+            Button("Undo Completion") {
+                Task { await appState.undoLastCompletion() }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
         #else
         Text("macOS")
         #endif
     }
+
+    #if os(iOS)
+    private var undoPromptTitle: String {
+        if let title = appState.undoableCompletionTitle {
+            return "Undo completing \u{201C}\(title)\u{201D}?"
+        }
+        return "Undo completion?"
+    }
+    #endif
 
     private var notificationBellButton: some View {
         Button {

--- a/mDoneTests/AppStateTests.swift
+++ b/mDoneTests/AppStateTests.swift
@@ -176,4 +176,54 @@ final class AppStateTests: XCTestCase {
         XCTAssertNil(auth.getToken())
         XCTAssertNil(auth.getRefreshToken())
     }
+
+    // MARK: - Shake-to-undo completion tracking (#82)
+
+    func testNoUndoTargetByDefault() {
+        let appState = AppState()
+        XCTAssertFalse(appState.canUndoLastCompletion)
+        XCTAssertNil(appState.undoableCompletionTitle)
+    }
+
+    func testRecordingCompletionMakesItUndoable() {
+        let appState = AppState()
+        let task = VTask(id: 7, title: "Walk the dog", done: false, priority: 0, projectId: 10)
+
+        appState.recordCompletionForUndo(task)
+
+        XCTAssertTrue(appState.canUndoLastCompletion)
+        XCTAssertEqual(appState.undoableCompletionTitle, "Walk the dog")
+        XCTAssertEqual(appState.undoableCompletion?.id, 7)
+    }
+
+    func testRecordingNewerCompletionReplacesPrevious() {
+        let appState = AppState()
+        appState.recordCompletionForUndo(VTask(id: 1, title: "First", done: false, priority: 0, projectId: 10))
+        appState.recordCompletionForUndo(VTask(id: 2, title: "Second", done: false, priority: 0, projectId: 10))
+
+        XCTAssertEqual(appState.undoableCompletion?.id, 2,
+                       "Only the most recent completion is undoable")
+        XCTAssertEqual(appState.undoableCompletionTitle, "Second")
+    }
+
+    func testClearUndoMatchingIdResets() {
+        let appState = AppState()
+        appState.recordCompletionForUndo(VTask(id: 5, title: "Task", done: false, priority: 0, projectId: 10))
+
+        appState.clearUndoIfMatches(id: 5)
+
+        XCTAssertFalse(appState.canUndoLastCompletion,
+                       "Un-completing the same task by other means clears the undo target")
+    }
+
+    func testClearUndoNonMatchingIdKeepsTarget() {
+        let appState = AppState()
+        appState.recordCompletionForUndo(VTask(id: 5, title: "Task", done: false, priority: 0, projectId: 10))
+
+        appState.clearUndoIfMatches(id: 99)
+
+        XCTAssertTrue(appState.canUndoLastCompletion,
+                      "A different task changing state must not clear the pending undo")
+        XCTAssertEqual(appState.undoableCompletion?.id, 5)
+    }
 }

--- a/mDoneTests/AppStateTests.swift
+++ b/mDoneTests/AppStateTests.swift
@@ -3,6 +3,24 @@ import XCTest
 
 @MainActor
 final class AppStateTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    /// Builds an `AppState` whose `TaskService` talks to `MockURLProtocol`,
+    /// so tests can drive `undoLastCompletion()`'s network path deterministically.
+    private func makeMockedAppState() async -> AppState {
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        return AppState(taskService: TaskService(apiClient: client))
+    }
+
     // MARK: - uniquedById
 
     func testUniquedByIdRemovesDuplicates() {
@@ -225,5 +243,94 @@ final class AppStateTests: XCTestCase {
         XCTAssertTrue(appState.canUndoLastCompletion,
                       "A different task changing state must not clear the pending undo")
         XCTAssertEqual(appState.undoableCompletion?.id, 5)
+    }
+
+    // MARK: - Shake-to-undo network path: undoLastCompletion() (#82)
+
+    func testUndoRestoresTaskInPlaceOnSuccess() async {
+        let appState = await makeMockedAppState()
+        let task = VTask(id: 42, title: "Buy milk", done: true, priority: 1, projectId: 3)
+        appState.tasks = [task]
+        appState.recordCompletionForUndo(task)
+
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 200, url: request.url!)
+            let json = """
+            {"id": 42, "title": "Buy milk", "done": false, "priority": 1, "project_id": 3}
+            """
+            return (response, Data(json.utf8))
+        }
+
+        await appState.undoLastCompletion()
+
+        XCTAssertEqual(appState.tasks.count, 1, "Undo must not duplicate the already-present task")
+        XCTAssertEqual(appState.tasks.first?.id, 42)
+        XCTAssertEqual(appState.tasks.first?.done, false, "Undo must mark the task not-done locally")
+        XCTAssertFalse(appState.canUndoLastCompletion, "A successful undo consumes the pending target")
+    }
+
+    func testUndoReinsertsTaskWhenMissingFromList() async {
+        let appState = await makeMockedAppState()
+        // The completed task was dropped from `tasks` by an all-tasks refresh
+        // (that endpoint returns only undone tasks), so it's no longer present.
+        let task = VTask(id: 7, title: "Walk the dog", done: true, priority: 0, projectId: 10)
+        appState.tasks = []
+        appState.recordCompletionForUndo(task)
+
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 200, url: request.url!)
+            let json = """
+            {"id": 7, "title": "Walk the dog", "done": false, "priority": 0, "project_id": 10}
+            """
+            return (response, Data(json.utf8))
+        }
+
+        await appState.undoLastCompletion()
+
+        XCTAssertEqual(appState.tasks.map(\.id), [7], "A missing task must be re-inserted, not silently lost")
+        XCTAssertEqual(appState.tasks.first?.done, false)
+    }
+
+    func testUndoPreservesDueDateFromSnapshotWhenResponseOmitsIt() async {
+        let appState = await makeMockedAppState()
+        let due = Date(timeIntervalSince1970: 1_750_000_000)
+        var task = VTask(id: 99, title: "Pay rent", done: true, priority: 2, projectId: 5)
+        task.dueDate = due
+        appState.tasks = [task]
+        appState.recordCompletionForUndo(task)
+
+        // The un-complete response omits due_date — the bug that put the task in
+        // the wrong Inbox section. The restore must rebuild from the snapshot.
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 200, url: request.url!)
+            let json = """
+            {"id": 99, "title": "Pay rent", "done": false, "priority": 2, "project_id": 5}
+            """
+            return (response, Data(json.utf8))
+        }
+
+        await appState.undoLastCompletion()
+
+        XCTAssertEqual(appState.tasks.first?.effectiveDueDate, due,
+                       "Undo must preserve the original due date so the task returns to its Inbox section")
+    }
+
+    func testUndoKeepsTargetWhenRequestFails() async {
+        let appState = await makeMockedAppState()
+        let task = VTask(id: 11, title: "Flaky", done: true, priority: 0, projectId: 1)
+        appState.tasks = [task]
+        appState.recordCompletionForUndo(task)
+
+        // 400 (not 5xx) so APIClient fails fast instead of retrying with backoff.
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 400, url: request.url!)
+            return (response, Data("{\"message\": \"bad request\"}".utf8))
+        }
+
+        await appState.undoLastCompletion()
+
+        XCTAssertTrue(appState.canUndoLastCompletion,
+                      "A failed undo must keep the pending target so the user can retry")
+        XCTAssertEqual(appState.undoableCompletion?.id, 11)
     }
 }


### PR DESCRIPTION
## Summary
Implements #82: shake the iPhone after completing a task to undo the completion.

- Marking a task done records it as a shake-to-undo target.
- A device shake surfaces a native confirmation dialog naming the task ("Undo completing "…"?"); confirming restores it to incomplete via the API.
- Only the **most recent** completion is undoable; the target is replaced when a newer task is completed and cleared if the task is un-completed by other means.
- An accidental shake is never destructive — there's always an explicit prompt, no silent auto-revert. Shaking with nothing to undo does nothing.
- iPhone only (shake detection is `#if os(iOS)`).

## Implementation
- `AppState`: `undoableCompletion` tracking + `undoLastCompletion()`; wired into `toggleTaskDone`.
- `ShakeDetector.swift`: `onShake` SwiftUI modifier via a `UIWindow.motionEnded` override posting a notification.
- `MainTabView`: `.onShake` → `confirmationDialog`.

## Test plan
- [x] `xcodebuild ... -only-testing:mDoneTests test` — 313 unit tests pass, incl. 5 new `AppStateTests` covering undo-target tracking.
- [x] iOS build succeeds (iPhone 17 simulator).
- [ ] Manual: complete a task on device, shake, confirm undo restores it. (Shake gestures don't fire in the simulator — needs a physical device / TestFlight.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)