### PR TITLE
Add OpenID Connect (OIDC) support for self-hosted servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- OpenID Connect (OIDC) authentication support. The app now dynamically detects OIDC availability on your self-hosted server, lists active providers, and allows secure authentication via an in-app browser sheet.
 - Settings → Tasks → "Calm Mode" (off by default). When on, overdue tasks aren't singled out: no red due dates, no separate "Overdue" list or counts, and no red highlight in the widgets. Overdue tasks simply appear in Today alongside everything else, in the app and on widgets (#68).
+
 
 ### Fixed
 - Widget: the Today's Tasks and Upcoming widgets no longer let their header drift off the top (or clip the bottom rows) when there are more tasks than fit. This was most noticeable with larger text sizes. The header now stays pinned in place, the visible rows always fit the widget, and a "+N more" count fills the last line (#99).

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -302,6 +302,45 @@ final class AppState {
         print("[mDone] Validation OK - got \(projects.count) projects")
         #endif
 
+        authService.saveToken(loginResponse.token)
+        if let capturedRefreshToken {
+            authService.saveRefreshToken(capturedRefreshToken)
+        }
+        isAuthenticated = true
+    }
+
+    @MainActor
+    func loginWithOIDC(serverURL: String, providerKey: String, code: String, redirectURL: String) async throws {
+        #if DEBUG
+        print("[mDone] loginWithOIDC() called")
+        #endif
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        await registerAPIClientHandlers()
+        let url = serverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        await APIClient.shared.configure(serverURL: url, token: "")
+
+        let callbackRequest = OIDCCallbackRequest(code: code, redirectUrl: redirectURL)
+        let endpoint = Endpoint(path: "/api/v1/auth/openid/\(providerKey)/callback", method: .POST)
+        let loginResponse: LoginResponse = try await APIClient.shared.send(endpoint, body: callbackRequest)
+        let capturedRefreshToken = await APIClient.shared.currentRefreshToken()
+
+        // Configure with the JWT token + refresh cookie so subsequent requests
+        // (and the 401 retry path) have everything they need.
+        await APIClient.shared.configure(
+            serverURL: url,
+            token: loginResponse.token,
+            refreshToken: capturedRefreshToken
+        )
+
+        // Validate
+        let projects: [Project] = try await APIClient.shared.fetch(Endpoint.projects())
+        #if DEBUG
+        print("[mDone] OIDC Validation OK - got \(projects.count) projects")
+        #endif
+
         authService.saveServerURL(url)
         authService.saveToken(loginResponse.token)
         if let capturedRefreshToken {
@@ -309,6 +348,7 @@ final class AppState {
         }
         isAuthenticated = true
     }
+
 
     @MainActor
     func logout() async {

--- a/mDone/Models/APIModels.swift
+++ b/mDone/Models/APIModels.swift
@@ -143,3 +143,37 @@ struct PaginationInfo {
     var totalPages: Int
     var resultCount: Int
 }
+
+// MARK: - OIDC & Server Info Models
+
+struct InfoResponse: Codable {
+    struct Auth: Codable {
+        struct OpenID: Codable {
+            struct Provider: Codable, Identifiable {
+                var id: String { key }
+                var name: String
+                var key: String
+                var authUrl: String
+                var logoutUrl: String?
+                var clientId: String
+                var scope: String?
+            }
+            var enabled: Bool
+            var providers: [Provider]?
+        }
+        struct Local: Codable {
+            var enabled: Bool
+        }
+        var local: Local?
+        var openidConnect: OpenID?
+    }
+    var auth: Auth?
+}
+
+struct OIDCCallbackRequest: Encodable {
+    var code: String
+    var redirectUrl: String
+    var scope: String?
+    var totpPasscode: String?
+}
+

--- a/mDone/Services/APIClient.swift
+++ b/mDone/Services/APIClient.swift
@@ -1,8 +1,9 @@
 import Foundation
 
 actor APIClient {
-    private let session: URLSession
+    private var session: URLSession
     private let decoder: JSONDecoder
+
     private let encoder: JSONEncoder
     private var serverURL: String?
     private var apiToken: String?
@@ -76,6 +77,13 @@ actor APIClient {
         refreshToken = nil
         isJWTSession = false
     }
+
+    #if DEBUG
+    func setSessionForTesting(_ session: URLSession) {
+        self.session = session
+    }
+    #endif
+
 
     func setOnTokensUpdated(_ handler: @Sendable @escaping (_ token: String, _ refreshToken: String?) -> Void) {
         onTokensUpdated = handler
@@ -519,4 +527,42 @@ actor APIClient {
         let (data, httpResponse) = try await executeWithRefresh { try self.buildRequest(for: endpoint) }
         _ = try handleResponse(data: data, httpResponse: httpResponse)
     }
+
+    func fetchServerInfo(from urlString: String) async throws -> InfoResponse {
+        var cleanURL = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !cleanURL.hasPrefix("http://") && !cleanURL.hasPrefix("https://") {
+            cleanURL = "https://" + cleanURL
+        }
+        cleanURL = cleanURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        guard let url = URL(string: cleanURL + "/api/v1/info") else {
+            throw NetworkError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw NetworkError.serverUnreachable
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.unknown(URLError(.badServerResponse))
+        }
+
+        guard (200 ... 299).contains(httpResponse.statusCode) else {
+            throw NetworkError.serverError(statusCode: httpResponse.statusCode, message: nil)
+        }
+
+        do {
+            return try decoder.decode(InfoResponse.self, from: data)
+        } catch {
+            throw NetworkError.decodingError(error)
+        }
+    }
 }
+

--- a/mDone/Views/Setup/OIDCWebView.swift
+++ b/mDone/Views/Setup/OIDCWebView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import WebKit
+
+#if os(iOS)
+import UIKit
+typealias PlatformViewRepresentable = UIViewRepresentable
+#elseif os(macOS)
+import AppKit
+typealias PlatformViewRepresentable = NSViewRepresentable
+#endif
+
+struct OIDCWebView: PlatformViewRepresentable {
+    let url: URL
+    let redirectURI: String
+    let onCallback: (String) -> Void
+    let onCancel: () -> Void
+
+    #if os(iOS)
+    func makeUIView(context: Context) -> WKWebView {
+        makeWebView(context: context)
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+    #elseif os(macOS)
+    func makeNSView(context: Context) -> WKWebView {
+        makeWebView(context: context)
+    }
+
+    func updateNSView(_ nsView: WKWebView, context: Context) {}
+    #endif
+
+    private func makeWebView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        
+        #if os(iOS)
+        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        #elseif os(macOS)
+        webView.autoresizesSubviews = true
+        webView.autoresizingMask = [.width, .height]
+        #endif
+
+        #if DEBUG
+        print("[mDone] WebView initiating load for: \(self.url.absoluteString)")
+        #endif
+        
+        let request = URLRequest(url: self.url)
+        webView.load(request)
+        
+        return webView
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+        var parent: OIDCWebView
+
+        init(_ parent: OIDCWebView) {
+            self.parent = parent
+        }
+
+        func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            if let url = navigationAction.request.url {
+                #if DEBUG
+                print("[mDone] WebView navigating to: \(url.absoluteString)")
+                #endif
+
+                if url.absoluteString.hasPrefix(parent.redirectURI) {
+                    if let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+                       let queryItems = components.queryItems,
+                       let code = queryItems.first(where: { $0.name == "code" })?.value {
+                        #if DEBUG
+                        print("[mDone] Intercepted OAuth code: \(code)")
+                        #endif
+                        parent.onCallback(code)
+                        decisionHandler(.cancel)
+                        return
+                    }
+                }
+            }
+            decisionHandler(.allow)
+        }
+
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+            #if DEBUG
+            print("[mDone] WebView didStartProvisionalNavigation: \(webView.url?.absoluteString ?? "no URL")")
+            #endif
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            #if DEBUG
+            print("[mDone] WebView didFinish: \(webView.url?.absoluteString ?? "no URL")")
+            #endif
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            #if DEBUG
+            print("[mDone] WebView didFail: \(error.localizedDescription)")
+            #endif
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            #if DEBUG
+            print("[mDone] WebView didFailProvisionalNavigation: \(error.localizedDescription)")
+            #endif
+        }
+    }
+}

--- a/mDone/Views/Setup/ServerSetupView.swift
+++ b/mDone/Views/Setup/ServerSetupView.swift
@@ -1,5 +1,12 @@
 import SwiftUI
 
+struct OIDCLoginSession: Identifiable {
+    let id = UUID()
+    let authURL: URL
+    let redirectURI: String
+    let providerKey: String
+}
+
 struct ServerSetupView: View {
     @Environment(AppState.self) private var appState
     // When the session expires we keep the server URL in AuthService so the
@@ -11,8 +18,18 @@ struct ServerSetupView: View {
     @State private var isConnecting = false
     @State private var errorMessage: String?
     @State private var authMode: AuthMode = .credentials
+    @State private var oidcProviders: [InfoResponse.Auth.OpenID.Provider] = []
+    @State private var isLocalAuthEnabled = true
+    @State private var oidcSession: OIDCLoginSession? = nil
+    @State private var oidcRedirectURI = ""
+    @State private var selectedProviderKey = ""
+    @State private var checkTask: Task<Void, Never>? = nil
+    @State private var isCheckingServer = false
+    @FocusState private var isServerURLFocused: Bool
+
 
     @ScaledMetric(relativeTo: .largeTitle) private var logoSize: CGFloat = 64
+
 
     enum AuthMode: String, CaseIterable {
         case credentials = "Login"
@@ -48,16 +65,29 @@ struct ServerSetupView: View {
                                 .foregroundStyle(.secondary)
                                 .textCase(.uppercase)
 
-                            TextField("https://vikunja.example.com", text: $serverURL)
-                                .textFieldStyle(.roundedBorder)
-                            #if os(iOS)
-                                .textContentType(.URL)
-                            #endif
-                                .autocorrectionDisabled()
-                            #if os(iOS)
-                                .textInputAutocapitalization(.never)
-                                .keyboardType(.URL)
-                            #endif
+                             ZStack(alignment: .trailing) {
+                                 TextField("https://vikunja.example.com", text: $serverURL)
+                                     .textFieldStyle(.roundedBorder)
+                                     .focused($isServerURLFocused)
+                                     .onSubmit {
+                                         checkServerImmediately(serverURL)
+                                     }
+                                 #if os(iOS)
+                                     .textContentType(.URL)
+                                 #endif
+                                     .autocorrectionDisabled()
+                                 #if os(iOS)
+                                     .textInputAutocapitalization(.never)
+                                     .keyboardType(.URL)
+                                 #endif
+
+                                 if isCheckingServer {
+                                     ProgressView()
+                                         .controlSize(.small)
+                                         .padding(.trailing, 8)
+                                 }
+                             }
+
                         }
 
                         Picker("Auth Method", selection: $authMode) {
@@ -68,32 +98,34 @@ struct ServerSetupView: View {
                         .pickerStyle(.segmented)
 
                         if authMode == .credentials {
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text("Username")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                    .textCase(.uppercase)
+                            if isLocalAuthEnabled {
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text("Username")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .textCase(.uppercase)
 
-                                TextField("Username", text: $username)
-                                    .textFieldStyle(.roundedBorder)
-                                #if os(iOS)
-                                    .textContentType(.username)
-                                    .textInputAutocapitalization(.never)
-                                #endif
-                                    .autocorrectionDisabled()
-                            }
+                                    TextField("Username", text: $username)
+                                        .textFieldStyle(.roundedBorder)
+                                    #if os(iOS)
+                                        .textContentType(.username)
+                                        .textInputAutocapitalization(.never)
+                                    #endif
+                                        .autocorrectionDisabled()
+                                }
 
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text("Password")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                    .textCase(.uppercase)
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text("Password")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .textCase(.uppercase)
 
-                                SecureField("Password", text: $password)
-                                    .textFieldStyle(.roundedBorder)
-                                #if os(iOS)
-                                    .textContentType(.password)
-                                #endif
+                                    SecureField("Password", text: $password)
+                                        .textFieldStyle(.roundedBorder)
+                                    #if os(iOS)
+                                        .textContentType(.password)
+                                    #endif
+                                }
                             }
                         } else {
                             VStack(alignment: .leading, spacing: 6) {
@@ -124,31 +156,35 @@ struct ServerSetupView: View {
                             .padding(.horizontal)
                     }
 
-                    Button {
-                        connect()
-                    } label: {
-                        Group {
-                            if isConnecting {
-                                ProgressView()
-                                    .tint(.white)
-                            } else {
-                                Text("Connect")
-                                    .fontWeight(.semibold)
+                    if authMode != .credentials || isLocalAuthEnabled {
+                        Button {
+                            connect()
+                        } label: {
+                            Group {
+                                if isConnecting {
+                                    ProgressView()
+                                        .tint(.white)
+                                } else {
+                                    Text("Connect")
+                                        .fontWeight(.semibold)
+                                }
                             }
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 44)
                         }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 44)
+                        .buttonStyle(.borderedProminent)
+                        .disabled(isFormIncomplete || isConnecting)
+                        .padding(.horizontal)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(isFormIncomplete || isConnecting)
-                    .padding(.horizontal)
 
                     if authMode == .credentials {
-                        Text("Login with your Vikunja username and password for full functionality")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal, 32)
+                        if isLocalAuthEnabled {
+                            Text("Login with your Vikunja username and password for full functionality")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal, 32)
+                        }
                     } else {
                         Text(
                             "API tokens have limited permissions. Use Login for full functionality including task reordering."
@@ -159,13 +195,92 @@ struct ServerSetupView: View {
                         .padding(.horizontal, 32)
                     }
 
+                    if !oidcProviders.isEmpty {
+                        VStack(spacing: 12) {
+                            if isLocalAuthEnabled || authMode == .apiToken {
+                                HStack {
+                                    Rectangle()
+                                        .fill(Color.secondary.opacity(0.3))
+                                        .frame(height: 1)
+                                    Text("or sign in with")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                    Rectangle()
+                                        .fill(Color.secondary.opacity(0.3))
+                                        .frame(height: 1)
+                                }
+                                .padding(.vertical, 8)
+                            }
+
+                            ForEach(oidcProviders) { provider in
+                                Button {
+                                    startOIDCLogin(provider: provider)
+                                } label: {
+                                    HStack(spacing: 12) {
+                                        Image(systemName: "lock.circle.fill")
+                                            .font(.title3)
+                                        Text("Sign in with \(provider.name)")
+                                            .fontWeight(.semibold)
+                                    }
+                                    .frame(maxWidth: .infinity)
+                                    .frame(height: 44)
+                                }
+                                .buttonStyle(.bordered)
+                                .tint(.accentColor)
+                            }
+                        }
+                        .padding(.horizontal)
+                    }
+
                     Spacer()
+
                 }
             }
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif
+            .onAppear {
+                if !serverURL.isEmpty {
+                    checkServerImmediately(serverURL)
+                }
+            }
+            .onChange(of: serverURL) { _, newValue in
+                checkServerDebounced(newValue)
+            }
+            .onChange(of: isServerURLFocused) { _, isFocused in
+                if !isFocused && !serverURL.isEmpty {
+                    checkServerImmediately(serverURL)
+                }
+            }
+
+            .sheet(item: $oidcSession) { session in
+                NavigationStack {
+                    OIDCWebView(
+                        url: session.authURL,
+                        redirectURI: session.redirectURI,
+                        onCallback: { code in
+                            oidcSession = nil
+                            handleOIDCCallback(code: code)
+                        },
+                        onCancel: {
+                            oidcSession = nil
+                        }
+                    )
+                    #if os(iOS)
+                    .navigationTitle("Sign In")
+                    .navigationBarTitleDisplayMode(.inline)
+                    #endif
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") {
+                                oidcSession = nil
+                            }
+                        }
+                    }
+                }
+            }
         }
+
     }
 
     private var isFormIncomplete: Bool {
@@ -207,4 +322,232 @@ struct ServerSetupView: View {
             isConnecting = false
         }
     }
