### PR TITLE
release: 1.4.0 (build 39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-05-29
+
 ### Added
 - Shake your iPhone right after completing a task to undo it. mDone shows a confirmation prompt naming the task ("Undo completing "…"?") so an accidental shake never silently reverses anything, and only the most recent completion can be undone (#82).
 

--- a/project.yml
+++ b/project.yml
@@ -16,8 +16,8 @@ settings:
     # not feature-related — see PR "decisions".
     PRODUCT_NAME: "$(TARGET_NAME)"
     SWIFT_VERSION: "5.9"
-    MARKETING_VERSION: "1.3.1"
-    CURRENT_PROJECT_VERSION: "35"
+    MARKETING_VERSION: "1.4.0"
+    CURRENT_PROJECT_VERSION: "39"
     DEVELOPMENT_TEAM: "Z62E7MGREE"
     CODE_SIGN_IDENTITY: "Apple Development"
     CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- Bump `MARKETING_VERSION` to 1.4.0 and `CURRENT_PROJECT_VERSION` to 39, matching the build submitted to App Review.
- Cut the shake-to-undo feature (#82) from `[Unreleased]` into a dated `## [1.4.0] - 2026-05-29` CHANGELOG section.

iOS 1.4.0 (build 39) is already uploaded and `WAITING_FOR_REVIEW` in App Store Connect; this PR brings the repo metadata in line with what shipped.

## Test plan
- [x] Full unit suite green (317 tests, 0 failures) on the feature branch prior to merge.
- [ ] No code change here — version/metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)