### PR TITLE
Fix unclickable links in the marketing site's final CTA

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -275,7 +275,7 @@ section{ padding:96px 0; }
 
 /* ---------- privacy (dark) ---------- */
 .privacy{ background:var(--night); color:#fff; position:relative; overflow:hidden; }
-.privacy::before{ content:""; position:absolute; width:600px; height:600px; border-radius:50%;
+.privacy::before{ content:""; position:absolute; width:600px; height:600px; border-radius:50%; pointer-events:none;
   background:radial-gradient(circle, rgba(82,122,250,.35), transparent 70%); filter:blur(70px);
   top:-200px; right:-120px; }
 .privacy .wrap{ position:relative; }
@@ -308,7 +308,7 @@ section{ padding:96px 0; }
   background:linear-gradient(160deg,#5d83fb,#3f5fe6); color:#fff; position:relative; overflow:hidden;
   box-shadow:var(--shadow-lg);
 }
-.final .box::after{ content:""; position:absolute; inset:0;
+.final .box::after{ content:""; position:absolute; inset:0; pointer-events:none;
   background:radial-gradient(circle at 70% -10%, rgba(255,255,255,.28), transparent 55%); }
 .final .box > *{ position:relative; }
 .final h2{ color:#fff; font-size:clamp(30px,4.4vw,44px); }


### PR DESCRIPTION
The final CTA's decorative gradient overlay (.final .box::after, inset:0) had default pointer-events, so it sat on top of the content and swallowed clicks before they reached the App Store and GitHub links. Adds pointer-events:none to that overlay (and the analogous .privacy::before glow). Verified by hit-testing that clicks now reach both links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)