### PR TITLE
Add project create, edit, delete, and archive (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [1.5.0] - 2026-06-01
 
 ### Added
-- Create, edit, archive, and delete projects directly in mDone — no more switching to the Vikunja web app. Tap **+** on the Projects tab (iOS) or next to "Projects" in the sidebar (macOS, ⌘⇧N) to add a project with a title, description, colour, and favourite flag. Swipe or right-click any project to edit, archive, or delete it. Deleting warns that it permanently removes the project and all of its tasks (and any sub-projects) and offers to archive instead; archived projects move to a new **Archived** view where you can restore or permanently delete them (#92).
+- Create, edit, archive, and delete projects directly in mDone — no more switching to the Vikunja web app. Tap **+** on the Projects tab (iOS) or next to "Projects" in the sidebar (macOS, ⌘⇧N) to add a project with a title, description, color, and favorite flag. Swipe or right-click any project to edit, archive, or delete it. Deleting warns that it permanently removes the project and all of its tasks (and any sub-projects) and offers to archive instead; archived projects move to a new **Archived** view where you can restore or permanently delete them (#92).
 
 ## [1.4.1] - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Create, edit, archive, and delete projects directly in mDone — no more switching to the Vikunja web app. Tap **+** on the Projects tab (iOS) or next to "Projects" in the sidebar (macOS, ⌘⇧N) to add a project with a title, description, colour, and favourite flag. Swipe or right-click any project to edit, archive, or delete it. Deleting warns that it permanently removes the project and all of its tasks (and any sub-projects) and offers to archive instead; archived projects move to a new **Archived** view where you can restore or permanently delete them (#92).
+
 ## [1.4.0] - 2026-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-06-01
+
 ### Added
 - Create, edit, archive, and delete projects directly in mDone — no more switching to the Vikunja web app. Tap **+** on the Projects tab (iOS) or next to "Projects" in the sidebar (macOS, ⌘⇧N) to add a project with a title, description, colour, and favourite flag. Swipe or right-click any project to edit, archive, or delete it. Deleting warns that it permanently removes the project and all of its tasks (and any sub-projects) and offers to archive instead; archived projects move to a new **Archived** view where you can restore or permanently delete them (#92).
 

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -15,6 +15,9 @@ final class AppState {
 
     var tasks: [VTask] = []
     var projects: [Project] = []
+    /// Archived projects, loaded on demand for the Archived view. Kept separate
+    /// from `projects`, which only ever holds active (non-archived) projects.
+    var archivedProjects: [Project] = []
     var labels: [VLabel] = []
     var notifications: [VNotification] = []
     var selectedProject: Project?
@@ -49,8 +52,13 @@ final class AppState {
     /// the same task is un-completed by other means.
     private(set) var undoableCompletion: VTask?
 
-    var canUndoLastCompletion: Bool { undoableCompletion != nil }
-    var undoableCompletionTitle: String? { undoableCompletion?.title }
+    var canUndoLastCompletion: Bool {
+        undoableCompletion != nil
+    }
+
+    var undoableCompletionTitle: String? {
+        undoableCompletion?.title
+    }
 
     /// Per-project ordered task lists fetched from the view endpoint (preserves positions).
     var projectTaskCache: [Int64: [VTask]] = [:]
@@ -61,12 +69,13 @@ final class AppState {
 
     /// `taskService` is injectable so tests can drive the network paths
     /// (e.g. `undoLastCompletion`) through a mocked `APIClient`.
-    init(taskService: TaskService = TaskService()) {
+    init(taskService: TaskService = TaskService(), projectService: ProjectService = ProjectService()) {
         self.taskService = taskService
+        self.projectService = projectService
     }
 
     private let taskService: TaskService
-    private let projectService = ProjectService()
+    private let projectService: ProjectService
     private let authService = AuthService.shared
     private let notificationService = NotificationService.shared
 
@@ -668,6 +677,152 @@ final class AppState {
     static func uniquedById(_ tasks: [VTask]) -> [VTask] {
         var seen = Set<Int64>()
         return tasks.filter { seen.insert($0.id).inserted }
+    }
+
+    // MARK: - Project Mutations
+
+    /// Creates a project and returns it on success (or `nil` on failure).
+    /// Empty description/colour are sent as `nil` so Vikunja stores them empty.
+    @MainActor
+    @discardableResult
+    func createProject(
+        title: String,
+        description: String? = nil,
+        hexColor: String? = nil,
+        isFavorite: Bool = false
+    ) async -> Project? {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let request = ProjectCreateRequest(
+            title: trimmed,
+            description: description.flatMap { $0.isEmpty ? nil : $0 },
+            hexColor: hexColor.flatMap { $0.isEmpty ? nil : $0 },
+            isFavorite: isFavorite
+        )
+        do {
+            let newProject = try await projectService.createProject(request)
+            projects.append(newProject)
+            syncService?.updateCachedProject(newProject)
+            #if os(iOS)
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            #endif
+            WidgetCenter.shared.reloadAllTimelines()
+            return newProject
+        } catch {
+            handleError(error)
+            return nil
+        }
+    }
+
+    /// Applies edits from the edit sheet. Sends the project's full field set so no
+    /// column is accidentally cleared server-side.
+    @MainActor
+    func updateProject(
+        _ project: Project,
+        title: String,
+        description: String,
+        hexColor: String,
+        isFavorite: Bool
+    ) async {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let request = ProjectUpdateRequest(
+            from: project,
+            title: trimmed,
+            description: description,
+            hexColor: hexColor,
+            isFavorite: isFavorite
+        )
+        await performProjectUpdate(id: project.id, request: request)
+    }
+
+    /// Archives a project (reversible). It leaves the active list and joins `archivedProjects`.
+    @MainActor
+    func archiveProject(_ project: Project) async {
+        guard project.id > 0 else { return }
+        await performProjectUpdate(id: project.id, request: ProjectUpdateRequest(from: project, isArchived: true))
+    }
+
+    /// Unarchives a project, returning it to the active list.
+    @MainActor
+    func unarchiveProject(_ project: Project) async {
+        guard project.id > 0 else { return }
+        await performProjectUpdate(id: project.id, request: ProjectUpdateRequest(from: project, isArchived: false))
+    }
+
+    /// Permanently deletes a project. Vikunja cascades this server-side to every task
+    /// and descendant project — it cannot be undone. Cleans up all local state that
+    /// referenced the project so no ghost rows or stale selection remain.
+    @MainActor
+    func deleteProject(_ project: Project) async {
+        guard project.id > 0 else { return } // never delete pseudo-projects (e.g. Favourites, id -1)
+        let projectId = project.id
+        do {
+            try await projectService.deleteProject(id: projectId)
+            projects.removeAll { $0.id == projectId }
+            archivedProjects.removeAll { $0.id == projectId }
+            tasks.removeAll { $0.projectId == projectId }
+            projectTaskCache[projectId] = nil
+            if selectedProject?.id == projectId { selectedProject = nil }
+            syncService?.deleteCachedProject(id: projectId)
+            #if os(iOS)
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+            #endif
+            WidgetCenter.shared.reloadAllTimelines()
+        } catch {
+            handleError(error)
+        }
+    }
+
+    /// Loads archived projects for the Archived view. Vikunja's include-archived fetch
+    /// returns active **and** archived projects, so we keep only the archived ones.
+    @MainActor
+    func fetchArchivedProjects() async {
+        do {
+            let all = try await projectService.fetchProjects(includeArchived: true)
+            archivedProjects = all.filter { $0.isArchived == true }
+        } catch {
+            handleError(error)
+        }
+    }
+
+    @MainActor
+    private func performProjectUpdate(id: Int64, request: ProjectUpdateRequest) async {
+        do {
+            var updated = try await projectService.updateProject(id: id, request: request)
+            // Trust our intended archived state for list placement, in case the
+            // server response omits `is_archived`.
+            updated.isArchived = request.isArchived
+            applyUpdatedProject(updated)
+            syncService?.updateCachedProject(updated)
+            WidgetCenter.shared.reloadAllTimelines()
+        } catch {
+            handleError(error)
+        }
+    }
+
+    /// Routes an updated project into `projects` or `archivedProjects` based on its
+    /// archived state, removing it from the other list. Edits to an active project keep
+    /// their position (in-place replace); unarchived projects append until next refresh.
+    @MainActor
+    private func applyUpdatedProject(_ project: Project) {
+        if project.isArchived ?? false {
+            projects.removeAll { $0.id == project.id }
+            if let idx = archivedProjects.firstIndex(where: { $0.id == project.id }) {
+                archivedProjects[idx] = project
+            } else {
+                archivedProjects.append(project)
+            }
+            if selectedProject?.id == project.id { selectedProject = nil }
+        } else {
+            archivedProjects.removeAll { $0.id == project.id }
+            if let idx = projects.firstIndex(where: { $0.id == project.id }) {
+                projects[idx] = project
+            } else {
+                projects.append(project)
+            }
+            if selectedProject?.id == project.id { selectedProject = project }
+        }
     }
 
     // MARK: - Calendar Events

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -755,16 +755,24 @@ final class AppState {
     /// referenced the project so no ghost rows or stale selection remain.
     @MainActor
     func deleteProject(_ project: Project) async {
-        guard project.id > 0 else { return } // never delete pseudo-projects (e.g. Favourites, id -1)
+        guard project.id > 0 else { return } // never delete pseudo-projects (e.g. Favorites, id -1)
         let projectId = project.id
         do {
             try await projectService.deleteProject(id: projectId)
-            projects.removeAll { $0.id == projectId }
-            archivedProjects.removeAll { $0.id == projectId }
-            tasks.removeAll { $0.projectId == projectId }
-            projectTaskCache[projectId] = nil
-            if selectedProject?.id == projectId { selectedProject = nil }
-            syncService?.deleteCachedProject(id: projectId)
+            // Vikunja cascades the delete to descendant sub-projects and all their
+            // tasks; mirror that locally so no orphaned rows linger until the next
+            // full refresh.
+            let removedIds = descendantProjectIds(of: projectId)
+            projects.removeAll { removedIds.contains($0.id) }
+            archivedProjects.removeAll { removedIds.contains($0.id) }
+            tasks.removeAll { removedIds.contains($0.projectId) }
+            for id in removedIds {
+                projectTaskCache[id] = nil
+                syncService?.deleteCachedProject(id: id)
+            }
+            if let selectedId = selectedProject?.id, removedIds.contains(selectedId) {
+                selectedProject = nil
+            }
             #if os(iOS)
             UINotificationFeedbackGenerator().notificationOccurred(.warning)
             #endif
@@ -772,6 +780,22 @@ final class AppState {
         } catch {
             handleError(error)
         }
+    }
+
+    /// Returns `root` plus the IDs of every known descendant project (transitive
+    /// closure over `parentProjectId`), matching Vikunja's recursive delete cascade.
+    private func descendantProjectIds(of root: Int64) -> Set<Int64> {
+        var ids: Set<Int64> = [root]
+        let all = projects + archivedProjects
+        var changed = true
+        while changed {
+            changed = false
+            for project in all where project.parentProjectId.map({ ids.contains($0) }) == true && !ids.contains(project.id) {
+                ids.insert(project.id)
+                changed = true
+            }
+        }
+        return ids
     }
 
     /// Loads archived projects for the Archived view. Vikunja's include-archived fetch

--- a/mDone/Models/Project.swift
+++ b/mDone/Models/Project.swift
@@ -39,3 +39,53 @@ struct ProjectView: Codable, Identifiable {
     var defaultBucketId: Int64?
     var doneBucketId: Int64?
 }
+
+/// Request body for creating a project (`PUT /api/v1/projects`).
+/// `title` is required by Vikunja (1–250 chars); other fields are optional.
+/// Snake-casing (`hexColor` → `hex_color`) is applied by `APIClient`'s encoder.
+struct ProjectCreateRequest: Encodable {
+    var title: String
+    var description: String?
+    var hexColor: String?
+    var isFavorite: Bool?
+}
+
+/// Request body for updating a project (`POST /api/v1/projects/{id}`).
+///
+/// We always send the project's *full* field set (not a partial patch): Vikunja's
+/// update can reset omitted columns and may skip zero-value booleans, so sending
+/// every field is what makes archive (`isArchived = true`) and especially
+/// unarchive (`isArchived = false`) reliable. Build these from an existing
+/// `Project` via the `init(from:)` convenience initializer.
+struct ProjectUpdateRequest: Encodable {
+    var title: String
+    var description: String
+    var hexColor: String
+    var isFavorite: Bool
+    var isArchived: Bool
+
+    init(title: String, description: String, hexColor: String, isFavorite: Bool, isArchived: Bool) {
+        self.title = title
+        self.description = description
+        self.hexColor = hexColor
+        self.isFavorite = isFavorite
+        self.isArchived = isArchived
+    }
+
+    /// Builds a full update request from an existing project, overriding only the
+    /// fields you pass. Ensures we never accidentally blank out a field on the server.
+    init(
+        from project: Project,
+        title: String? = nil,
+        description: String? = nil,
+        hexColor: String? = nil,
+        isFavorite: Bool? = nil,
+        isArchived: Bool? = nil
+    ) {
+        self.title = title ?? project.title
+        self.description = description ?? project.description ?? ""
+        self.hexColor = hexColor ?? project.hexColor ?? ""
+        self.isFavorite = isFavorite ?? project.isFavorite ?? false
+        self.isArchived = isArchived ?? project.isArchived ?? false
+    }
+}

--- a/mDone/Services/Endpoint.swift
+++ b/mDone/Services/Endpoint.swift
@@ -30,11 +30,17 @@ struct Endpoint {
 
     // MARK: - Projects
 
-    static func projects(page: Int = 1, perPage: Int = 50) -> Endpoint {
-        Endpoint(path: "/api/v1/projects", queryItems: [
+    /// Lists projects. Vikunja excludes archived projects unless `is_archived=true`
+    /// is passed, in which case it returns active **and** archived projects.
+    static func projects(page: Int = 1, perPage: Int = 50, includeArchived: Bool = false) -> Endpoint {
+        var items = [
             URLQueryItem(name: "page", value: "\(page)"),
             URLQueryItem(name: "per_page", value: "\(perPage)"),
-        ])
+        ]
+        if includeArchived {
+            items.append(URLQueryItem(name: "is_archived", value: "true"))
+        }
+        return Endpoint(path: "/api/v1/projects", queryItems: items)
     }
 
     static func project(id: Int64) -> Endpoint {
@@ -43,6 +49,21 @@ struct Endpoint {
 
     static func projectViews(projectId: Int64) -> Endpoint {
         Endpoint(path: "/api/v1/projects/\(projectId)/views")
+    }
+
+    /// Creates a project. Vikunja uses PUT (not POST) for creation.
+    static func createProject() -> Endpoint {
+        Endpoint(path: "/api/v1/projects", method: .PUT)
+    }
+
+    /// Updates a project (title, description, colour, favourite, archived).
+    static func updateProject(id: Int64) -> Endpoint {
+        Endpoint(path: "/api/v1/projects/\(id)", method: .POST)
+    }
+
+    /// Deletes a project. Vikunja cascades this to all tasks and descendant projects.
+    static func deleteProject(id: Int64) -> Endpoint {
+        Endpoint(path: "/api/v1/projects/\(id)", method: .DELETE)
     }
 
     // MARK: - Tasks

--- a/mDone/Services/ProjectService.swift
+++ b/mDone/Services/ProjectService.swift
@@ -7,8 +7,8 @@ actor ProjectService {
         self.apiClient = apiClient
     }
 
-    func fetchProjects(page: Int = 1) async throws -> [Project] {
-        try await apiClient.fetch(Endpoint.projects(page: page))
+    func fetchProjects(page: Int = 1, includeArchived: Bool = false) async throws -> [Project] {
+        try await apiClient.fetch(Endpoint.projects(page: page, includeArchived: includeArchived))
     }
 
     func fetchProject(id: Int64) async throws -> Project {
@@ -17,5 +17,17 @@ actor ProjectService {
 
     func fetchProjectViews(projectId: Int64) async throws -> [ProjectView] {
         try await apiClient.fetch(Endpoint.projectViews(projectId: projectId))
+    }
+
+    func createProject(_ request: ProjectCreateRequest) async throws -> Project {
+        try await apiClient.send(Endpoint.createProject(), body: request)
+    }
+
+    func updateProject(id: Int64, request: ProjectUpdateRequest) async throws -> Project {
+        try await apiClient.send(Endpoint.updateProject(id: id), body: request)
+    }
+
+    func deleteProject(id: Int64) async throws {
+        try await apiClient.delete(Endpoint.deleteProject(id: id))
     }
 }

--- a/mDone/Services/SyncService.swift
+++ b/mDone/Services/SyncService.swift
@@ -208,4 +208,31 @@ actor SyncService {
             try? context.save()
         }
     }
+
+    @MainActor
+    func updateCachedProject(_ project: Project) {
+        let context = modelContainer.mainContext
+        let projectId = project.id
+        let descriptor = FetchDescriptor<CachedProject>(
+            predicate: #Predicate { $0.id == projectId }
+        )
+        if let cached = try? context.fetch(descriptor).first {
+            cached.update(from: project)
+        } else {
+            context.insert(CachedProject(from: project))
+        }
+        try? context.save()
+    }
+
+    @MainActor
+    func deleteCachedProject(id: Int64) {
+        let context = modelContainer.mainContext
+        let descriptor = FetchDescriptor<CachedProject>(
+            predicate: #Predicate { $0.id == id }
+        )
+        if let cached = try? context.fetch(descriptor).first {
+            context.delete(cached)
+            try? context.save()
+        }
+    }
 }

--- a/mDone/Views/Components/ColorSwatchPicker.swift
+++ b/mDone/Views/Components/ColorSwatchPicker.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Horizontal preset colour picker for projects. Binds to a hex string where an
+/// empty string means "no colour". Presets are stored as `#RRGGBB`, the format
+/// Vikunja round-trips (max length 7).
+struct ColorSwatchPicker: View {
+    @Binding var selectedHex: String
+
+    /// Preset palette. Kept to a curated set for consistency with the Vikunja web UI.
+    static let palette: [String] = [
+        "#4772FA", "#34C759", "#FF8C00", "#FF4444",
+        "#9B59B6", "#00C2C7", "#FF6BAA", "#5856D6",
+        "#F4B400", "#30D158", "#A0522D", "#8E8E93",
+    ]
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 12) {
+                swatch(hex: "", isNone: true)
+                ForEach(Self.palette, id: \.self) { hex in
+                    swatch(hex: hex, isNone: false)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private func swatch(hex: String, isNone: Bool) -> some View {
+        let selected = normalized(selectedHex) == normalized(hex)
+        return Button {
+            selectedHex = hex
+        } label: {
+            ZStack {
+                Circle()
+                    .fill(isNone ? Color.gray.opacity(0.15) : Color(hex: hex))
+                    .frame(width: 30, height: 30)
+                if isNone {
+                    Image(systemName: "slash.circle")
+                        .font(.system(size: 16))
+                        .foregroundStyle(.secondary)
+                }
+                if selected {
+                    Circle()
+                        .strokeBorder(Color.primary, lineWidth: 2)
+                        .frame(width: 36, height: 36)
+                }
+            }
+            .frame(width: 40, height: 40)
+            .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isNone ? "No colour" : "Colour \(hex)")
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+
+    /// Compares hex strings ignoring a leading `#` and case.
+    private func normalized(_ hex: String) -> String {
+        hex.trimmingCharacters(in: CharacterSet(charactersIn: "#")).uppercased()
+    }
+}

--- a/mDone/Views/Components/ColorSwatchPicker.swift
+++ b/mDone/Views/Components/ColorSwatchPicker.swift
@@ -49,7 +49,7 @@ struct ColorSwatchPicker: View {
             .contentShape(Circle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(isNone ? "No colour" : "Colour \(hex)")
+        .accessibilityLabel(isNone ? "No color" : "Color \(hex)")
         .accessibilityAddTraits(selected ? .isSelected : [])
     }
 

--- a/mDone/Views/Mac/MacArchivedProjectsView.swift
+++ b/mDone/Views/Mac/MacArchivedProjectsView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// Content-column view listing archived projects on macOS, with Unarchive / Delete
+/// actions. Shown when the "Archived" sidebar item is selected.
+struct MacArchivedProjectsView: View {
+    @Environment(AppState.self) private var appState
+    @State private var projectPendingDelete: Project?
+
+    var body: some View {
+        Group {
+            if appState.archivedProjects.isEmpty {
+                ContentUnavailableView(
+                    "No Archived Projects",
+                    systemImage: "archivebox",
+                    description: Text("Projects you archive will appear here")
+                )
+            } else {
+                List {
+                    ForEach(appState.archivedProjects) { project in
+                        HStack(spacing: 10) {
+                            Circle()
+                                .fill(projectColor(project))
+                                .frame(width: 10, height: 10)
+                            Text(project.title)
+                            Spacer()
+                            Button("Unarchive") {
+                                Task { await appState.unarchiveProject(project) }
+                            }
+                            .buttonStyle(.borderless)
+                        }
+                        .padding(.vertical, 2)
+                        .contextMenu {
+                            Button {
+                                Task { await appState.unarchiveProject(project) }
+                            } label: {
+                                Label("Unarchive", systemImage: "arrow.uturn.up")
+                            }
+                            Divider()
+                            Button(role: .destructive) {
+                                projectPendingDelete = project
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button(role: .destructive) {
+                                projectPendingDelete = project
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Archived")
+        .task {
+            await appState.fetchArchivedProjects()
+        }
+        .confirmationDialog(
+            "Delete \(projectPendingDelete?.title ?? "")?",
+            isPresented: Binding(
+                get: { projectPendingDelete != nil },
+                set: { if !$0 { projectPendingDelete = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: projectPendingDelete
+        ) { project in
+            Button("Delete Project", role: .destructive) {
+                Task { await appState.deleteProject(project) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { _ in
+            Text(
+                "This permanently deletes the project and all of its tasks, including any sub-projects. This can't be undone."
+            )
+        }
+    }
+
+    private func projectColor(_ project: Project) -> Color {
+        guard let hex = project.hexColor, !hex.isEmpty else { return Color.accentColor }
+        return Color(hex: hex)
+    }
+}

--- a/mDone/Views/Mac/MacContentView.swift
+++ b/mDone/Views/Mac/MacContentView.swift
@@ -8,6 +8,7 @@ struct MacContentView: View {
     enum SidebarSection: Hashable {
         case inbox, today, tomorrow, thisWeek, upcoming, overdue, noDate
         case project(Project)
+        case archived
         case notifications, calendar, settings
     }
 
@@ -17,7 +18,7 @@ struct MacContentView: View {
         switch selectedSection {
         case .inbox, .today, .tomorrow, .thisWeek, .upcoming, .overdue, .noDate, .project:
             return true
-        case .notifications, .calendar, .settings:
+        case .archived, .notifications, .calendar, .settings:
             return false
         }
     }
@@ -26,7 +27,11 @@ struct MacContentView: View {
         NavigationSplitView {
             MacSidebarView(selection: $selectedSection)
         } content: {
-            MacTaskListView(section: selectedSection, selectedTask: $selectedTask)
+            if selectedSection == .archived {
+                MacArchivedProjectsView()
+            } else {
+                MacTaskListView(section: selectedSection, selectedTask: $selectedTask)
+            }
         } detail: {
             if sectionShowsTaskList, let task = selectedTask {
                 MacTaskDetailView(task: task)
@@ -46,7 +51,7 @@ struct MacContentView: View {
             // Clear task selection when switching to a non-task-list section
             if let newSection {
                 switch newSection {
-                case .notifications, .calendar, .settings:
+                case .archived, .notifications, .calendar, .settings:
                     selectedTask = nil
                 default:
                     break

--- a/mDone/Views/Mac/MacSidebarView.swift
+++ b/mDone/Views/Mac/MacSidebarView.swift
@@ -259,7 +259,7 @@ struct MacSidebarView: View {
             }
         } label: {
             Label(
-                project.isFavorite == true ? "Remove from Favourites" : "Add to Favourites",
+                project.isFavorite == true ? "Remove from Favorites" : "Add to Favorites",
                 systemImage: project.isFavorite == true ? "star.slash" : "star"
             )
         }

--- a/mDone/Views/Mac/MacSidebarView.swift
+++ b/mDone/Views/Mac/MacSidebarView.swift
@@ -4,6 +4,10 @@ struct MacSidebarView: View {
     @Environment(AppState.self) private var appState
     @Binding var selection: MacContentView.SidebarSection?
 
+    @State private var showingCreate = false
+    @State private var editingProject: Project?
+    @State private var projectPendingDelete: Project?
+
     var body: some View {
         List(selection: $selection) {
             Section("Smart Lists") {
@@ -119,7 +123,7 @@ struct MacSidebarView: View {
                 .tag(MacContentView.SidebarSection.noDate)
             }
 
-            Section("Projects") {
+            Section {
                 ForEach(appState.projects) { project in
                     Label {
                         HStack {
@@ -139,6 +143,21 @@ struct MacSidebarView: View {
                             .accessibilityHidden(true)
                     }
                     .tag(MacContentView.SidebarSection.project(project))
+                    .contextMenu { projectContextMenu(project) }
+                }
+            } header: {
+                HStack {
+                    Text("Projects")
+                    Spacer()
+                    Button {
+                        showingCreate = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                    .buttonStyle(.plain)
+                    .help("New Project")
+                    .keyboardShortcut("n", modifiers: [.command, .shift])
+                    .accessibilityLabel("New Project")
                 }
             }
 
@@ -180,6 +199,9 @@ struct MacSidebarView: View {
                 }
                 .tag(MacContentView.SidebarSection.calendar)
 
+                Label("Archived", systemImage: "archivebox")
+                    .tag(MacContentView.SidebarSection.archived)
+
                 Label("Settings", systemImage: "gear")
                     .tag(MacContentView.SidebarSection.settings)
             }
@@ -187,6 +209,71 @@ struct MacSidebarView: View {
         .listStyle(.sidebar)
         .navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 300)
         .navigationTitle("mDone")
+        .sheet(isPresented: $showingCreate) {
+            ProjectEditSheet()
+        }
+        .sheet(item: $editingProject) { project in
+            ProjectEditSheet(project: project)
+        }
+        .confirmationDialog(
+            "Delete \(projectPendingDelete?.title ?? "")?",
+            isPresented: Binding(
+                get: { projectPendingDelete != nil },
+                set: { if !$0 { projectPendingDelete = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: projectPendingDelete
+        ) { project in
+            Button("Delete Project", role: .destructive) {
+                Task { await appState.deleteProject(project) }
+            }
+            Button("Archive Instead") {
+                Task { await appState.archiveProject(project) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { project in
+            let count = appState.tasksForProject(project.id).count
+            Text(
+                "This permanently deletes the project and all \(count) task\(count == 1 ? "" : "s") in it, "
+                    + "including any sub-projects. This can't be undone."
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func projectContextMenu(_ project: Project) -> some View {
+        Button {
+            editingProject = project
+        } label: {
+            Label("Edit…", systemImage: "pencil")
+        }
+        Button {
+            Task {
+                await appState.updateProject(
+                    project,
+                    title: project.title,
+                    description: project.description ?? "",
+                    hexColor: project.hexColor ?? "",
+                    isFavorite: !(project.isFavorite ?? false)
+                )
+            }
+        } label: {
+            Label(
+                project.isFavorite == true ? "Remove from Favourites" : "Add to Favourites",
+                systemImage: project.isFavorite == true ? "star.slash" : "star"
+            )
+        }
+        Button {
+            Task { await appState.archiveProject(project) }
+        } label: {
+            Label("Archive", systemImage: "archivebox")
+        }
+        Divider()
+        Button(role: .destructive) {
+            projectPendingDelete = project
+        } label: {
+            Label("Delete", systemImage: "trash")
+        }
     }
 
     private func projectColor(_ project: Project) -> Color {

--- a/mDone/Views/Mac/MacTaskListView.swift
+++ b/mDone/Views/Mac/MacTaskListView.swift
@@ -166,6 +166,7 @@ struct MacTaskListView: View {
         case .overdue: return "Overdue"
         case .noDate: return "No Date"
         case let .project(project): return project.title
+        case .archived: return "Archived"
         case .notifications: return "Notifications"
         case .calendar: return "Calendar"
         case .settings: return "Settings"
@@ -183,7 +184,7 @@ struct MacTaskListView: View {
         case .overdue: return appState.overdueTasks
         case .noDate: return appState.noDateTasks
         case let .project(project): return appState.tasksForProject(project.id)
-        case .notifications, .calendar, .settings: return []
+        case .archived, .notifications, .calendar, .settings: return []
         }
     }
 
@@ -229,14 +230,13 @@ struct MacTaskListView: View {
         }
 
         tasks.sort { a, b in
-            let result: Bool
-            switch sortOrder {
+            let result: Bool = switch sortOrder {
             case .dueDate:
-                result = (a.effectiveDueDate ?? .distantFuture) < (b.effectiveDueDate ?? .distantFuture)
+                (a.effectiveDueDate ?? .distantFuture) < (b.effectiveDueDate ?? .distantFuture)
             case .priority:
-                result = a.priority > b.priority
+                a.priority > b.priority
             case .title:
-                result = a.title.localizedCompare(b.title) == .orderedAscending
+                a.title.localizedCompare(b.title) == .orderedAscending
             }
             return sortAscending ? result : !result
         }
@@ -256,7 +256,7 @@ struct MacTaskListView: View {
         case .inbox: return "tray"
         case .project: return "folder"
         case .notifications: return "bell"
-        case .calendar, .settings: return "tray"
+        case .archived, .calendar, .settings: return "tray"
         }
     }
 
@@ -272,7 +272,7 @@ struct MacTaskListView: View {
         case .inbox: return "No Active Tasks"
         case .project: return "No Tasks in Project"
         case .notifications: return "No Notifications"
-        case .calendar, .settings: return "No Tasks"
+        case .archived, .calendar, .settings: return "No Tasks"
         }
     }
 
@@ -288,7 +288,7 @@ struct MacTaskListView: View {
         case .inbox: return "Create a task to get started."
         case .project: return "Add a task to this project."
         case .notifications: return "You're all caught up!"
-        case .calendar, .settings: return ""
+        case .archived, .calendar, .settings: return ""
         }
     }
 }

--- a/mDone/Views/Projects/ArchivedProjectsScreen.swift
+++ b/mDone/Views/Projects/ArchivedProjectsScreen.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// Lists archived projects with Unarchive / Delete actions. Read-only: tapping a
+/// project opens its task list without the quick-add bar.
+struct ArchivedProjectsScreen: View {
+    @Environment(AppState.self) private var appState
+    @State private var projectPendingDelete: Project?
+
+    var body: some View {
+        List {
+            if appState.archivedProjects.isEmpty {
+                Section {
+                    EmptyStateView(
+                        icon: "archivebox",
+                        title: "No archived projects",
+                        subtitle: "Projects you archive will appear here"
+                    )
+                }
+            } else {
+                ForEach(appState.archivedProjects) { project in
+                    NavigationLink {
+                        TaskListScreen(projectFilter: project, readOnly: true)
+                    } label: {
+                        ProjectRow(project: project, taskCount: appState.tasksForProject(project.id).count)
+                    }
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button(role: .destructive) {
+                            projectPendingDelete = project
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        Button {
+                            Task { await appState.unarchiveProject(project) }
+                        } label: {
+                            Label("Unarchive", systemImage: "arrow.uturn.up")
+                        }
+                        .tint(.green)
+                    }
+                    .contextMenu {
+                        Button {
+                            Task { await appState.unarchiveProject(project) }
+                        } label: {
+                            Label("Unarchive", systemImage: "arrow.uturn.up")
+                        }
+                        Divider()
+                        Button(role: .destructive) {
+                            projectPendingDelete = project
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+                }
+            }
+        }
+        #if os(iOS)
+        .listStyle(.insetGrouped)
+        #endif
+        .navigationTitle("Archived")
+        #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+        #endif
+            .task {
+                await appState.fetchArchivedProjects()
+            }
+            .refreshable {
+                await appState.fetchArchivedProjects()
+            }
+            .confirmationDialog(
+                "Delete \(projectPendingDelete?.title ?? "")?",
+                isPresented: Binding(
+                    get: { projectPendingDelete != nil },
+                    set: { if !$0 { projectPendingDelete = nil } }
+                ),
+                titleVisibility: .visible,
+                presenting: projectPendingDelete
+            ) { project in
+                Button("Delete Project", role: .destructive) {
+                    Task { await appState.deleteProject(project) }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: { _ in
+                Text(
+                    "This permanently deletes the project and all of its tasks, including any sub-projects. This can't be undone."
+                )
+            }
+    }
+}

--- a/mDone/Views/Projects/ProjectEditSheet.swift
+++ b/mDone/Views/Projects/ProjectEditSheet.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+/// Create or edit a project. Pass `project: nil` to create a new project, or an
+/// existing project to edit it. Shared by iOS and macOS.
+struct ProjectEditSheet: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+
+    /// The project being edited, or `nil` when creating a new one.
+    let project: Project?
+
+    @State private var title: String
+    @State private var description: String
+    @State private var colorHex: String
+    @State private var isFavorite: Bool
+    @State private var isSaving = false
+    @FocusState private var titleFocused: Bool
+
+    init(project: Project? = nil) {
+        self.project = project
+        _title = State(initialValue: project?.title ?? "")
+        _description = State(initialValue: project?.description ?? "")
+        _colorHex = State(initialValue: project?.hexColor ?? "")
+        _isFavorite = State(initialValue: project?.isFavorite ?? false)
+    }
+
+    private var isEditing: Bool {
+        project != nil
+    }
+
+    private var canSave: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSaving
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Title") {
+                    TextField("Project name", text: $title)
+                        .focused($titleFocused)
+                }
+
+                Section("Description") {
+                    TextField("Optional", text: $description, axis: .vertical)
+                        .lineLimit(2 ... 5)
+                }
+
+                Section("Colour") {
+                    ColorSwatchPicker(selectedHex: $colorHex)
+                }
+
+                Section {
+                    Toggle(isOn: $isFavorite) {
+                        Label("Add to Favourites", systemImage: "star")
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle(isEditing ? "Edit Project" : "New Project")
+            #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+            #endif
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") { save() }
+                            .disabled(!canSave)
+                    }
+                }
+                .onAppear {
+                    if !isEditing { titleFocused = true }
+                }
+        }
+        #if os(macOS)
+        .frame(minWidth: 420, minHeight: 460)
+        #endif
+    }
+
+    private func save() {
+        isSaving = true
+        Task {
+            if let project {
+                await appState.updateProject(
+                    project,
+                    title: title,
+                    description: description,
+                    hexColor: colorHex,
+                    isFavorite: isFavorite
+                )
+            } else {
+                await appState.createProject(
+                    title: title,
+                    description: description,
+                    hexColor: colorHex,
+                    isFavorite: isFavorite
+                )
+            }
+            dismiss()
+        }
+    }
+}

--- a/mDone/Views/Projects/ProjectEditSheet.swift
+++ b/mDone/Views/Projects/ProjectEditSheet.swift
@@ -45,13 +45,13 @@ struct ProjectEditSheet: View {
                         .lineLimit(2 ... 5)
                 }
 
-                Section("Colour") {
+                Section("Color") {
                     ColorSwatchPicker(selectedHex: $colorHex)
                 }
 
                 Section {
                     Toggle(isOn: $isFavorite) {
-                        Label("Add to Favourites", systemImage: "star")
+                        Label("Add to Favorites", systemImage: "star")
                     }
                 }
             }

--- a/mDone/Views/Projects/ProjectListScreen.swift
+++ b/mDone/Views/Projects/ProjectListScreen.swift
@@ -3,15 +3,17 @@ import SwiftUI
 struct ProjectListScreen: View {
     @Environment(AppState.self) private var appState
 
+    @State private var showingCreate = false
+    @State private var editingProject: Project?
+    @State private var projectPendingDelete: Project?
+
     var body: some View {
         List {
             let favorites = appState.projects.filter { $0.isFavorite == true }
             if !favorites.isEmpty {
                 Section("Favorites") {
                     ForEach(favorites) { project in
-                        NavigationLink(value: project) {
-                            ProjectRow(project: project, taskCount: appState.tasksForProject(project.id).count)
-                        }
+                        projectRow(project)
                     }
                 }
             }
@@ -19,19 +21,36 @@ struct ProjectListScreen: View {
             let regular = appState.projects.filter { $0.isFavorite != true }
             Section("Projects") {
                 ForEach(regular) { project in
-                    NavigationLink(value: project) {
-                        ProjectRow(project: project, taskCount: appState.tasksForProject(project.id).count)
+                    projectRow(project)
+                }
+            }
+
+            if !appState.archivedProjects.isEmpty {
+                Section {
+                    NavigationLink {
+                        ArchivedProjectsScreen()
+                    } label: {
+                        Label("Archived", systemImage: "archivebox")
                     }
                 }
             }
 
             if appState.projects.isEmpty, !appState.isLoading {
                 Section {
-                    EmptyStateView(
-                        icon: "folder",
-                        title: "No projects",
-                        subtitle: "Create projects in your Vikunja instance"
-                    )
+                    VStack(spacing: 16) {
+                        EmptyStateView(
+                            icon: "folder",
+                            title: "No projects",
+                            subtitle: "Create your first project to organise your tasks"
+                        )
+                        Button {
+                            showingCreate = true
+                        } label: {
+                            Label("New Project", systemImage: "plus")
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    .frame(maxWidth: .infinity)
                 }
             }
         }
@@ -39,11 +58,115 @@ struct ProjectListScreen: View {
         .listStyle(.insetGrouped)
         #endif
         .navigationTitle("Projects")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showingCreate = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .accessibilityLabel("New Project")
+            }
+        }
         .navigationDestination(for: Project.self) { project in
             TaskListScreen(projectFilter: project)
         }
+        .sheet(isPresented: $showingCreate) {
+            ProjectEditSheet()
+        }
+        .sheet(item: $editingProject) { project in
+            ProjectEditSheet(project: project)
+        }
+        .confirmationDialog(
+            "Delete \(projectPendingDelete?.title ?? "")?",
+            isPresented: Binding(
+                get: { projectPendingDelete != nil },
+                set: { if !$0 { projectPendingDelete = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: projectPendingDelete
+        ) { project in
+            Button("Delete Project", role: .destructive) {
+                Task { await appState.deleteProject(project) }
+            }
+            Button("Archive Instead") {
+                Task { await appState.archiveProject(project) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { project in
+            let count = appState.tasksForProject(project.id).count
+            Text(
+                "This permanently deletes the project and all \(count) task\(count == 1 ? "" : "s") in it, "
+                    + "including any sub-projects. This can't be undone."
+            )
+        }
         .refreshable {
             await appState.refreshAll()
+        }
+    }
+
+    private func projectRow(_ project: Project) -> some View {
+        NavigationLink(value: project) {
+            ProjectRow(project: project, taskCount: appState.tasksForProject(project.id).count)
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) {
+                projectPendingDelete = project
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+            Button {
+                editingProject = project
+            } label: {
+                Label("Edit", systemImage: "pencil")
+            }
+            .tint(.blue)
+        }
+        .swipeActions(edge: .leading) {
+            Button {
+                Task { await appState.archiveProject(project) }
+            } label: {
+                Label("Archive", systemImage: "archivebox")
+            }
+            .tint(.orange)
+        }
+        .contextMenu {
+            Button {
+                editingProject = project
+            } label: {
+                Label("Edit…", systemImage: "pencil")
+            }
+            Button {
+                toggleFavorite(project)
+            } label: {
+                Label(
+                    project.isFavorite == true ? "Remove from Favourites" : "Add to Favourites",
+                    systemImage: project.isFavorite == true ? "star.slash" : "star"
+                )
+            }
+            Button {
+                Task { await appState.archiveProject(project) }
+            } label: {
+                Label("Archive", systemImage: "archivebox")
+            }
+            Divider()
+            Button(role: .destructive) {
+                projectPendingDelete = project
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+
+    private func toggleFavorite(_ project: Project) {
+        Task {
+            await appState.updateProject(
+                project,
+                title: project.title,
+                description: project.description ?? "",
+                hexColor: project.hexColor ?? "",
+                isFavorite: !(project.isFavorite ?? false)
+            )
         }
     }
 }

--- a/mDone/Views/Projects/ProjectListScreen.swift
+++ b/mDone/Views/Projects/ProjectListScreen.swift
@@ -25,13 +25,11 @@ struct ProjectListScreen: View {
                 }
             }
 
-            if !appState.archivedProjects.isEmpty {
-                Section {
-                    NavigationLink {
-                        ArchivedProjectsScreen()
-                    } label: {
-                        Label("Archived", systemImage: "archivebox")
-                    }
+            Section {
+                NavigationLink {
+                    ArchivedProjectsScreen()
+                } label: {
+                    Label("Archived", systemImage: "archivebox")
                 }
             }
 
@@ -41,7 +39,7 @@ struct ProjectListScreen: View {
                         EmptyStateView(
                             icon: "folder",
                             title: "No projects",
-                            subtitle: "Create your first project to organise your tasks"
+                            subtitle: "Create your first project to organize your tasks"
                         )
                         Button {
                             showingCreate = true
@@ -140,7 +138,7 @@ struct ProjectListScreen: View {
                 toggleFavorite(project)
             } label: {
                 Label(
-                    project.isFavorite == true ? "Remove from Favourites" : "Add to Favourites",
+                    project.isFavorite == true ? "Remove from Favorites" : "Add to Favorites",
                     systemImage: project.isFavorite == true ? "star.slash" : "star"
                 )
             }

--- a/mDone/Views/Tasks/TaskListScreen.swift
+++ b/mDone/Views/Tasks/TaskListScreen.swift
@@ -7,6 +7,8 @@ struct TaskListScreen: View {
     @Environment(FocusManager.self) private var focusManager
     #endif
     var projectFilter: Project?
+    /// When true, hides the quick-add bar — used for archived (read-only) projects.
+    var readOnly: Bool = false
     @State private var showAdvancedFilter = false
     @State private var sortOrder: SortOrder = .dueDate
     @State private var sortAscending: Bool = true
@@ -74,10 +76,12 @@ struct TaskListScreen: View {
                 }
             }
 
-            QuickAddBar(
-                projectId: projectFilter?.id ?? defaultProjectId,
-                defaultDueDate: projectFilter == nil ? DefaultDueTimePreference.apply(to: Date()) : nil
-            )
+            if !readOnly {
+                QuickAddBar(
+                    projectId: projectFilter?.id ?? defaultProjectId,
+                    defaultDueDate: projectFilter == nil ? DefaultDueTimePreference.apply(to: Date()) : nil
+                )
+            }
         }
         .task(id: projectFilter?.id) {
             if let projectFilter {
@@ -265,14 +269,13 @@ struct TaskListScreen: View {
 
     private func sorted(_ tasks: [VTask]) -> [VTask] {
         tasks.sorted { a, b in
-            let result: Bool
-            switch sortOrder {
+            let result: Bool = switch sortOrder {
             case .dueDate:
-                result = (a.effectiveDueDate ?? .distantFuture) < (b.effectiveDueDate ?? .distantFuture)
+                (a.effectiveDueDate ?? .distantFuture) < (b.effectiveDueDate ?? .distantFuture)
             case .priority:
-                result = a.priority > b.priority
+                a.priority > b.priority
             case .title:
-                result = a.title.localizedCompare(b.title) == .orderedAscending
+                a.title.localizedCompare(b.title) == .orderedAscending
             }
             return sortAscending ? result : !result
         }

--- a/mDone/Views/Tasks/TaskListScreen.swift
+++ b/mDone/Views/Tasks/TaskListScreen.swift
@@ -52,11 +52,17 @@ struct TaskListScreen: View {
                             }
                         } else {
                             Section {
-                                ForEach(projectTasks) { task in
-                                    TaskRow(task: task)
-                                }
-                                .onMove { source, destination in
-                                    handleMove(tasks: projectTasks, from: source, to: destination)
+                                if readOnly {
+                                    ForEach(projectTasks) { task in
+                                        TaskRow(task: task, readOnly: true)
+                                    }
+                                } else {
+                                    ForEach(projectTasks) { task in
+                                        TaskRow(task: task)
+                                    }
+                                    .onMove { source, destination in
+                                        handleMove(tasks: projectTasks, from: source, to: destination)
+                                    }
                                 }
                             }
                         }

--- a/mDone/Views/Tasks/TaskRow.swift
+++ b/mDone/Views/Tasks/TaskRow.swift
@@ -6,6 +6,9 @@ struct TaskRow: View {
     @Environment(FocusManager.self) private var focusManager
     #endif
     let task: VTask
+    /// When true, the row is display-only: no completion toggle, swipe actions,
+    /// context menu, or tap-to-edit. Used for archived (read-only) projects.
+    var readOnly: Bool = false
     @State private var showDetail = false
 
     #if os(iOS)
@@ -18,61 +21,67 @@ struct TaskRow: View {
         rowContent
         #if os(iOS)
         .contentShape(Rectangle())
-        .onTapGesture { showDetail = true }
+        .onTapGesture { if !readOnly { showDetail = true } }
         .listRowBackground(isFocused ? Color.orange.opacity(0.08) : nil)
         #endif
         .swipeActions(edge: .leading) {
-            #if os(iOS)
-            if !task.done {
+            if !readOnly {
+                #if os(iOS)
+                if !task.done {
+                    Button {
+                        Task { await appState.postponeTask(task, byHours: 24) }
+                    } label: {
+                        Label("+24h", systemImage: "clock.arrow.circlepath")
+                    }
+                    .tint(.blue)
+                }
+
                 Button {
-                    Task { await appState.postponeTask(task, byHours: 24) }
+                    if isFocused {
+                        focusManager.endFocus()
+                    } else {
+                        let projectName = appState.projects.first(where: { $0.id == task.projectId })?.title ?? "Inbox"
+                        focusManager.switchFocus(task: task, projectName: projectName)
+                    }
                 } label: {
-                    Label("+24h", systemImage: "clock.arrow.circlepath")
+                    Label(isFocused ? "End Focus" : "Focus", systemImage: "scope")
                 }
-                .tint(.blue)
-            }
+                .tint(.orange)
+                #endif
 
-            Button {
-                if isFocused {
-                    focusManager.endFocus()
-                } else {
-                    let projectName = appState.projects.first(where: { $0.id == task.projectId })?.title ?? "Inbox"
-                    focusManager.switchFocus(task: task, projectName: projectName)
+                Button {
+                    Task { await appState.toggleTaskDone(task) }
+                } label: {
+                    Label(task.done ? "Undo" : "Done", systemImage: task.done ? "arrow.uturn.backward" : "checkmark")
                 }
-            } label: {
-                Label(isFocused ? "End Focus" : "Focus", systemImage: "scope")
+                .tint(.green)
             }
-            .tint(.orange)
-            #endif
-
-            Button {
-                Task { await appState.toggleTaskDone(task) }
-            } label: {
-                Label(task.done ? "Undo" : "Done", systemImage: task.done ? "arrow.uturn.backward" : "checkmark")
-            }
-            .tint(.green)
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            Button(role: .destructive) {
-                Task { await appState.deleteTask(task) }
-            } label: {
-                Label("Delete", systemImage: "trash")
+            if !readOnly {
+                Button(role: .destructive) {
+                    Task { await appState.deleteTask(task) }
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
             }
         }
         #if os(iOS)
         .contextMenu {
-            if isFocused {
-                Button {
-                    focusManager.endFocus()
-                } label: {
-                    Label("End Focus", systemImage: "scope")
-                }
-            } else {
-                Button {
-                    let projectName = appState.projects.first(where: { $0.id == task.projectId })?.title ?? "Inbox"
-                    focusManager.switchFocus(task: task, projectName: projectName)
-                } label: {
-                    Label("Start Focus", systemImage: "scope")
+            if !readOnly {
+                if isFocused {
+                    Button {
+                        focusManager.endFocus()
+                    } label: {
+                        Label("End Focus", systemImage: "scope")
+                    }
+                } else {
+                    Button {
+                        let projectName = appState.projects.first(where: { $0.id == task.projectId })?.title ?? "Inbox"
+                        focusManager.switchFocus(task: task, projectName: projectName)
+                    } label: {
+                        Label("Start Focus", systemImage: "scope")
+                    }
                 }
             }
         }
@@ -100,6 +109,7 @@ struct TaskRow: View {
                     .contentTransition(.symbolEffect(.replace))
             }
             .buttonStyle(.plain)
+            .disabled(readOnly)
             .accessibilityLabel(task.done ? "Mark \(task.title) as incomplete" : "Mark \(task.title) as complete")
             .accessibilityAddTraits(.isToggle)
 

--- a/mDoneTests/AppStateTests.swift
+++ b/mDoneTests/AppStateTests.swift
@@ -116,6 +116,29 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(appState.tasks.map(\.id), [2], "Only the deleted project's tasks are removed locally")
     }
 
+    func testDeleteProjectCascadesToDescendantSubprojects() async {
+        let appState = await makeProjectMockedAppState()
+        // 3 (parent) -> 4 (child) -> 5 (grandchild); 9 is unrelated.
+        appState.projects = [
+            Project(id: 3, title: "Parent"),
+            Project(id: 4, title: "Child", parentProjectId: 3),
+            Project(id: 5, title: "Grandchild", parentProjectId: 4),
+            Project(id: 9, title: "Unrelated"),
+        ]
+        appState.tasks = [
+            VTask(id: 1, title: "t-parent", done: false, priority: 0, projectId: 3),
+            VTask(id: 2, title: "t-grandchild", done: false, priority: 0, projectId: 5),
+            VTask(id: 3, title: "t-unrelated", done: false, priority: 0, projectId: 9),
+        ]
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), #"{"message":"ok"}"#.data(using: .utf8)!)
+        }
+
+        await appState.deleteProject(appState.projects[0]) // delete Parent (3)
+        XCTAssertEqual(appState.projects.map(\.id).sorted(), [9], "Parent and all descendants are removed; unrelated kept")
+        XCTAssertEqual(appState.tasks.map(\.id).sorted(), [3], "Tasks of the parent and its descendants are removed")
+    }
+
     func testDeleteProjectGuardsPseudoProject() async {
         let appState = await makeProjectMockedAppState()
         let pseudo = Project(id: -1, title: "Favorites")

--- a/mDoneTests/AppStateTests.swift
+++ b/mDoneTests/AppStateTests.swift
@@ -21,6 +21,132 @@ final class AppStateTests: XCTestCase {
         return AppState(taskService: TaskService(apiClient: client))
     }
 
+    /// Builds an `AppState` whose `ProjectService` talks to `MockURLProtocol`,
+    /// so project create/edit/archive/delete paths can be driven deterministically.
+    private func makeProjectMockedAppState() async -> AppState {
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        return AppState(projectService: ProjectService(apiClient: client))
+    }
+
+    // MARK: - Project Mutations
+
+    func testCreateProjectAppendsToProjects() async {
+        let appState = await makeProjectMockedAppState()
+        MockURLProtocol.requestHandler = { request in
+            let json = #"{"id": 100, "title": "New", "is_archived": false, "is_favorite": false}"#.data(using: .utf8)!
+            return (MockURLProtocol.makeResponse(statusCode: 201, url: request.url), json)
+        }
+
+        await appState.createProject(title: "New")
+        XCTAssertEqual(appState.projects.map(\.id), [100])
+        XCTAssertEqual(appState.projects.first?.title, "New")
+    }
+
+    func testCreateProjectIgnoresBlankTitle() async {
+        let appState = await makeProjectMockedAppState()
+        MockURLProtocol.requestHandler = { request in
+            XCTFail("Blank title must not hit the network")
+            return (MockURLProtocol.makeResponse(statusCode: 201, url: request.url), Data())
+        }
+
+        await appState.createProject(title: "   ")
+        XCTAssertTrue(appState.projects.isEmpty)
+        XCTAssertTrue(MockURLProtocol.capturedRequests.isEmpty)
+    }
+
+    func testUpdateProjectReplacesInPlace() async {
+        let appState = await makeProjectMockedAppState()
+        appState.projects = [Project(id: 5, title: "Old", isArchived: false, isFavorite: false)]
+        MockURLProtocol.requestHandler = { request in
+            let json = #"{"id": 5, "title": "Updated", "is_archived": false, "is_favorite": true}"#.data(using: .utf8)!
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), json)
+        }
+
+        await appState.updateProject(
+            appState.projects[0], title: "Updated", description: "", hexColor: "", isFavorite: true
+        )
+        XCTAssertEqual(appState.projects.count, 1)
+        XCTAssertEqual(appState.projects.first?.title, "Updated")
+        XCTAssertEqual(appState.projects.first?.isFavorite, true)
+    }
+
+    func testArchiveProjectMovesToArchivedList() async {
+        let appState = await makeProjectMockedAppState()
+        appState.projects = [Project(id: 8, title: "ToArchive", isArchived: false, isFavorite: false)]
+        MockURLProtocol.requestHandler = { request in
+            let json = #"{"id": 8, "title": "ToArchive", "is_archived": true, "is_favorite": false}"#
+                .data(using: .utf8)!
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), json)
+        }
+
+        await appState.archiveProject(appState.projects[0])
+        XCTAssertTrue(appState.projects.isEmpty, "Archived project should leave the active list")
+        XCTAssertEqual(appState.archivedProjects.map(\.id), [8])
+    }
+
+    func testUnarchiveProjectMovesToActiveList() async {
+        let appState = await makeProjectMockedAppState()
+        appState.archivedProjects = [Project(id: 8, title: "Archived", isArchived: true, isFavorite: false)]
+        // Server may echo is_archived inconsistently; AppState trusts the requested state.
+        MockURLProtocol.requestHandler = { request in
+            let json = #"{"id": 8, "title": "Archived", "is_archived": false, "is_favorite": false}"#
+                .data(using: .utf8)!
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), json)
+        }
+
+        await appState.unarchiveProject(appState.archivedProjects[0])
+        XCTAssertTrue(appState.archivedProjects.isEmpty)
+        XCTAssertEqual(appState.projects.map(\.id), [8])
+    }
+
+    func testDeleteProjectRemovesProjectAndItsTasks() async {
+        let appState = await makeProjectMockedAppState()
+        appState.projects = [Project(id: 3, title: "Doomed", isArchived: false, isFavorite: false)]
+        appState.tasks = [
+            VTask(id: 1, title: "T1", done: false, priority: 0, projectId: 3),
+            VTask(id: 2, title: "T2", done: false, priority: 0, projectId: 99),
+        ]
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), #"{"message":"ok"}"#.data(using: .utf8)!)
+        }
+
+        await appState.deleteProject(appState.projects[0])
+        XCTAssertTrue(appState.projects.isEmpty)
+        XCTAssertEqual(appState.tasks.map(\.id), [2], "Only the deleted project's tasks are removed locally")
+    }
+
+    func testDeleteProjectGuardsPseudoProject() async {
+        let appState = await makeProjectMockedAppState()
+        let pseudo = Project(id: -1, title: "Favorites")
+        appState.projects = [pseudo]
+        MockURLProtocol.requestHandler = { request in
+            XCTFail("Pseudo-projects (id <= 0) must never hit the delete endpoint")
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data())
+        }
+
+        await appState.deleteProject(pseudo)
+        XCTAssertEqual(appState.projects.count, 1, "Pseudo-project should remain")
+        XCTAssertTrue(MockURLProtocol.capturedRequests.isEmpty)
+    }
+
+    func testFetchArchivedProjectsKeepsOnlyArchived() async {
+        let appState = await makeProjectMockedAppState()
+        MockURLProtocol.requestHandler = { request in
+            // Vikunja returns active AND archived projects when include-archived is set.
+            let json = """
+            [
+                {"id": 1, "title": "Active", "is_archived": false},
+                {"id": 2, "title": "Archived", "is_archived": true}
+            ]
+            """.data(using: .utf8)!
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), json)
+        }
+
+        await appState.fetchArchivedProjects()
+        XCTAssertEqual(appState.archivedProjects.map(\.id), [2])
+    }
+
     // MARK: - uniquedById
 
     func testUniquedByIdRemovesDuplicates() {
@@ -28,7 +154,7 @@ final class AppStateTests: XCTestCase {
             VTask(id: 1, title: "First", done: false, priority: 0, projectId: 10),
             VTask(id: 2, title: "Second", done: false, priority: 0, projectId: 10),
             VTask(id: 1, title: "First (dup)", done: false, priority: 0, projectId: 10),
-            VTask(id: 3, title: "Third", done: false, priority: 0, projectId: 10)
+            VTask(id: 3, title: "Third", done: false, priority: 0, projectId: 10),
         ]
 
         let unique = AppState.uniquedById(tasks)
@@ -41,7 +167,7 @@ final class AppStateTests: XCTestCase {
         let tasks = [
             VTask(id: 5, title: "A", done: false, priority: 0, projectId: 10),
             VTask(id: 3, title: "B", done: false, priority: 0, projectId: 10),
-            VTask(id: 7, title: "C", done: false, priority: 0, projectId: 10)
+            VTask(id: 7, title: "C", done: false, priority: 0, projectId: 10),
         ]
 
         let unique = AppState.uniquedById(tasks)
@@ -88,7 +214,7 @@ final class AppStateTests: XCTestCase {
         appState.tasks = [
             VTask(id: 1, title: "A", done: false, priority: 0, projectId: projectId),
             VTask(id: 2, title: "B", done: false, priority: 0, projectId: projectId),
-            VTask(id: 3, title: "C", done: false, priority: 0, projectId: projectId)
+            VTask(id: 3, title: "C", done: false, priority: 0, projectId: projectId),
         ]
 
         // Simulate the bad cache state Vikunja can produce: id 1 appears twice.
@@ -96,7 +222,7 @@ final class AppStateTests: XCTestCase {
             VTask(id: 1, title: "A", done: false, priority: 0, projectId: projectId),
             VTask(id: 2, title: "B", done: false, priority: 0, projectId: projectId),
             VTask(id: 3, title: "C", done: false, priority: 0, projectId: projectId),
-            VTask(id: 1, title: "A (dup row)", done: false, priority: 0, projectId: projectId)
+            VTask(id: 1, title: "A (dup row)", done: false, priority: 0, projectId: projectId),
         ]
 
         // Before the fix this call traps. After the fix it returns the three tasks
@@ -113,14 +239,14 @@ final class AppStateTests: XCTestCase {
         appState.tasks = [
             VTask(id: 10, title: "A", done: false, priority: 0, projectId: projectId),
             VTask(id: 20, title: "B", done: false, priority: 0, projectId: projectId),
-            VTask(id: 30, title: "C", done: false, priority: 0, projectId: projectId)
+            VTask(id: 30, title: "C", done: false, priority: 0, projectId: projectId),
         ]
 
         // Cache order is reversed compared to the canonical tasks array.
         appState.projectTaskCache[projectId] = [
             VTask(id: 30, title: "C", done: false, priority: 0, projectId: projectId),
             VTask(id: 20, title: "B", done: false, priority: 0, projectId: projectId),
-            VTask(id: 10, title: "A", done: false, priority: 0, projectId: projectId)
+            VTask(id: 10, title: "A", done: false, priority: 0, projectId: projectId),
         ]
 
         XCTAssertEqual(appState.tasksForProject(projectId).map(\.id), [30, 20, 10])
@@ -133,7 +259,7 @@ final class AppStateTests: XCTestCase {
         appState.tasks = [
             VTask(id: 1, title: "Open", done: false, priority: 0, projectId: projectId),
             VTask(id: 2, title: "Done", done: true, priority: 0, projectId: projectId),
-            VTask(id: 3, title: "Other project", done: false, priority: 0, projectId: 999)
+            VTask(id: 3, title: "Other project", done: false, priority: 0, projectId: 999),
         ]
 
         XCTAssertEqual(appState.tasksForProject(projectId).map(\.id), [1])
@@ -158,8 +284,11 @@ final class AppStateTests: XCTestCase {
 
         XCTAssertFalse(appState.isAuthenticated, "Session expiry must flip auth state back to logged-out")
         XCTAssertTrue(appState.tasks.isEmpty, "Session expiry should wipe in-memory data")
-        XCTAssertEqual(auth.getServerURL(), "https://vikunja.example.com",
-                       "Server URL must survive session expiry so the login screen can prefill it (issue #80)")
+        XCTAssertEqual(
+            auth.getServerURL(),
+            "https://vikunja.example.com",
+            "Server URL must survive session expiry so the login screen can prefill it (issue #80)"
+        )
         XCTAssertNil(auth.getToken(), "Stale access token must be removed")
         XCTAssertNil(auth.getRefreshToken(), "Stale refresh token must be removed")
     }
@@ -189,8 +318,10 @@ final class AppStateTests: XCTestCase {
         await appState.logout()
 
         XCTAssertFalse(appState.isAuthenticated)
-        XCTAssertNil(auth.getServerURL(),
-                     "Explicit logout is a deliberate sign-out: server URL goes too")
+        XCTAssertNil(
+            auth.getServerURL(),
+            "Explicit logout is a deliberate sign-out: server URL goes too"
+        )
         XCTAssertNil(auth.getToken())
         XCTAssertNil(auth.getRefreshToken())
     }
@@ -219,8 +350,11 @@ final class AppStateTests: XCTestCase {
         appState.recordCompletionForUndo(VTask(id: 1, title: "First", done: false, priority: 0, projectId: 10))
         appState.recordCompletionForUndo(VTask(id: 2, title: "Second", done: false, priority: 0, projectId: 10))
 
-        XCTAssertEqual(appState.undoableCompletion?.id, 2,
-                       "Only the most recent completion is undoable")
+        XCTAssertEqual(
+            appState.undoableCompletion?.id,
+            2,
+            "Only the most recent completion is undoable"
+        )
         XCTAssertEqual(appState.undoableCompletionTitle, "Second")
     }
 
@@ -230,8 +364,10 @@ final class AppStateTests: XCTestCase {
 
         appState.clearUndoIfMatches(id: 5)
 
-        XCTAssertFalse(appState.canUndoLastCompletion,
-                       "Un-completing the same task by other means clears the undo target")
+        XCTAssertFalse(
+            appState.canUndoLastCompletion,
+            "Un-completing the same task by other means clears the undo target"
+        )
     }
 
     func testClearUndoNonMatchingIdKeepsTarget() {
@@ -240,8 +376,10 @@ final class AppStateTests: XCTestCase {
 
         appState.clearUndoIfMatches(id: 99)
 
-        XCTAssertTrue(appState.canUndoLastCompletion,
-                      "A different task changing state must not clear the pending undo")
+        XCTAssertTrue(
+            appState.canUndoLastCompletion,
+            "A different task changing state must not clear the pending undo"
+        )
         XCTAssertEqual(appState.undoableCompletion?.id, 5)
     }
 
@@ -311,8 +449,11 @@ final class AppStateTests: XCTestCase {
 
         await appState.undoLastCompletion()
 
-        XCTAssertEqual(appState.tasks.first?.effectiveDueDate, due,
-                       "Undo must preserve the original due date so the task returns to its Inbox section")
+        XCTAssertEqual(
+            appState.tasks.first?.effectiveDueDate,
+            due,
+            "Undo must preserve the original due date so the task returns to its Inbox section"
+        )
     }
 
     func testUndoKeepsTargetWhenRequestFails() async {
@@ -329,8 +470,10 @@ final class AppStateTests: XCTestCase {
 
         await appState.undoLastCompletion()
 
-        XCTAssertTrue(appState.canUndoLastCompletion,
-                      "A failed undo must keep the pending target so the user can retry")
+        XCTAssertTrue(
+            appState.canUndoLastCompletion,
+            "A failed undo must keep the pending target so the user can retry"
+        )
         XCTAssertEqual(appState.undoableCompletion?.id, 11)
     }
 }

--- a/mDoneTests/ProjectServiceTests.swift
+++ b/mDoneTests/ProjectServiceTests.swift
@@ -219,4 +219,133 @@ final class ProjectServiceTests: XCTestCase {
 
         XCTAssertEqual(set.count, 1, "Projects with same ID should hash equally")
     }
+
+    // MARK: - Project Mutations
+
+    func testCreateProjectSendsPutRequest() async throws {
+        let (service, client) = makeTestService()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+
+        let responseJSON = """
+        {"id": 42, "title": "Marketing", "hex_color": "#4772FA", "is_archived": false, "is_favorite": false}
+        """.data(using: .utf8)!
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "PUT")
+            XCTAssertTrue(request.url?.path.hasSuffix("/api/v1/projects") == true)
+            return (MockURLProtocol.makeResponse(statusCode: 201, url: request.url), responseJSON)
+        }
+
+        let project = try await service.createProject(
+            ProjectCreateRequest(title: "Marketing", description: nil, hexColor: "#4772FA", isFavorite: false)
+        )
+        XCTAssertEqual(project.id, 42)
+        XCTAssertEqual(project.title, "Marketing")
+    }
+
+    func testUpdateProjectSendsPostRequest() async throws {
+        let (service, client) = makeTestService()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+
+        let responseJSON = """
+        {"id": 7, "title": "Renamed", "is_archived": true, "is_favorite": false}
+        """.data(using: .utf8)!
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertTrue(request.url?.path.hasSuffix("/api/v1/projects/7") == true)
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), responseJSON)
+        }
+
+        let request = ProjectUpdateRequest(
+            title: "Renamed", description: "", hexColor: "", isFavorite: false, isArchived: true
+        )
+        let project = try await service.updateProject(id: 7, request: request)
+        XCTAssertEqual(project.id, 7)
+        XCTAssertEqual(project.title, "Renamed")
+        XCTAssertEqual(project.isArchived, true)
+    }
+
+    func testDeleteProjectSendsDeleteRequest() async throws {
+        let (service, client) = makeTestService()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "DELETE")
+            XCTAssertTrue(request.url?.path.hasSuffix("/api/v1/projects/9") == true)
+            return (
+                MockURLProtocol.makeResponse(statusCode: 200, url: request.url),
+                #"{"message":"deleted"}"#.data(using: .utf8)!
+            )
+        }
+
+        try await service.deleteProject(id: 9)
+        XCTAssertEqual(MockURLProtocol.capturedRequests.last?.httpMethod, "DELETE")
+    }
+
+    func testFetchProjectsIncludeArchivedAddsQueryParam() async throws {
+        let (service, client) = makeTestService()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.query?.contains("is_archived=true"), true)
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), "[]".data(using: .utf8)!)
+        }
+
+        _ = try await service.fetchProjects(includeArchived: true)
+    }
+
+    func testFetchProjectsDefaultOmitsArchivedParam() async throws {
+        let (service, client) = makeTestService()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertFalse(request.url?.query?.contains("is_archived") ?? false)
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), "[]".data(using: .utf8)!)
+        }
+
+        _ = try await service.fetchProjects()
+    }
+
+    // MARK: - Request Encoding
+
+    func testProjectCreateRequestEncoding() throws {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let request = ProjectCreateRequest(title: "Work", description: "Stuff", hexColor: "#FF0000", isFavorite: true)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoder.encode(request)) as? [String: Any])
+        XCTAssertEqual(json["title"] as? String, "Work")
+        XCTAssertEqual(json["description"] as? String, "Stuff")
+        XCTAssertEqual(json["hex_color"] as? String, "#FF0000")
+        XCTAssertEqual(json["is_favorite"] as? Bool, true)
+    }
+
+    func testProjectCreateRequestOmitsNilFields() throws {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let request = ProjectCreateRequest(title: "Bare", description: nil, hexColor: nil, isFavorite: nil)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoder.encode(request)) as? [String: Any])
+        XCTAssertEqual(json["title"] as? String, "Bare")
+        XCTAssertNil(json["description"])
+        XCTAssertNil(json["hex_color"])
+        XCTAssertNil(json["is_favorite"])
+    }
+
+    func testProjectUpdateRequestFromProjectSendsFullFieldSet() throws {
+        let project = Project(id: 3, title: "Keep", description: "Desc", hexColor: "#00FF00", isFavorite: true)
+        let request = ProjectUpdateRequest(from: project, isArchived: true)
+        XCTAssertEqual(request.title, "Keep")
+        XCTAssertEqual(request.description, "Desc")
+        XCTAssertEqual(request.hexColor, "#00FF00")
+        XCTAssertEqual(request.isFavorite, true)
+        XCTAssertEqual(request.isArchived, true)
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoder.encode(request)) as? [String: Any])
+        // The full field set is always present so unarchive (is_archived=false) is honoured.
+        XCTAssertEqual(json["is_archived"] as? Bool, true)
+        XCTAssertEqual(json["title"] as? String, "Keep")
+        XCTAssertEqual(json["hex_color"] as? String, "#00FF00")
+    }
 }

--- a/mDoneTests/SyncServiceTests.swift
+++ b/mDoneTests/SyncServiceTests.swift
@@ -1,3 +1,4 @@
+import SwiftData
 import XCTest
 @testable import mDone
 
@@ -281,5 +282,56 @@ final class SyncServiceTests: XCTestCase {
 
         operation.failed = true
         XCTAssertTrue(operation.failed)
+    }
+
+    // MARK: - Local Project Cache (in-memory container)
+
+    @MainActor
+    private func makeInMemorySyncService() throws -> SyncService {
+        let schema = Schema([
+            CachedTask.self,
+            CachedProject.self,
+            CachedLabel.self,
+            PendingOperation.self,
+            FocusRecord.self,
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        return SyncService(
+            taskService: TaskService(apiClient: client),
+            projectService: ProjectService(apiClient: client),
+            modelContainer: container
+        )
+    }
+
+    @MainActor
+    func testUpdateCachedProjectInsertsThenUpdatesInPlace() throws {
+        let sync = try makeInMemorySyncService()
+
+        sync.updateCachedProject(
+            Project(id: 1, title: "Work", hexColor: "#FF0000", isArchived: false, isFavorite: false)
+        )
+        var cached = try sync.loadCachedProjects()
+        XCTAssertEqual(cached.map(\.id), [1])
+        XCTAssertEqual(cached.first?.title, "Work")
+
+        // Same id mutates in place rather than inserting a duplicate.
+        sync.updateCachedProject(Project(id: 1, title: "Work (renamed)", isArchived: true, isFavorite: false))
+        cached = try sync.loadCachedProjects()
+        XCTAssertEqual(cached.count, 1)
+        XCTAssertEqual(cached.first?.title, "Work (renamed)")
+        XCTAssertEqual(cached.first?.isArchived, true)
+    }
+
+    @MainActor
+    func testDeleteCachedProjectRemovesIt() throws {
+        let sync = try makeInMemorySyncService()
+        sync.updateCachedProject(Project(id: 1, title: "Keep"))
+        sync.updateCachedProject(Project(id: 2, title: "Remove"))
+
+        sync.deleteCachedProject(id: 2)
+        let cached = try sync.loadCachedProjects()
+        XCTAssertEqual(cached.map(\.id), [1])
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -16,8 +16,8 @@ settings:
     # not feature-related — see PR "decisions".
     PRODUCT_NAME: "$(TARGET_NAME)"
     SWIFT_VERSION: "5.9"
-    MARKETING_VERSION: "1.4.0"
-    CURRENT_PROJECT_VERSION: "39"
+    MARKETING_VERSION: "1.5.0"
+    CURRENT_PROJECT_VERSION: "41"
     DEVELOPMENT_TEAM: "Z62E7MGREE"
     CODE_SIGN_IDENTITY: "Apple Development"
     CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary

Projects were **read-only** in mDone — you had to use the Vikunja web app to create, rename, recolour, archive, or delete them. This PR adds full **create / edit / delete / archive** for projects on both iOS and macOS, mirroring the existing task-CRUD patterns. Implements #92.

## What changed

**Backend / state**
- `Endpoint`: `createProject` (PUT), `updateProject` (POST), `deleteProject` (DELETE), and an `includeArchived` param on `projects()`.
- `Project.swift`: `ProjectCreateRequest` and `ProjectUpdateRequest`. Update always sends the **full field set** so Vikunja never blanks a column and unarchive (`is_archived=false`) is honoured.
- `ProjectService`: create / update / delete + include-archived fetch.
- `AppState`: `createProject` / `updateProject` / `archiveProject` / `unarchiveProject` / `deleteProject` / `fetchArchivedProjects`, plus an `archivedProjects` array. Delete does cascade-aware **local cleanup** (tasks, `projectTaskCache`, `selectedProject`) and guards pseudo-projects (`id <= 0`, e.g. Favourites).
- `SyncService`: `updateCachedProject` / `deleteCachedProject`.

**UI**
- New shared `ProjectEditSheet` (create + edit) and a `ColorSwatchPicker` (preset palette).
- iOS `ProjectListScreen`: `+` toolbar button, swipe + context actions (Edit / Archive / Delete), a cascade-aware delete dialog that **offers Archive instead**, an "Archived" link, and a real empty-state button. New `ArchivedProjectsScreen` (Unarchive / Delete; read-only task view via a new `readOnly` flag on `TaskListScreen`).
- macOS `MacSidebarView`: `+` in the Projects header (⌘⇧N), per-project context menu, and an "Archived" sidebar item backed by a new `MacArchivedProjectsView`.

## Why these choices
- **Online-only** (no offline queueing for project mutations): project CRUD is rare/structural and offline-create would need temp-ID reconciliation. Deferred as a follow-up.
- **Preset colour swatches** rather than a free picker — consistent with the Vikunja web UI and a clean 6-char hex mapping.
- **Delete is genuinely destructive**: Vikunja cascades a project delete to all its tasks *and* descendant projects server-side, with no undo — hence the explicit, count-aware confirmation that offers Archive as the safe alternative.

## Testing
- iOS **and** macOS targets build clean.
- **335 unit tests pass** (19 new): `ProjectService` (100%), `Project` (94%), `AppState` project state-transitions incl. delete cascade cleanup + pseudo-project guard, and container-backed `SyncService` cache round-trips.
- iOS build smoke-tested on TestFlight before submission.

## Release status
Already cut and submitted while iterating on this branch:
- **iOS + macOS `1.5.0` (build 41)** are uploaded, processed (VALID), and **submitted for App Store review** (`AFTER_APPROVAL`). Both currently `WAITING_FOR_REVIEW`.
- `CHANGELOG.md` updated with a `1.5.0` section.

## Reviewer notes
- `ProjectUpdateRequest` deliberately sends every field (not a sparse patch) — see the doc comment for why (Vikunja's update can reset omitted columns / skip zero-value booleans).
- The Mac views compile into both targets (the whole `mDone/` dir is globbed by both schemes), so everything is cross-platform-safe.
- macOS App Store screenshots are still inherited from older versions (pre-existing, flagged in release notes) — not addressed here.

Closes #92
