### PR TITLE
Release 1.6.2 (build 44): fix dead Buy Me a Coffee link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Added
-- Settings → Tasks → "Calm Mode" (off by default). When on, overdue tasks aren't singled out: no red due dates, no separate "Overdue" list or counts, and no red highlight in the widgets. Overdue tasks simply appear in Today alongside everything else, in the app and on widgets (#68).
+## [1.6.2] - 2026-06-08
+
+### Fixed
+- The in-app "Buy Me a Coffee" support link now opens the correct page. The previous link pointed to a page that no longer exists.
+
+## [1.6.1] - 2026-06-06
 
 ### Fixed
 - Widget: the Today's Tasks and Upcoming widgets no longer let their header drift off the top (or clip the bottom rows) when there are more tasks than fit. This was most noticeable with larger text sizes. The header now stays pinned in place, the visible rows always fit the widget, and a "+N more" count fills the last line (#99).
+
+## [1.6.0] - 2026-06-03
+
+### Added
+- Settings → Tasks → "Calm Mode" (off by default). When on, overdue tasks aren't singled out: no red due dates, no separate "Overdue" list or counts, and no red highlight in the widgets. Overdue tasks simply appear in Today alongside everything else, in the app and on widgets (#68).
 
 ## [1.5.0] - 2026-06-01
 

--- a/project.yml
+++ b/project.yml
@@ -16,8 +16,8 @@ settings:
     # not feature-related — see PR "decisions".
     PRODUCT_NAME: "$(TARGET_NAME)"
     SWIFT_VERSION: "5.9"
-    MARKETING_VERSION: "1.5.0"
-    CURRENT_PROJECT_VERSION: "41"
+    MARKETING_VERSION: "1.6.2"
+    CURRENT_PROJECT_VERSION: "44"
     DEVELOPMENT_TEAM: "Z62E7MGREE"
     CODE_SIGN_IDENTITY: "Apple Development"
     CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## What

Cuts release **1.6.2 / build 44** for **iOS and macOS**, carrying the Buy Me a Coffee link fix to the App Store.

## Why

The `marcuslab` link fix (#102) had never shipped in a released binary:
- Live **iOS 1.6.1** (build 43) was cut from the widget-fix branch, before #102 merged.
- Live **macOS 1.6.0** predates it too.

Both live apps still point the in-app About screen's "Buy Me a Coffee" button at the old `https://www.buymeacoffee.com/losperdidos` page, **which is now dead**. This release ships the correct `https://buymeacoffee.com/marcuslab` link.

## Changes

- `project.yml`: `MARKETING_VERSION` 1.5.0 → **1.6.2**, `CURRENT_PROJECT_VERSION` → **44** (macOS goes 1.6.0 → 1.6.2; one shared marketing-version setting, so both platforms align).
- `CHANGELOG.md`: adds the 1.6.2 entry, and promotes the 1.6.0 (Calm Mode) and 1.6.1 (widget overflow) entries that had shipped but were never moved out of `[Unreleased]`.

## Shipping status

Build 44 archived, uploaded, and **submitted to App Store review on both platforms** (`AFTER_APPROVAL`, auto-release on approval). The actual link change itself already lives on `main` (#102); this PR is the version bump + changelog for the release that carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)