+
+    private func isValidServerURL(_ urlString: String) -> Bool {
+        #if DEBUG
+        print("[mDone] isValidServerURL checking: '\(urlString)'")
+        #endif
+        var clean = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !clean.hasPrefix("http://") && !clean.hasPrefix("https://") {
+            clean = "https://" + clean
+        }
+        guard let url = URL(string: clean),
+              let host = url.host,
+              !host.isEmpty else {
+            #if DEBUG
+            print("[mDone] isValidServerURL: URL or host is empty/nil")
+            #endif
+            return false
+        }
+        
+        // Allow localhost or loopback IP
+        if host == "localhost" || host == "127.0.0.1" {
+            #if DEBUG
+            print("[mDone] isValidServerURL: Valid localhost/loopback!")
+            #endif
+            return true
+        }
+        
+        let parts = host.split(separator: ".")
+        
+        // Allow IPv4 addresses (e.g. 192.168.1.100)
+        if parts.count == 4, parts.allSatisfy({ Int($0) != nil }) {
+            #if DEBUG
+            print("[mDone] isValidServerURL: Valid IPv4 address!")
+            #endif
+            return true
+        }
+        
+        guard parts.count >= 2,
+              let lastPart = parts.last,
+              lastPart.count >= 2 else {
+            #if DEBUG
+            print("[mDone] isValidServerURL: Host parts count < 2 or lastPart < 2. Parts: \(parts)")
+            #endif
+            return false
+        }
+        
+        #if DEBUG
+        print("[mDone] isValidServerURL: Valid URL!")
+        #endif
+        return true
+    }
+
+    private func checkServerDebounced(_ url: String) {
+        #if DEBUG
+        print("[mDone] checkServerDebounced called for: '\(url)'")
+        #endif
+        checkTask?.cancel()
+        guard isValidServerURL(url) else {
+            #if DEBUG
+            print("[mDone] checkServerDebounced: Invalid URL format, clearing providers")
+            #endif
+            self.oidcProviders = []
+            self.isLocalAuthEnabled = true
+            return
+        }
+
+        checkTask = Task {
+            #if DEBUG
+            print("[mDone] checkServerDebounced task started, sleeping for 2s")
+            #endif
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard !Task.isCancelled else {
+                #if DEBUG
+                print("[mDone] checkServerDebounced task cancelled during sleep")
+                #endif
+                return
+            }
+
+            isCheckingServer = true
+            defer { isCheckingServer = false }
+
+            #if DEBUG
+            print("[mDone] checkServerDebounced sending request to info endpoint")
+            #endif
+            do {
+                let info = try await APIClient.shared.fetchServerInfo(from: url)
+                guard !Task.isCancelled else { return }
+                
+                if let local = info.auth?.local {
+                    self.isLocalAuthEnabled = local.enabled
+                } else {
+                    self.isLocalAuthEnabled = true
+                }
+                
+                if let openid = info.auth?.openidConnect, openid.enabled {
+                    self.oidcProviders = openid.providers ?? []
+                    #if DEBUG
+                    print("[mDone] checkServerDebounced success! Enabled: \(openid.enabled), Providers: \(self.oidcProviders), Local Auth: \(self.isLocalAuthEnabled)")
+                    #endif
+                } else {
+                    self.oidcProviders = []
+                    #if DEBUG
+                    print("[mDone] checkServerDebounced success but OIDC is disabled, Local Auth: \(self.isLocalAuthEnabled)")
+                    #endif
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                #if DEBUG
+                print("[mDone] Error checking server for OIDC/Local: \(error)")
+                #endif
+                self.oidcProviders = []
+                self.isLocalAuthEnabled = true
+            }
+        }
+    }
+
+    private func checkServerImmediately(_ url: String) {
+        #if DEBUG
+        print("[mDone] checkServerImmediately called for: '\(url)'")
+        #endif
+        checkTask?.cancel()
+        guard isValidServerURL(url) else {
+            #if DEBUG
+            print("[mDone] checkServerImmediately: Invalid URL format, clearing providers")
+            #endif
+            self.oidcProviders = []
+            self.isLocalAuthEnabled = true
+            return
+        }
+
+        checkTask = Task {
+            isCheckingServer = true
+            defer { isCheckingServer = false }
+
+            #if DEBUG
+            print("[mDone] checkServerImmediately sending request to info endpoint")
+            #endif
+            do {
+                let info = try await APIClient.shared.fetchServerInfo(from: url)
+                guard !Task.isCancelled else { return }
+                
+                if let local = info.auth?.local {
+                    self.isLocalAuthEnabled = local.enabled
+                } else {
+                    self.isLocalAuthEnabled = true
+                }
+                
+                if let openid = info.auth?.openidConnect, openid.enabled {
+                    self.oidcProviders = openid.providers ?? []
+                    #if DEBUG
+                    print("[mDone] checkServerImmediately success! Enabled: \(openid.enabled), Providers: \(self.oidcProviders), Local Auth: \(self.isLocalAuthEnabled)")
+                    #endif
+                } else {
+                    self.oidcProviders = []
+                    #if DEBUG
+                    print("[mDone] checkServerImmediately success but OIDC is disabled, Local Auth: \(self.isLocalAuthEnabled)")
+                    #endif
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                #if DEBUG
+                print("[mDone] Error checking server for OIDC/Local: \(error)")
+                #endif
+                self.oidcProviders = []
+                self.isLocalAuthEnabled = true
+            }
+        }
+    }
+
+
+
+
+    private func startOIDCLogin(provider: InfoResponse.Auth.OpenID.Provider) {
+        var cleanURL = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !cleanURL.hasPrefix("http://"), !cleanURL.hasPrefix("https://") {
+            cleanURL = "https://" + cleanURL
+        }
+        cleanURL = cleanURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        let redirectURI = "\(cleanURL)/auth/openid/\(provider.key)"
+        self.oidcRedirectURI = redirectURI
+        self.selectedProviderKey = provider.key
+
+        var components = URLComponents(string: provider.authUrl)
+        components?.queryItems = [
+            URLQueryItem(name: "client_id", value: provider.clientId),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope", value: provider.scope ?? "openid profile email"),
+            URLQueryItem(name: "state", value: UUID().uuidString.lowercased())
+        ]
+
+        if let finalURL = components?.url {
+            self.oidcSession = OIDCLoginSession(
+                authURL: finalURL,
+                redirectURI: redirectURI,
+                providerKey: provider.key
+            )
+        }
+    }
+
+    private func handleOIDCCallback(code: String) {
+        isConnecting = true
+        errorMessage = nil
+
+        var cleanURL = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !cleanURL.hasPrefix("http://"), !cleanURL.hasPrefix("https://") {
+            cleanURL = "https://" + cleanURL
+        }
+        cleanURL = cleanURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        Task {
+            do {
+                try await appState.loginWithOIDC(
+                    serverURL: cleanURL,
+                    providerKey: selectedProviderKey,
+                    code: code,
+                    redirectURL: oidcRedirectURI
+                )
+            } catch {
+                #if DEBUG
+                print("[mDone] OIDC Login error: \(error)")
+                #endif
+                errorMessage = error.localizedDescription
+            }
+            isConnecting = false
+        }
+    }
 }
+

--- a/mDoneTests/APIClientTests.swift
+++ b/mDoneTests/APIClientTests.swift
@@ -811,4 +811,65 @@ final class APIClientTests: XCTestCase {
             XCTFail("Unexpected error type: \(error)")
         }
     }
