### PR TITLE
Add privacy policy page to the marketing site

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -691,6 +691,7 @@ footer{ background:var(--bg-2); border-top:1px solid var(--line); padding:56px 0
           <a href="#features">Features</a>
           <a href="#showcase">Screens</a>
           <a href="#privacy">Privacy</a>
+          <a href="privacy-policy.html">Privacy Policy</a>
           <a href="https://apps.apple.com/us/app/mdone/id6760613430">App Store</a>
         </div>
         <div class="foot-col">

--- a/website/privacy-policy.html
+++ b/website/privacy-policy.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>mDone - Privacy Policy</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.7;
+            color: #1d1d1f;
+            background-color: #ffffff;
+            padding: 2rem 1rem;
+        }
+
+        .container {
+            max-width: 720px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            font-size: 2rem;
+            font-weight: 700;
+            margin-bottom: 0.25rem;
+        }
+
+        .subtitle {
+            font-size: 1rem;
+            color: #6e6e73;
+            margin-bottom: 2rem;
+        }
+
+        h2 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            margin-top: 2rem;
+            margin-bottom: 0.75rem;
+            color: #1d1d1f;
+        }
+
+        p {
+            margin-bottom: 1rem;
+            color: #424245;
+        }
+
+        ul {
+            margin-bottom: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        li {
+            margin-bottom: 0.5rem;
+            color: #424245;
+        }
+
+        a {
+            color: #0071e3;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .effective-date {
+            margin-top: 3rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid #d2d2d7;
+            font-size: 0.875rem;
+            color: #6e6e73;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Privacy Policy</h1>
+        <p class="subtitle">mDone &mdash; Task Manager for Vikunja</p>
+
+        <h2>Overview</h2>
+        <p>
+            mDone is a task management app that connects to your own self-hosted
+            <a href="https://vikunja.io" target="_blank" rel="noopener">Vikunja</a> server.
+            Your privacy is fundamental to how this app is built. mDone does not collect,
+            track, or share any personal data with third parties.
+        </p>
+
+        <h2>Data Collection</h2>
+        <p>
+            mDone does <strong>not</strong> collect any personal information. There are no
+            analytics, no tracking pixels, no advertising identifiers, and no telemetry of
+            any kind. The app does not communicate with any server other than the Vikunja
+            instance you configure.
+        </p>
+
+        <h2>Data Storage</h2>
+        <p>The app stores a limited amount of data locally on your device:</p>
+        <ul>
+            <li><strong>Authentication tokens</strong> are stored securely in the device's Keychain, protected by the operating system's built-in encryption.</li>
+            <li><strong>Server URL and credentials</strong> are stored in the device's secure storage.</li>
+            <li><strong>Task data</strong> is fetched from your own Vikunja server and may be cached locally on the device to enable offline access.</li>
+        </ul>
+        <p>
+            All data remains on your device and your server. Nothing is transmitted to the
+            developer or any third party.
+        </p>
+
+        <h2>Third-Party Services</h2>
+        <p>
+            mDone does not integrate with any third-party services, SDKs, or APIs. The app
+            communicates exclusively with the Vikunja server URL that you provide.
+        </p>
+
+        <h2>Analytics and Tracking</h2>
+        <p>
+            mDone contains no analytics frameworks, crash reporters, or tracking mechanisms.
+            The app does not collect usage data of any kind.
+        </p>
+
+        <h2>Children's Privacy</h2>
+        <p>
+            mDone does not knowingly collect any information from anyone, including children
+            under the age of 13.
+        </p>
+
+        <h2>Changes to This Policy</h2>
+        <p>
+            If this privacy policy is updated, the revised version will be posted on this
+            page with an updated effective date. Continued use of the app after changes
+            constitutes acceptance of the revised policy.
+        </p>
+
+        <h2>Contact</h2>
+        <p>
+            If you have questions or concerns about this privacy policy, please open an
+            issue on GitHub:<br>
+            <a href="https://github.com/marco308/mdone/issues" target="_blank" rel="noopener">
+                github.com/marco308/mdone/issues
+            </a>
+        </p>
+
+        <p class="effective-date">Effective date: March 15, 2026</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Copies docs/privacy-policy.html into website/ and links it from the footer, so /mdone/privacy-policy.html keeps serving after GitHub Pages switches from the legacy main:/docs source to the GitHub Actions workflow (which serves website/). Without this, the App Store privacy-policy URL would 404 after the switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)