### PR TITLE
Add Schedule quick-actions to task long-press menu (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Long-press a task and pick **Schedule** for one-tap rescheduling to Today, Tomorrow, This Weekend, Next Week, or Next Month. These set an absolute due date (ignoring the task's current date, unlike the "+24h" swipe), and Next Week respects your "Start week on" preference (#67).
+
 ## [1.6.2] - 2026-06-08
 
 ### Fixed

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -603,6 +603,35 @@ final class AppState {
         }
     }
 
+    /// Reschedules a task to an absolute due date from a quick-action preset
+    /// (issue #67). Ignores the task's current due date, unlike `postponeTask`.
+    @MainActor
+    func rescheduleTask(_ task: VTask, to option: ScheduleOption) async {
+        let newDate = option.date()
+
+        let originalDueDate: Date?
+        if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+            originalDueDate = tasks[index].dueDate
+            tasks[index].dueDate = newDate
+        } else {
+            originalDueDate = nil
+        }
+
+        do {
+            let updated = try await taskService.updateTask(id: task.id, request: TaskUpdateRequest(dueDate: newDate))
+            if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
+                tasks[index] = updated
+            }
+            syncService?.updateCachedTask(updated)
+            WidgetCenter.shared.reloadAllTimelines()
+        } catch {
+            if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+                tasks[index].dueDate = originalDueDate
+            }
+            handleError(error)
+        }
+    }
+
     @MainActor
     func updateTask(id: Int64, request: TaskUpdateRequest) async {
         do {
@@ -797,7 +826,9 @@ final class AppState {
         var changed = true
         while changed {
             changed = false
-            for project in all where project.parentProjectId.map({ ids.contains($0) }) == true && !ids.contains(project.id) {
+            for project in all
+                where project.parentProjectId.map({ ids.contains($0) }) == true && !ids.contains(project.id)
+            {
                 ids.insert(project.id)
                 changed = true
             }

--- a/mDone/App/ScheduleOption.swift
+++ b/mDone/App/ScheduleOption.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Quick-reschedule presets surfaced in a task's long-press menu.
+///
+/// Unlike the "+24h" swipe action (which shifts relative to the task's current
+/// due date), each option produces an *absolute* due date computed from today,
+/// ignoring whatever date the task currently has. Results are normalised to the
+/// start of the target day, so the rescheduled task becomes date-only (no
+/// specific time), matching how `VTask.hasSpecificTime` treats midnight.
+enum ScheduleOption: CaseIterable, Identifiable {
+    case today
+    case tomorrow
+    case thisWeekend
+    case nextWeek
+    case nextMonth
+
+    var id: Self {
+        self
+    }
+
+    var label: String {
+        switch self {
+        case .today: "Today"
+        case .tomorrow: "Tomorrow"
+        case .thisWeekend: "This Weekend"
+        case .nextWeek: "Next Week"
+        case .nextMonth: "Next Month"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .today: "sun.max"
+        case .tomorrow: "sunrise"
+        case .thisWeekend: "calendar.day.timeline.left"
+        case .nextWeek: "calendar"
+        case .nextMonth: "calendar.badge.clock"
+        }
+    }
+
+    /// The absolute due date for this option, computed from `now` using a
+    /// calendar that honours the user's "Start week on" preference (issue #60).
+    func date(from now: Date = Date(), calendar: Calendar = .app) -> Date {
+        let startOfToday = calendar.startOfDay(for: now)
+        let target: Date = switch self {
+        case .today:
+            startOfToday
+        case .tomorrow:
+            calendar.date(byAdding: .day, value: 1, to: startOfToday) ?? startOfToday
+        case .thisWeekend:
+            // Upcoming Saturday. If today is already Saturday, rolls to next Saturday.
+            calendar.nextDate(
+                after: now,
+                matching: DateComponents(weekday: 7),
+                matchingPolicy: .nextTime
+            ) ?? startOfToday
+        case .nextWeek:
+            // Start of next week, respecting the user's first-weekday preference.
+            if let thisWeekStart = calendar.dateInterval(of: .weekOfYear, for: now)?.start {
+                calendar.date(byAdding: .weekOfYear, value: 1, to: thisWeekStart) ?? startOfToday
+            } else {
+                calendar.date(byAdding: .day, value: 7, to: startOfToday) ?? startOfToday
+            }
+        case .nextMonth:
+            // First day of the following month.
+            if let monthStart = calendar.dateInterval(of: .month, for: now)?.start {
+                calendar.date(byAdding: .month, value: 1, to: monthStart) ?? startOfToday
+            } else {
+                calendar.date(byAdding: .month, value: 1, to: startOfToday) ?? startOfToday
+            }
+        }
+        return calendar.startOfDay(for: target)
+    }
+}

--- a/mDone/Views/Tasks/TaskRow.swift
+++ b/mDone/Views/Tasks/TaskRow.swift
@@ -70,6 +70,20 @@ struct TaskRow: View {
         #if os(iOS)
         .contextMenu {
             if !readOnly {
+                if !task.done {
+                    Menu {
+                        ForEach(ScheduleOption.allCases) { option in
+                            Button {
+                                Task { await appState.rescheduleTask(task, to: option) }
+                            } label: {
+                                Label(option.label, systemImage: option.systemImage)
+                            }
+                        }
+                    } label: {
+                        Label("Schedule", systemImage: "calendar")
+                    }
+                }
+
                 if isFocused {
                     Button {
                         focusManager.endFocus()

--- a/mDoneTests/ScheduleOptionTests.swift
+++ b/mDoneTests/ScheduleOptionTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import mDone
+
+final class ScheduleOptionTests: XCTestCase {
+    /// A fixed calendar so results don't depend on the device locale or the
+    /// stored "Start week on" preference. Monday-first, UTC.
+    private func calendar(firstWeekday: Int = 2) -> Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        cal.firstWeekday = firstWeekday
+        return cal
+    }
+
+    /// Builds a date at the given Y/M/D (midnight UTC) for assertions.
+    private func date(_ year: Int, _ month: Int, _ day: Int, in cal: Calendar) -> Date {
+        cal.date(from: DateComponents(year: year, month: month, day: day))!
+    }
+
+    /// Reference "now": Wednesday 11 June 2026, 14:30 UTC.
+    private func referenceNow(in cal: Calendar) -> Date {
+        cal.date(from: DateComponents(year: 2026, month: 6, day: 11, hour: 14, minute: 30))!
+    }
+
+    func testEveryResultIsStartOfDay() {
+        let cal = calendar()
+        let now = referenceNow(in: cal)
+        for option in ScheduleOption.allCases {
+            let result = option.date(from: now, calendar: cal)
+            let comps = cal.dateComponents([.hour, .minute, .second], from: result)
+            XCTAssertEqual(comps.hour, 0, "\(option) should be midnight")
+            XCTAssertEqual(comps.minute, 0)
+            XCTAssertEqual(comps.second, 0)
+        }
+    }
+
+    func testToday() {
+        let cal = calendar()
+        let result = ScheduleOption.today.date(from: referenceNow(in: cal), calendar: cal)
+        XCTAssertEqual(result, date(2026, 6, 11, in: cal))
+    }
+
+    func testTomorrow() {
+        let cal = calendar()
+        let result = ScheduleOption.tomorrow.date(from: referenceNow(in: cal), calendar: cal)
+        XCTAssertEqual(result, date(2026, 6, 12, in: cal))
+    }
+
+    func testThisWeekendIsUpcomingSaturday() {
+        let cal = calendar()
+        // Wed 11 June → Sat 13 June 2026.
+        let result = ScheduleOption.thisWeekend.date(from: referenceNow(in: cal), calendar: cal)
+        XCTAssertEqual(result, date(2026, 6, 13, in: cal))
+        XCTAssertEqual(cal.component(.weekday, from: result), 7)
+    }
+
+    func testThisWeekendOnSaturdayRollsToNextSaturday() throws {
+        let cal = calendar()
+        // Sat 13 June 2026 at noon → next Saturday 20 June.
+        let saturday = try XCTUnwrap(cal.date(from: DateComponents(year: 2026, month: 6, day: 13, hour: 12)))
+        let result = ScheduleOption.thisWeekend.date(from: saturday, calendar: cal)
+        XCTAssertEqual(result, date(2026, 6, 20, in: cal))
+    }
+
+    func testNextWeekMondayStart() {
+        let cal = calendar(firstWeekday: 2) // Monday
+        // Week of Wed 11 June starts Mon 8 June; next week starts Mon 15 June.
+        let result = ScheduleOption.nextWeek.date(from: referenceNow(in: cal), calendar: cal)
+        XCTAssertEqual(result, date(2026, 6, 15, in: cal))
+        XCTAssertEqual(cal.component(.weekday, from: result), 2)
+    }
+
+    func testNextWeekHonoursSundayStart() {
+        let cal = calendar(firstWeekday: 1) // Sunday
+        // Week of Wed 11 June starts Sun 7 June; next week starts Sun 14 June.
+        let result = ScheduleOption.nextWeek.date(from: referenceNow(in: cal), calendar: cal)
+        XCTAssertEqual(result, date(2026, 6, 14, in: cal))
+        XCTAssertEqual(cal.component(.weekday, from: result), 1)
+    }
+
+    func testNextMonthIsFirstOfFollowingMonth() {
+        let cal = calendar()
+        let result = ScheduleOption.nextMonth.date(from: referenceNow(in: cal), calendar: cal)
+        XCTAssertEqual(result, date(2026, 7, 1, in: cal))
+    }
+
+    func testNextMonthWrapsYear() throws {
+        let cal = calendar()
+        let december = try XCTUnwrap(cal.date(from: DateComponents(year: 2026, month: 12, day: 20, hour: 9)))
+        let result = ScheduleOption.nextMonth.date(from: december, calendar: cal)
+        XCTAssertEqual(result, date(2027, 1, 1, in: cal))
+    }
+
+    func testAllOptionsHaveLabelAndImage() {
+        for option in ScheduleOption.allCases {
+            XCTAssertFalse(option.label.isEmpty)
+            XCTAssertFalse(option.systemImage.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
Closes #67.

## What

Adds a **Schedule** submenu to a task's long-press (context) menu on iPhone, with one-tap rescheduling presets:

- **Today**
- **Tomorrow**
- **This Weekend** (upcoming Saturday)
- **Next Week** (start of next week)
- **Next Month** (1st of the following month)

These set an **absolute** due date computed from today, ignoring the task's current date, which is the behaviour the issue asked for ("they would ignore the current date"). This is deliberately distinct from the existing **+24h** swipe, which shifts relative to the task's set date.

## Notes / decisions

- The issue's "Later this week" is implemented as **This Weekend** (the upcoming Saturday) so it maps to a concrete, well-defined date. If today is already Saturday it rolls to next Saturday.
- **Next Week** honours the user's "Start week on" preference (#60) via the existing `Calendar.app` helper.
- All targets normalise to the start of the day, so a rescheduled task becomes date-only (no specific time), matching how `VTask.hasSpecificTime` treats midnight.
- Menu only appears for not-done tasks, alongside the existing Focus action.

## Implementation

- New `ScheduleOption` enum (`mDone/App/ScheduleOption.swift`) holds the preset list, labels, SF Symbols, and the pure date computation.
- New `AppState.rescheduleTask(_:to:)` mirrors `postponeTask` (optimistic local update, rollback on failure, cache + widget refresh) but sets an absolute date.
- `TaskRow` context menu gains the Schedule submenu.

## Tests

- `ScheduleOptionTests` — 10 tests covering every preset, start-of-day normalisation, weekend roll-over, Monday vs Sunday week starts, and year-wrap for Next Month. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)