### PR TITLE
Add About screen with feedback and sponsorship links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-06-01
+
+### Added
+- Settings → "About mDone" opens an About screen (iPhone and Mac) with the app version, a link to report bugs or request features, a link to the source on GitHub, and ways to support development (GitHub Sponsors and Buy Me a Coffee).
+
 ## [1.4.0] - 2026-05-29
 
 ### Added

--- a/mDone/Views/Settings/AboutScreen.swift
+++ b/mDone/Views/Settings/AboutScreen.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+/// Lightweight About screen reachable from Settings on both iOS and macOS.
+/// Presented as a sheet so it behaves identically inside the iOS navigation
+/// stack and the macOS NavigationSplitView content column.
+struct AboutScreen: View {
+    @Environment(\.dismiss) private var dismiss
+
+    private static let repoURL = URL(string: "https://github.com/marco308/mdone")!
+    private static let issuesURL = URL(string: "https://github.com/marco308/mdone/issues/new/choose")!
+    private static let sponsorURL = URL(string: "https://github.com/sponsors/marco308")!
+    private static let coffeeURL = URL(string: "https://www.buymeacoffee.com/losperdidos")!
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    VStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 56))
+                            .foregroundStyle(.tint)
+                            .accessibilityHidden(true)
+                        Text("mDone")
+                            .font(.title2.bold())
+                        Text(Self.versionString)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        Text("A native task manager for Vikunja.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+                }
+                .listRowBackground(Color.clear)
+
+                Section("Feedback") {
+                    Link(destination: Self.issuesURL) {
+                        Label("Report a Bug or Request a Feature", systemImage: "ladybug")
+                    }
+                    Link(destination: Self.repoURL) {
+                        Label("View Source on GitHub", systemImage: "chevron.left.forwardslash.chevron.right")
+                    }
+                }
+
+                Section {
+                    Link(destination: Self.sponsorURL) {
+                        Label("Sponsor on GitHub", systemImage: "heart")
+                    }
+                    Link(destination: Self.coffeeURL) {
+                        Label("Buy Me a Coffee", systemImage: "cup.and.saucer")
+                    }
+                } header: {
+                    Text("Support mDone")
+                } footer: {
+                    Text("mDone is built and maintained by one person. If it's useful to you, a tip or sponsorship helps keep it going.")
+                }
+            }
+            .navigationTitle("About")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        #if os(macOS)
+        .frame(minWidth: 420, minHeight: 480)
+        #endif
+    }
+
+    private static var versionString: String {
+        let info = Bundle.main.infoDictionary
+        let short = info?["CFBundleShortVersionString"] as? String ?? "—"
+        let build = info?["CFBundleVersion"] as? String ?? "—"
+        return "Version \(short) (\(build))"
+    }
+}
+
+#Preview {
+    AboutScreen()
+}

--- a/mDone/Views/Settings/SettingsScreen.swift
+++ b/mDone/Views/Settings/SettingsScreen.swift
@@ -7,6 +7,7 @@ struct SettingsScreen: View {
     @AppStorage(WeekStartPreference.storageKey) private var firstWeekday = WeekStartPreference.system.rawValue
     @AppStorage(DefaultDueTimePreference.storageKey) private var defaultDueTime = DefaultDueTimePreference.defaultRawValue
     @State private var showLogoutConfirm = false
+    @State private var showAbout = false
 
     private var serverURL: String {
         AuthService.shared.getServerURL() ?? "Not configured"
@@ -92,25 +93,41 @@ struct SettingsScreen: View {
             #endif
 
             Section {
+                Button {
+                    showAbout = true
+                } label: {
+                    Label("About mDone", systemImage: "info.circle")
+                }
+            }
+
+            Section {
                 Button("Disconnect", role: .destructive) {
                     showLogoutConfirm = true
                 }
             }
 
             Section {
-                HStack {
-                    Spacer()
-                    VStack(spacing: 4) {
-                        Text("mDone")
-                            .font(.caption.bold())
-                        Text(Self.versionString)
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
+                Button {
+                    showAbout = true
+                } label: {
+                    HStack {
+                        Spacer()
+                        VStack(spacing: 4) {
+                            Text("mDone")
+                                .font(.caption.bold())
+                            Text(Self.versionString)
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                        Spacer()
                     }
-                    Spacer()
                 }
+                .buttonStyle(.plain)
             }
             .listRowBackground(Color.clear)
+        }
+        .sheet(isPresented: $showAbout) {
+            AboutScreen()
         }
         #if os(iOS)
         .listStyle(.insetGrouped)


### PR DESCRIPTION
## Summary
Adds an **About screen** reachable from Settings on both iOS and macOS — Settings → "About mDone", or by tapping the version footer.

It shows the app version and provides:
- **Report a Bug or Request a Feature** → GitHub issues
- **View Source on GitHub** → repo
- **Sponsor on GitHub** → github.com/sponsors/marco308
- **Buy Me a Coffee** → buymeacoffee.com/losperdidos

Presented as a sheet so it behaves consistently inside the iOS navigation stack and the macOS `NavigationSplitView` content column.

## Changes
- New `mDone/Views/Settings/AboutScreen.swift` (cross-platform)
- `SettingsScreen.swift`: "About mDone" row + tappable version footer open the sheet
- `CHANGELOG.md`: 1.4.1 entry

## Testing
- iOS + macOS both build clean
- 317/317 unit tests pass (the lone red UITest is the credential-gated screenshot test, pre-existing and unrelated)
- Shipped as **1.4.1 (build 40)** to TestFlight (processing VALID); submitted to App Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)