### PR TITLE
Update Buy Me a Coffee link to marcuslab

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 github: marco308
-buy_me_a_coffee: losperdidos
+buy_me_a_coffee: marcuslab

--- a/mDone/Views/Settings/AboutScreen.swift
+++ b/mDone/Views/Settings/AboutScreen.swift
@@ -9,7 +9,7 @@ struct AboutScreen: View {
     private static let repoURL = URL(string: "https://github.com/marco308/mdone")!
     private static let issuesURL = URL(string: "https://github.com/marco308/mdone/issues/new/choose")!
     private static let sponsorURL = URL(string: "https://github.com/sponsors/marco308")!
-    private static let coffeeURL = URL(string: "https://www.buymeacoffee.com/losperdidos")!
+    private static let coffeeURL = URL(string: "https://buymeacoffee.com/marcuslab")!
 
     var body: some View {
         NavigationStack {

--- a/website/index.html
+++ b/website/index.html
@@ -645,7 +645,7 @@ footer{ background:var(--bg-2); border-top:1px solid var(--line); padding:56px 0
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21s-7-4.35-9.5-8.5C1 9.5 2.5 6 6 6c2 0 3 1.2 4 2.5C11 7.2 12 6 14 6c3.5 0 5 3.5 3.5 6.5C19 16.65 12 21 12 21z"/></svg>
           Sponsor on GitHub
         </a>
-        <a class="btn btn-ghost" href="https://www.buymeacoffee.com/losperdidos">
+        <a class="btn btn-ghost" href="https://buymeacoffee.com/marcuslab">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M5 8h11v5a4 4 0 01-4 4H9a4 4 0 01-4-4V8z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/><path d="M16 9h2.5a2.5 2.5 0 010 5H16" stroke="currentColor" stroke-width="2"/><path d="M7 3c0 1-1 1.5-1 2.5M11 3c0 1-1 1.5-1 2.5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
           Buy me a coffee
         </a>
@@ -703,7 +703,7 @@ footer{ background:var(--bg-2); border-top:1px solid var(--line); padding:56px 0
         <div class="foot-col">
           <h4>Support</h4>
           <a href="https://github.com/sponsors/marco308">GitHub Sponsors</a>
-          <a href="https://www.buymeacoffee.com/losperdidos">Buy me a coffee</a>
+          <a href="https://buymeacoffee.com/marcuslab">Buy me a coffee</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Updates the **Buy Me a Coffee** handle from `losperdidos` to **`marcuslab`** (https://buymeacoffee.com/marcuslab) everywhere it appears:

- **App:** `mDone/Views/Settings/AboutScreen.swift` (Settings → About mDone → "Buy Me a Coffee").
- **GitHub sponsorship:** `.github/FUNDING.yml` `buy_me_a_coffee:` (the repo Sponsor button updates once this merges to `main`).
- **Marketing site:** the two donate links in `website/index.html` (support section + footer), so they don't keep pointing at the old account.

No `losperdidos` references remain. The `docs/*.marcuslab.uk` test-server domain is unrelated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