+
+    // MARK: - OIDC / fetchServerInfo() Tests
+
+    func testFetchServerInfoSucceeds() async throws {
+        let client = makeTestClient()
+        let infoJSON = """
+        {
+            "auth": {
+                "openid_connect": {
+                    "enabled": true,
+                    "providers": [
+                        {
+                            "name": "Keycloak",
+                            "key": "keycloak",
+                            "auth_url": "https://sso.example.com/auth",
+                            "client_id": "client123",
+                            "scope": "openid email"
+                        }
+                    ]
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://mock.vikunja.io/api/v1/info")
+            let response = MockURLProtocol.makeResponse(statusCode: 200, url: request.url)
+            return (response, infoJSON)
+        }
+
+        let info = try await client.fetchServerInfo(from: "mock.vikunja.io")
+        XCTAssertTrue(info.auth?.openidConnect?.enabled ?? false)
+        XCTAssertEqual(info.auth?.openidConnect?.providers?.count, 1)
+        let provider = info.auth?.openidConnect?.providers?.first
+        XCTAssertEqual(provider?.name, "Keycloak")
+        XCTAssertEqual(provider?.key, "keycloak")
+        XCTAssertEqual(provider?.authUrl, "https://sso.example.com/auth")
+        XCTAssertEqual(provider?.clientId, "client123")
+        XCTAssertEqual(provider?.scope, "openid email")
+    }
+
+    func testFetchServerInfoFailsWithUnreachable() async {
+        let client = makeTestClient()
+        MockURLProtocol.requestHandler = { _ in
+            throw URLError(.cannotConnectToHost)
+        }
+
+        do {
+            _ = try await client.fetchServerInfo(from: "mock.vikunja.io")
+            XCTFail("Expected error to be thrown")
+        } catch let error as NetworkError {
+            if case .serverUnreachable = error {
+                // Expected
+            } else {
+                XCTFail("Expected .serverUnreachable, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 }
+

--- a/mDoneTests/AppStateTests.swift
+++ b/mDoneTests/AppStateTests.swift
@@ -564,4 +564,96 @@ final class AppStateTests: XCTestCase {
         XCTAssertTrue(SharedKeys.sharedDefaults.bool(forKey: SharedKeys.calmModeKey))
         SharedKeys.sharedDefaults.removeObject(forKey: SharedKeys.calmModeKey)
     }
+
+    // MARK: - OIDC Login Tests
+
+    func testLoginWithOIDCSucceeds() async throws {
+        let auth = AuthService.shared
+        auth.clearAll()
+        defer { auth.clearAll() }
+
+        // Configure the shared APIClient to use our mock session
+        let mockSession = MockURLProtocol.mockSession()
+        await APIClient.shared.setSessionForTesting(mockSession)
+        defer {
+            Task {
+                await APIClient.shared.setSessionForTesting(.shared)
+            }
+        }
+
+        let appState = AppState()
+        XCTAssertFalse(appState.isAuthenticated)
+
+        let loginResponseJSON = """
+        {
+            "token": "oidc-jwt-token"
+        }
+        """.data(using: .utf8)!
+
+        let projectsJSON = "[]".data(using: .utf8)!
+
+        var requestCount = 0
+        MockURLProtocol.requestHandler = { request in
+            requestCount += 1
+            if request.url?.path == "/api/v1/auth/openid/keycloak/callback" {
+                XCTAssertEqual(request.httpMethod, "POST")
+                return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), loginResponseJSON)
+            } else if request.url?.path == "/api/v1/projects" {
+                XCTAssertEqual(request.httpMethod, "GET")
+                return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), projectsJSON)
+            } else {
+                XCTFail("Unexpected request: \(request)")
+                return (MockURLProtocol.makeResponse(statusCode: 500, url: request.url), Data())
+            }
+        }
+
+        try await appState.loginWithOIDC(
+            serverURL: "https://mock.vikunja.io",
+            providerKey: "keycloak",
+            code: "auth-code-123",
+            redirectURL: "https://mock.vikunja.io/auth/openid/keycloak"
+        )
+
+        XCTAssertTrue(appState.isAuthenticated)
+        XCTAssertEqual(auth.getServerURL(), "https://mock.vikunja.io")
+        XCTAssertEqual(auth.getToken(), "oidc-jwt-token")
+        XCTAssertEqual(requestCount, 2)
+    }
+
+    func testLoginWithOIDCFailsOnNetworkError() async {
+        let auth = AuthService.shared
+        auth.clearAll()
+        defer { auth.clearAll() }
+
+        let mockSession = MockURLProtocol.mockSession()
+        await APIClient.shared.setSessionForTesting(mockSession)
+        defer {
+            Task {
+                await APIClient.shared.setSessionForTesting(.shared)
+            }
+        }
+
+        let appState = AppState()
+        XCTAssertFalse(appState.isAuthenticated)
+
+        MockURLProtocol.requestHandler = { _ in
+            throw URLError(.cannotConnectToHost)
+        }
+
+        do {
+            try await appState.loginWithOIDC(
+                serverURL: "https://mock.vikunja.io",
+                providerKey: "keycloak",
+                code: "auth-code-123",
+                redirectURL: "https://mock.vikunja.io/auth/openid/keycloak"
+            )
+            XCTFail("Expected network error to be thrown")
+        } catch {
+            // Expected
+        }
+
+        XCTAssertFalse(appState.isAuthenticated)
+        XCTAssertNil(auth.getToken())
+    }
 }
+


### PR DESCRIPTION
- Dynamically queries /api/v1/info endpoint for OIDC providers
- Adapts UI to hide credentials form when local auth is disabled
- Uses WKWebsiteDataStore.nonPersistent() in WKWebView to prevent cookie leaking and sandbox hangs
- Passes unit tests and builds cleanly on iOS simulator and devices

## Summary

Adds support for single sign-on providers; queries the API configuration to determine if there is one configured. If local sign-on is disabled (and only SSO is permitted), hides the local sign-in fields as well.

Keeps SSO as a semi-hidden option which is a common pattern in apps like this.

## Related Issues

Fixes #

## Testing

Tested on simulator and on an iPhone 17 Pro.

## Checklist

- [x] Builds on iOS and macOS
- [x] Tests pass
- [x] Ran `swiftlint lint --quiet` and `swiftformat .`
- [x] No breaking changes (or described in summary above)
