### PR TITLE
Fix widget overflow pushing the Today header off the top (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Settings → Tasks → "Calm Mode" (off by default). When on, overdue tasks aren't singled out: no red due dates, no separate "Overdue" list or counts, and no red highlight in the widgets. Overdue tasks simply appear in Today alongside everything else, in the app and on widgets (#68).
 
+### Fixed
+- Widget: the Today's Tasks and Upcoming widgets no longer let the "Today" header drift off the top (or clip the bottom rows) when there are more tasks than fit. This was most noticeable with larger text sizes. The header now stays pinned in place, the visible rows always fit the widget, and a "+N more" count fills the last line (#99).
+
 ## [1.5.0] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Settings → Tasks → "Calm Mode" (off by default). When on, overdue tasks aren't singled out: no red due dates, no separate "Overdue" list or counts, and no red highlight in the widgets. Overdue tasks simply appear in Today alongside everything else, in the app and on widgets (#68).
 
 ### Fixed
-- Widget: the Today's Tasks and Upcoming widgets no longer let the "Today" header drift off the top (or clip the bottom rows) when there are more tasks than fit. This was most noticeable with larger text sizes. The header now stays pinned in place, the visible rows always fit the widget, and a "+N more" count fills the last line (#99).
+- Widget: the Today's Tasks and Upcoming widgets no longer let their header drift off the top (or clip the bottom rows) when there are more tasks than fit. This was most noticeable with larger text sizes. The header now stays pinned in place, the visible rows always fit the widget, and a "+N more" count fills the last line (#99).
 
 ## [1.5.0] - 2026-06-01
 

--- a/mDoneWidgets/TodayTasksWidget.swift
+++ b/mDoneWidgets/TodayTasksWidget.swift
@@ -146,6 +146,10 @@ struct TodayTasksWidgetView: View {
                         taskListView
                     }
                 }
+                // Pin to the top so that if the rows ever exceed the canvas the
+                // overflow spills off the bottom (where the "+N more" hint lives)
+                // instead of centering and pushing the header off the top (#99).
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
         }
         .dynamicTypeSize(...DynamicTypeSize.xLarge)
@@ -197,11 +201,16 @@ struct TodayTasksWidgetView: View {
 
     private var taskListView: some View {
         VStack(alignment: .leading, spacing: 0) {
+            let totalAvailable = visibleOverdueTasks.count + visibleTodayTasks.count
+            // Reserve one line for the "+N more" footer when not everything fits,
+            // so the footer never pushes the list one row past maxRows and over
+            // the edge of the widget (#99).
+            let rowBudget = totalAvailable > maxRows ? max(maxRows - 1, 1) : maxRows
             // When only one bucket is shown (overdue-only or today-only), let it
             // claim all available rows instead of capping at maxOverdueRows.
-            let overdueCap = visibleTodayTasks.isEmpty ? maxRows : maxOverdueRows
+            let overdueCap = visibleTodayTasks.isEmpty ? rowBudget : maxOverdueRows
             let overdueLimit = min(visibleOverdueTasks.count, overdueCap)
-            let todayLimit = max(maxRows - overdueLimit, 0)
+            let todayLimit = max(rowBudget - overdueLimit, 0)
             let visibleOverdue = Array(visibleOverdueTasks.prefix(overdueLimit))
             let visibleToday = Array(visibleTodayTasks.prefix(todayLimit))
 
@@ -221,7 +230,6 @@ struct TodayTasksWidgetView: View {
             }
 
             let totalShown = visibleOverdue.count + visibleToday.count
-            let totalAvailable = visibleOverdueTasks.count + visibleTodayTasks.count
             if totalAvailable > totalShown {
                 Text("+\(totalAvailable - totalShown) more")
                     .font(.caption2)

--- a/mDoneWidgets/UpcomingWidget.swift
+++ b/mDoneWidgets/UpcomingWidget.swift
@@ -118,6 +118,9 @@ struct UpcomingWidgetView: View {
                         taskListView
                     }
                 }
+                // Pin to the top so overflow spills off the bottom rather than
+                // centering and pushing the header off the top (#99).
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
         }
         .dynamicTypeSize(...DynamicTypeSize.xLarge)
@@ -158,7 +161,11 @@ struct UpcomingWidgetView: View {
 
     private var taskListView: some View {
         VStack(alignment: .leading, spacing: 0) {
-            let visibleTasks = Array(entry.tasks.prefix(maxRows))
+            // Reserve one line for the "+N more" footer when not everything fits,
+            // so the footer never pushes the list past maxRows and over the edge
+            // of the widget (#99).
+            let rowBudget = entry.tasks.count > maxRows ? max(maxRows - 1, 1) : maxRows
+            let visibleTasks = Array(entry.tasks.prefix(rowBudget))
             ForEach(visibleTasks) { task in
                 taskRow(task: task)
             }


### PR DESCRIPTION
## Summary

The medium **Today's Tasks** and **Upcoming** widgets could let the header drift off the top of the widget once there were more tasks than fit, which is what #99 reports. It was most noticeable with larger text sizes.

Two causes, both in the widget list layout:

1. The "+N more" footer was drawn as an **extra line beyond `maxRows`**, so the content was one line taller than the tuned row budget exactly when there were more tasks than fit (the reporter's "more than 3 tasks").
2. The content stack was **not pinned to the top**, so when it overflowed WidgetKit centered it and the header slid off the top edge.

The earlier #66 work (the per-size `maxRows` table + Dynamic Type cap) narrowed the odds but never closed the hole, which is why it resurfaced.

## Before / after

The real `TodayTasksWidgetView`, rendered at a standard iPhone medium-widget size (338x158) with **Larger Text (xLarge)** and 5 tasks due:

![Issue 99 before and after](https://raw.githubusercontent.com/marco308/mdone/issue-99-assets/issue-99-before-after.png)

- **Before (1.5.0):** the "Today" header is sliced off the top and "+2 more" is clipped at the bottom (oversized content gets centered, so it bleeds off both edges).
- **After (this PR):** the header is pinned at the top, the rows fit, and "+3 more" sits cleanly on the last line.

<details>
<summary>Full-size individual frames</summary>

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/marco308/mdone/issue-99-assets/issue-99-before.png) | ![after](https://raw.githubusercontent.com/marco308/mdone/issue-99-assets/issue-99-after.png) |

</details>

## The fix

- Reserve a row for the "+N more" footer so the total number of lines never exceeds `maxRows`.
- Pin the content stack with `.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)` so any residual overflow spills off the bottom instead of pushing the header off the top.

Applied to both `TodayTasksWidget` and `UpcomingWidget` (they share the same list/footer pattern).

## Testing

- Built the widget extension for the simulator: `xcodebuild -scheme mDoneWidgets -sdk iphonesimulator` succeeds.
- Rendered the real widget views via `ImageRenderer` at 338x158 with xLarge Dynamic Type to produce the before/after above. Before clips the header; after keeps it pinned with the rows fitting.

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)
