### PR TITLE
Add Calm Mode (no-stress overdue handling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Settings → Tasks → "Calm Mode" (off by default). When on, overdue tasks aren't singled out: no red due dates, no separate "Overdue" list or counts, and no red highlight in the widgets. Overdue tasks simply appear in Today alongside everything else, in the app and on widgets (#68).
+
 ## [1.5.0] - 2026-06-01
 
 ### Added

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -163,6 +163,13 @@ final class AppState {
         tasks.filter(\.isDueToday).sorted { ($0.dueDate ?? .distantFuture) < ($1.dueDate ?? .distantFuture) }
     }
 
+    /// Today's list when Calm Mode is on: overdue tasks fold in alongside
+    /// today's, so they aren't singled out. `overdueTasks` and `todayTasks`
+    /// are disjoint by construction, so this is a simple union (overdue first).
+    var calmModeTodayTasks: [VTask] {
+        overdueTasks + todayTasks
+    }
+
     var tomorrowTasks: [VTask] {
         tasks.filter(\.isDueTomorrow).sorted { ($0.dueDate ?? .distantFuture) < ($1.dueDate ?? .distantFuture) }
     }

--- a/mDone/Views/Mac/MacSidebarView.swift
+++ b/mDone/Views/Mac/MacSidebarView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MacSidebarView: View {
     @Environment(AppState.self) private var appState
     @Binding var selection: MacContentView.SidebarSection?
+    @AppStorage("calmMode") private var calmMode = false
 
     @State private var showingCreate = false
     @State private var editingProject: Project?
@@ -99,7 +100,7 @@ struct MacSidebarView: View {
                     HStack {
                         Text("Overdue")
                         Spacer()
-                        if !appState.overdueTasks.isEmpty {
+                        if !calmMode, !appState.overdueTasks.isEmpty {
                             Text("\(appState.overdueTasks.count)")
                                 .font(.caption2)
                                 .foregroundStyle(.white)

--- a/mDone/Views/Mac/MacTaskListView.swift
+++ b/mDone/Views/Mac/MacTaskListView.swift
@@ -57,7 +57,7 @@ struct MacTaskListView: View {
             } else if section == .inbox {
                 List(selection: $selectedTask) {
                     if calmMode {
-                        let todayAndOverdue = appState.overdueTasks + appState.todayTasks
+                        let todayAndOverdue = appState.calmModeTodayTasks
                         if !todayAndOverdue.isEmpty {
                             SmartListSection(title: "Today", tasks: todayAndOverdue, accentColor: Color.accentColor)
                         }

--- a/mDone/Views/Mac/MacTaskListView.swift
+++ b/mDone/Views/Mac/MacTaskListView.swift
@@ -7,6 +7,7 @@ struct MacTaskListView: View {
     @State private var sortOrder: SortOrder = .dueDate
     @State private var sortAscending: Bool = true
     @State private var showAdvancedFilter = false
+    @AppStorage("calmMode") private var calmMode = false
 
     enum SortOrder: String, CaseIterable {
         case dueDate = "Due Date"
@@ -55,11 +56,18 @@ struct MacTaskListView: View {
                     .frame(maxHeight: .infinity)
             } else if section == .inbox {
                 List(selection: $selectedTask) {
-                    if !appState.overdueTasks.isEmpty {
-                        SmartListSection(title: "Overdue", tasks: appState.overdueTasks, accentColor: .red)
-                    }
-                    if !appState.todayTasks.isEmpty {
-                        SmartListSection(title: "Today", tasks: appState.todayTasks, accentColor: Color.accentColor)
+                    if calmMode {
+                        let todayAndOverdue = appState.overdueTasks + appState.todayTasks
+                        if !todayAndOverdue.isEmpty {
+                            SmartListSection(title: "Today", tasks: todayAndOverdue, accentColor: Color.accentColor)
+                        }
+                    } else {
+                        if !appState.overdueTasks.isEmpty {
+                            SmartListSection(title: "Overdue", tasks: appState.overdueTasks, accentColor: .red)
+                        }
+                        if !appState.todayTasks.isEmpty {
+                            SmartListSection(title: "Today", tasks: appState.todayTasks, accentColor: Color.accentColor)
+                        }
                     }
                     if !appState.tomorrowTasks.isEmpty {
                         SmartListSection(title: "Tomorrow", tasks: appState.tomorrowTasks, accentColor: .orange)

--- a/mDone/Views/Settings/SettingsScreen.swift
+++ b/mDone/Views/Settings/SettingsScreen.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WidgetKit
 
 struct SettingsScreen: View {
     @Environment(AppState.self) private var appState
@@ -6,6 +7,7 @@ struct SettingsScreen: View {
     @AppStorage("reminderOffset") private var reminderOffset = 30
     @AppStorage(WeekStartPreference.storageKey) private var firstWeekday = WeekStartPreference.system.rawValue
     @AppStorage(DefaultDueTimePreference.storageKey) private var defaultDueTime = DefaultDueTimePreference.defaultRawValue
+    @AppStorage("calmMode") private var calmMode = false
     @State private var showLogoutConfirm = false
     @State private var showAbout = false
 
@@ -47,6 +49,16 @@ struct SettingsScreen: View {
                 Text("Tasks")
             } footer: {
                 Text("Time of day applied to tasks you add to Today without picking a time. Pick a time later in the day to avoid the task showing as overdue right away.")
+            }
+
+            Section {
+                Toggle("Calm Mode", isOn: $calmMode)
+                    .onChange(of: calmMode) { _, newValue in
+                        SharedKeys.sharedDefaults.set(newValue, forKey: SharedKeys.calmModeKey)
+                        WidgetCenter.shared.reloadAllTimelines()
+                    }
+            } footer: {
+                Text("Overdue tasks appear like any other — no red, no separate Overdue list or counts. They still show in your lists and widgets.")
             }
 
             Section("Calendar") {

--- a/mDone/Views/Tasks/TaskListScreen.swift
+++ b/mDone/Views/Tasks/TaskListScreen.swift
@@ -12,6 +12,7 @@ struct TaskListScreen: View {
     @State private var showAdvancedFilter = false
     @State private var sortOrder: SortOrder = .dueDate
     @State private var sortAscending: Bool = true
+    @AppStorage("calmMode") private var calmMode = false
 
     enum SortOrder: String, CaseIterable {
         case dueDate = "Due Date"
@@ -191,20 +192,32 @@ struct TaskListScreen: View {
 
     @ViewBuilder
     private var smartListSections: some View {
-        if !appState.overdueTasks.isEmpty {
-            SmartListSection(
-                title: "Overdue",
-                tasks: sorted(appState.overdueTasks),
-                accentColor: .red
-            )
-        }
+        if calmMode {
+            // Calm Mode: overdue tasks aren't singled out — they fold into Today.
+            let todayAndOverdue = appState.overdueTasks + appState.todayTasks
+            if !todayAndOverdue.isEmpty {
+                SmartListSection(
+                    title: "Today",
+                    tasks: sorted(todayAndOverdue),
+                    accentColor: Color.accentColor
+                )
+            }
+        } else {
+            if !appState.overdueTasks.isEmpty {
+                SmartListSection(
+                    title: "Overdue",
+                    tasks: sorted(appState.overdueTasks),
+                    accentColor: .red
+                )
+            }
 
-        if !appState.todayTasks.isEmpty {
-            SmartListSection(
-                title: "Today",
-                tasks: sorted(appState.todayTasks),
-                accentColor: Color.accentColor
-            )
+            if !appState.todayTasks.isEmpty {
+                SmartListSection(
+                    title: "Today",
+                    tasks: sorted(appState.todayTasks),
+                    accentColor: Color.accentColor
+                )
+            }
         }
 
         if appState.calendarAccessGranted, !appState.todayCalendarEvents.isEmpty {

--- a/mDone/Views/Tasks/TaskListScreen.swift
+++ b/mDone/Views/Tasks/TaskListScreen.swift
@@ -194,7 +194,7 @@ struct TaskListScreen: View {
     private var smartListSections: some View {
         if calmMode {
             // Calm Mode: overdue tasks aren't singled out — they fold into Today.
-            let todayAndOverdue = appState.overdueTasks + appState.todayTasks
+            let todayAndOverdue = appState.calmModeTodayTasks
             if !todayAndOverdue.isEmpty {
                 SmartListSection(
                     title: "Today",

--- a/mDone/Views/Tasks/TaskRow.swift
+++ b/mDone/Views/Tasks/TaskRow.swift
@@ -10,6 +10,7 @@ struct TaskRow: View {
     /// context menu, or tap-to-edit. Used for archived (read-only) projects.
     var readOnly: Bool = false
     @State private var showDetail = false
+    @AppStorage("calmMode") private var calmMode = false
 
     #if os(iOS)
     private var isFocused: Bool {
@@ -131,7 +132,7 @@ struct TaskRow: View {
                             }
                         }
                         .font(.caption)
-                        .foregroundStyle(task.isOverdue ? .red : .secondary)
+                        .foregroundStyle(task.isOverdue && !calmMode ? .red : .secondary)
                     }
 
                     if task.isRepeating {

--- a/mDoneShared/SharedConstants.swift
+++ b/mDoneShared/SharedConstants.swift
@@ -14,6 +14,10 @@ enum SharedKeys {
     static let apiTokenKey = "com.mdone.shared.apiToken"
     static let serverURLKey = "com.mdone.shared.serverURL"
     static let widgetDataKey = "com.mdone.shared.widgetData"
+    /// Calm Mode: when true, overdue tasks are shown without any special
+    /// highlighting (no red, no separate "Overdue" grouping or counts).
+    /// Mirrored from the app's `@AppStorage("calmMode")` so widgets can read it.
+    static let calmModeKey = "com.mdone.shared.calmMode"
 
     static var sharedDefaults: UserDefaults {
         UserDefaults(suiteName: appGroupID) ?? .standard

--- a/mDoneTests/AppStateTests.swift
+++ b/mDoneTests/AppStateTests.swift
@@ -499,4 +499,69 @@ final class AppStateTests: XCTestCase {
         )
         XCTAssertEqual(appState.undoableCompletion?.id, 11)
     }
+
+    // MARK: - Calm Mode (#68)
+
+    /// Seeds a deterministic spread of due dates: overdue, due-today,
+    /// upcoming, no-date, and a done-but-overdue task.
+    private func seedCalmModeTasks(_ appState: AppState) throws {
+        let now = Date()
+        let cal = Calendar.current
+        let todayEndOfDay = try XCTUnwrap(cal.date(bySettingHour: 23, minute: 59, second: 59, of: now))
+        appState.tasks = [
+            VTask(id: 1, title: "Overdue", done: false,
+                  dueDate: cal.date(byAdding: .day, value: -2, to: now), priority: 0, projectId: 1),
+            VTask(id: 2, title: "Today", done: false,
+                  dueDate: todayEndOfDay, priority: 0, projectId: 1),
+            VTask(id: 3, title: "Upcoming", done: false,
+                  dueDate: cal.date(byAdding: .day, value: 3, to: now), priority: 0, projectId: 1),
+            VTask(id: 4, title: "No date", done: false, priority: 0, projectId: 1),
+            VTask(id: 5, title: "Done overdue", done: true,
+                  dueDate: cal.date(byAdding: .day, value: -3, to: now), priority: 0, projectId: 1),
+        ]
+    }
+
+    func testCalmModeTodayTasksUnionsOverdueAndToday() async throws {
+        let appState = await makeMockedAppState()
+        try seedCalmModeTasks(appState)
+
+        let ids = appState.calmModeTodayTasks.map(\.id)
+        XCTAssertEqual(ids, [1, 2], "Calm Mode's Today list is overdue + today, overdue first")
+    }
+
+    func testCalmModeTodayTasksExcludesUpcomingNoDateAndDone() async throws {
+        let appState = await makeMockedAppState()
+        try seedCalmModeTasks(appState)
+
+        let ids = Set(appState.calmModeTodayTasks.map(\.id))
+        XCTAssertFalse(ids.contains(3), "Upcoming tasks stay out of Today")
+        XCTAssertFalse(ids.contains(4), "No-date tasks stay out of Today")
+        XCTAssertFalse(ids.contains(5), "Completed tasks are never overdue/today")
+    }
+
+    func testOverdueAndTodayAreDisjointSoCalmModeHasNoDuplicates() async throws {
+        let appState = await makeMockedAppState()
+        try seedCalmModeTasks(appState)
+
+        // The union relies on these two sets never overlapping.
+        let overdue = Set(appState.overdueTasks.map(\.id))
+        let today = Set(appState.todayTasks.map(\.id))
+        XCTAssertTrue(overdue.isDisjoint(with: today), "Overdue and Today must not overlap")
+
+        let calmIds = appState.calmModeTodayTasks.map(\.id)
+        XCTAssertEqual(calmIds.count, Set(calmIds).count, "Calm Mode list has no duplicates")
+        XCTAssertEqual(calmIds.count, appState.overdueTasks.count + appState.todayTasks.count)
+    }
+
+    func testCalmModeKeyDefaultsOff() {
+        // Default OFF is the contract the widget extension relies on.
+        SharedKeys.sharedDefaults.removeObject(forKey: SharedKeys.calmModeKey)
+        XCTAssertFalse(SharedKeys.sharedDefaults.bool(forKey: SharedKeys.calmModeKey))
+    }
+
+    func testCalmModeKeyRoundTripsThroughAppGroup() {
+        SharedKeys.sharedDefaults.set(true, forKey: SharedKeys.calmModeKey)
+        XCTAssertTrue(SharedKeys.sharedDefaults.bool(forKey: SharedKeys.calmModeKey))
+        SharedKeys.sharedDefaults.removeObject(forKey: SharedKeys.calmModeKey)
+    }
 }

--- a/mDoneWidgets/LockScreenWidgets.swift
+++ b/mDoneWidgets/LockScreenWidgets.swift
@@ -100,6 +100,8 @@ struct LockScreenEntry: TimelineEntry {
 struct LockScreenCircularView: View {
     let entry: LockScreenEntry
 
+    private var calmMode: Bool { SharedKeys.sharedDefaults.bool(forKey: SharedKeys.calmModeKey) }
+
     var body: some View {
         if !entry.isAuthenticated {
             Image(systemName: "person.crop.circle.badge.questionmark")
@@ -115,7 +117,7 @@ struct LockScreenCircularView: View {
                     .font(.system(.title2, design: .rounded, weight: .bold))
             }
             .gaugeStyle(.accessoryCircular)
-            .tint(entry.overdueCount > 0 ? .red : .blue)
+            .tint(entry.overdueCount > 0 && !calmMode ? .red : .blue)
         }
     }
 }

--- a/mDoneWidgets/TodayTasksWidget.swift
+++ b/mDoneWidgets/TodayTasksWidget.swift
@@ -91,6 +91,10 @@ struct TodayTasksWidgetView: View {
     private var fontSize: WidgetFontSize { entry.configuration.fontSize }
     private var filterMode: TodayTaskFilterMode { entry.configuration.filterMode }
 
+    /// Calm Mode (set in the app, mirrored to the App Group): when on, overdue
+    /// tasks are shown without any red highlight or separate grouping.
+    private var calmMode: Bool { SharedKeys.sharedDefaults.bool(forKey: SharedKeys.calmModeKey) }
+
     private var visibleTodayTasks: [WidgetTask] {
         filterMode == .overdueOnly ? [] : entry.tasks
     }
@@ -202,7 +206,14 @@ struct TodayTasksWidgetView: View {
             let visibleToday = Array(visibleTodayTasks.prefix(todayLimit))
 
             if !visibleOverdue.isEmpty {
-                overdueSection(tasks: visibleOverdue)
+                if calmMode {
+                    // Calm Mode: overdue rows look like any other task — no red box.
+                    ForEach(visibleOverdue) { task in
+                        taskRow(task: task)
+                    }
+                } else {
+                    overdueSection(tasks: visibleOverdue)
+                }
             }
 
             ForEach(visibleToday) { task in
@@ -241,7 +252,7 @@ struct TodayTasksWidgetView: View {
                     .padding(.vertical, 2)
                     .background(
                         Capsule()
-                            .fill(visibleOverdueTasks.isEmpty ? Color.blue : Color.red)
+                            .fill(visibleOverdueTasks.isEmpty || calmMode ? Color.blue : Color.red)
                     )
                     .layoutPriority(1)
             }


### PR DESCRIPTION
Closes #68.

A Settings → Tasks toggle, **off by default**. When on, mDone stops singling out overdue tasks — they appear like any other task in the app and widgets ("no-stress" / Things 3 style). Off = byte-for-byte today's behaviour.

### What changes when on
- **Row:** overdue due-date renders neutral, not red (`TaskRow`).
- **Lists:** the dedicated "Overdue" section folds into **Today** (`TaskListScreen` iOS + `MacTaskListView`). Per the decision, overdue tasks land in Today.
- **Mac sidebar:** the red overdue count badge is hidden (the item itself stays).
- **Widgets:** the Today widget's red overdue box/count and the lock-screen red tint go neutral (`TodayTasksWidget`, `LockScreenWidgets`). The per-widget "Today + Overdue" filter is **not** overridden — that's the user's explicit choice; Calm Mode only removes the highlight.

### Kept deliberately
- The explicit "Overdue" filter in the filter sheet.
- The spoken "overdue" VoiceOver label (it's factually true).

### How it reaches widgets
`@AppStorage("calmMode")` in the app, mirrored to the App Group (`SharedKeys.calmModeKey`) on change, with `WidgetCenter.reloadAllTimelines()`. `isOverdue` stays the single source of truth; only presentation is gated.

### Testing
- iOS + macOS build clean.
- Unit suite passes (the one red test is the credential-gated screenshot UITest, pre-existing/unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)