### PR TITLE
Fix widget header pushed off the top when tasks overflow (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Settings → Tasks → "Calm Mode" (off by default). When on, overdue tasks aren't singled out: no red due dates, no separate "Overdue" list or counts, and no red highlight in the widgets. Overdue tasks simply appear in Today alongside everything else, in the app and on widgets (#68).
 
+### Fixed
+- Home screen widgets no longer push their header off the top when there are several tasks. The "Today"/"Upcoming" header now stays pinned at the top and any tasks beyond what fits are summarised by the "+N more" line at the bottom (#99).
+
 ## [1.5.0] - 2026-06-01
 
 ### Added

--- a/mDoneWidgets/TodayTasksWidget.swift
+++ b/mDoneWidgets/TodayTasksWidget.swift
@@ -109,8 +109,8 @@ struct TodayTasksWidgetView: View {
         case (.systemSmall, .compact): 3
         case (.systemSmall, .standard): 2
         case (.systemSmall, .large): 2
-        case (.systemMedium, .compact): 4
-        case (.systemMedium, .standard): 3
+        case (.systemMedium, .compact): 3
+        case (.systemMedium, .standard): 2
         case (.systemMedium, .large): 2
         case (.systemLarge, .compact): 9
         case (.systemLarge, .standard): 7
@@ -146,6 +146,11 @@ struct TodayTasksWidgetView: View {
                         taskListView
                     }
                 }
+                // Pin content to the top so the header always stays put. If the
+                // task rows ever exceed the widget height, the overflow is
+                // clipped from the bottom (where "+N more" already lives) rather
+                // than centring the stack and pushing the header off the top.
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             }
         }
         .dynamicTypeSize(...DynamicTypeSize.xLarge)

--- a/mDoneWidgets/UpcomingWidget.swift
+++ b/mDoneWidgets/UpcomingWidget.swift
@@ -91,8 +91,8 @@ struct UpcomingWidgetView: View {
         case (.systemSmall, .compact): 3
         case (.systemSmall, .standard): 2
         case (.systemSmall, .large): 2
-        case (.systemMedium, .compact): 4
-        case (.systemMedium, .standard): 3
+        case (.systemMedium, .compact): 3
+        case (.systemMedium, .standard): 2
         case (.systemMedium, .large): 2
         case (.systemLarge, .compact): 9
         case (.systemLarge, .standard): 7
@@ -118,6 +118,10 @@ struct UpcomingWidgetView: View {
                         taskListView
                     }
                 }
+                // Pin content to the top so the header always stays put; any row
+                // overflow clips from the bottom rather than centring the stack
+                // and pushing the header off the top of the widget.
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             }
         }
         .dynamicTypeSize(...DynamicTypeSize.xLarge)


### PR DESCRIPTION
Fixes #99.

## Problem
On the home-screen widgets, when there are more than a few tasks (the user reported this on the single-height, full-width / `systemMedium` size), the **"Today (#)" header creeps off the top of the widget**. This was first noted in #66 and re-reported in #99.

## Root cause
The authenticated content was a plain `VStack(alignment: .leading)` of `header + taskList` with no top alignment on the widget container. When the rendered rows exceed the widget height (easy on a medium widget once tasks carry due-time subtitles), WidgetKit centres the oversized stack vertically, so the top — the header — gets clipped off.

The `maxRows` cap and the `"+N more"` overflow indicator already existed (from #75), but nothing guaranteed the header stayed pinned, and the medium row caps were high enough to overflow.

## Fix
- Pin the authenticated content with `.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)` on both `TodayTasksWidgetView` and `UpcomingWidgetView`. The header is now always anchored at the top; any overflow clips from the **bottom**, where the existing `"+N more"` line summarises the remainder — matching exactly what the issue asked for ("header should remain in a fixed position with task items appearing below … +N to indicate there are more tasks").
- Trim the medium row caps (`compact` 4→3, `standard` 3→2) on both widgets so rows + the `"+N more"` line fit without overflowing in the first place.

## Verification
- `xcodebuild` iOS scheme (app + widget extension): **BUILD SUCCEEDED**.
- SwiftLint: no new warnings on the changed files.
- CHANGELOG updated under `[Unreleased] → Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)