### PR TITLE
Add Current tasks: pin long-running tasks with progress and a stall nudge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Current tasks**: mark a long-running task as "Current" to pin it to a dedicated section at the top of your Inbox, above Today, so slow-burn projects stay top of mind instead of sinking out of view. Each Current task shows a progress bar you can update (from its detail view, or quickly via the right-click / long-press menu), and an "Idle" badge appears when a Current task hasn't been touched for a while. Set how many idle days trigger the badge in Settings under "Current Tasks". Mark or unmark a task as Current from its context menu or detail view, on both iPhone and Mac.
+
 ## [1.6.2] - 2026-06-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- A task no longer briefly disappears from the **Current** section when you change its progress (or otherwise edit it). The task stayed gone until the next refresh because the server's update response omits labels; the app now keeps the task's labels through an edit.
+
 ### Added
 - **Current tasks**: mark a long-running task as "Current" to pin it to a dedicated section at the top of your Inbox, above Today, so slow-burn projects stay top of mind instead of sinking out of view. Each Current task shows a progress bar you can update (from its detail view, or quickly via the right-click / long-press menu), and an "Idle" badge appears when a Current task hasn't been touched for a while. Set how many idle days trigger the badge in Settings under "Current Tasks". Mark or unmark a task as Current from its context menu or detail view, on both iPhone and Mac.
 

--- a/docs/appstore-metadata.md
+++ b/docs/appstore-metadata.md
@@ -19,6 +19,9 @@ KEY FEATURES
 Smart Lists
 Stay on top of what matters. mDone organizes your tasks into smart views — Today, Upcoming, and Overdue — so you always know what to focus on next.
 
+Current Tasks
+Keep long-running work top of mind. Mark a task as Current and it stays pinned to its own section at the top of your list, above Today, with a progress bar you can update and a gentle idle nudge when it has sat untouched for too long. Perfect for slow-burn projects that would otherwise slip out of sight.
+
 Projects & Favorites
 Organize tasks into projects and mark the ones you use most as favorites for quick access from the sidebar.
 
@@ -74,10 +77,20 @@ Steps to test:
    - Swipe a task to complete or delete it.
    - Use the sidebar to navigate between projects and smart lists (Today, Upcoming, Overdue).
    - Open a task to edit its details, set a due date, or configure repeating.
+   - Long-press a task (or open it) and choose "Mark as Current" to pin it to the new Current section at the top of the list, then update its progress from the task's detail view.
    - Try the focus timer from a task's detail view.
    - Add a widget from the home screen (long press > Edit Home Screen > tap +).
 
 This is a private test server maintained by the developer for App Store review purposes.
+
+## What's New (v1.7.0)
+
+Current tasks: keep long-running work from slipping out of sight.
+
+- Mark any task as Current to pin it to a dedicated section at the top of your list, above Today.
+- Track momentum with a progress bar you can update from the task's detail view or a quick menu.
+- An idle badge appears when a Current task has not been touched for a while, so slow-burn projects do not stall silently. Set the idle threshold in Settings.
+- Available on both iPhone and Mac.
 
 ## What's New (v1.0.0)
 

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -69,13 +69,19 @@ final class AppState {
 
     /// `taskService` is injectable so tests can drive the network paths
     /// (e.g. `undoLastCompletion`) through a mocked `APIClient`.
-    init(taskService: TaskService = TaskService(), projectService: ProjectService = ProjectService()) {
+    init(
+        taskService: TaskService = TaskService(),
+        projectService: ProjectService = ProjectService(),
+        labelService: LabelService = LabelService()
+    ) {
         self.taskService = taskService
         self.projectService = projectService
+        self.labelService = labelService
     }
 
     private let taskService: TaskService
     private let projectService: ProjectService
+    private let labelService: LabelService
     private let authService = AuthService.shared
     private let notificationService = NotificationService.shared
 
@@ -211,6 +217,51 @@ final class AppState {
         }
 
         return result
+    }
+
+    // MARK: - Current (long-running) tasks
+
+    /// Title of the dedicated Vikunja label that marks a task as "Current".
+    static let currentLabelTitle = "Current"
+
+    private static let currentLabelIdKey = "currentLabelId"
+
+    /// The persisted id of the "Current" label, if one has been resolved
+    /// before. Stored so renaming the label on the server (or another client)
+    /// doesn't orphan the marker.
+    private var storedCurrentLabelId: Int64? {
+        get { (UserDefaults.standard.object(forKey: Self.currentLabelIdKey) as? NSNumber)?.int64Value }
+        set {
+            if let newValue {
+                UserDefaults.standard.set(NSNumber(value: newValue), forKey: Self.currentLabelIdKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Self.currentLabelIdKey)
+            }
+        }
+    }
+
+    /// The "Current" label, resolved from the loaded labels by stored id first,
+    /// then by title. `nil` until one exists; it's created lazily the first
+    /// time a task is marked Current.
+    var currentLabel: VLabel? {
+        if let id = storedCurrentLabelId, let match = labels.first(where: { $0.id == id }) {
+            return match
+        }
+        return labels.first { $0.title.caseInsensitiveCompare(Self.currentLabelTitle) == .orderedSame }
+    }
+
+    /// Whether `task` carries the "Current" label.
+    func isCurrent(_ task: VTask) -> Bool {
+        guard let currentLabel else { return false }
+        return task.labels?.contains { $0.id == currentLabel.id } ?? false
+    }
+
+    /// Active (not done) tasks marked "Current", most recently touched first.
+    var currentTasks: [VTask] {
+        guard let currentLabel else { return [] }
+        return tasks
+            .filter { !$0.done && ($0.labels?.contains { $0.id == currentLabel.id } ?? false) }
+            .sorted { ($0.updated ?? .distantPast) > ($1.updated ?? .distantPast) }
     }
 
     func checkAuth() async {
@@ -617,6 +668,98 @@ final class AppState {
         }
     }
 
+    // MARK: - Current task mutations
+
+    /// Resolves the "Current" label, creating it on the server if it doesn't
+    /// exist yet. Persists the id so it survives a later rename.
+    @MainActor
+    private func ensureCurrentLabel() async throws -> VLabel {
+        if let existing = currentLabel { return existing }
+        let created = try await labelService.createLabel(
+            LabelCreateRequest(title: Self.currentLabelTitle, hexColor: "1a8cff")
+        )
+        if !labels.contains(where: { $0.id == created.id }) {
+            labels.append(created)
+        }
+        storedCurrentLabelId = created.id
+        return created
+    }
+
+    /// Toggles the "Current" label on `task`, surfacing it in (or removing it
+    /// from) the Current section at the top of the task list. Optimistic: the
+    /// local copy updates immediately and reverts if the network call fails.
+    @MainActor
+    func toggleCurrent(_ task: VTask) async {
+        let label: VLabel
+        do {
+            label = try await ensureCurrentLabel()
+        } catch {
+            handleError(error)
+            return
+        }
+
+        let wasCurrent = isCurrent(task)
+        setCurrentLabelLocally(taskId: task.id, label: label, present: !wasCurrent)
+
+        do {
+            if wasCurrent {
+                try await labelService.removeLabel(taskId: task.id, labelId: label.id)
+            } else {
+                try await labelService.addLabel(taskId: task.id, labelId: label.id)
+            }
+            #if os(iOS)
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            #endif
+            WidgetCenter.shared.reloadAllTimelines()
+        } catch {
+            setCurrentLabelLocally(taskId: task.id, label: label, present: wasCurrent)
+            handleError(error)
+        }
+    }
+
+    /// Adds or removes `label` from the locally cached copy of a task, and
+    /// bumps its `updated` timestamp so the stall indicator resets. The
+    /// `tasks` array is the source of truth.
+    @MainActor
+    private func setCurrentLabelLocally(taskId: Int64, label: VLabel, present: Bool) {
+        guard let index = tasks.firstIndex(where: { $0.id == taskId }) else { return }
+        var labelList = tasks[index].labels ?? []
+        if present {
+            if !labelList.contains(where: { $0.id == label.id }) {
+                labelList.append(label)
+            }
+        } else {
+            labelList.removeAll { $0.id == label.id }
+        }
+        tasks[index].labels = labelList
+        tasks[index].updated = Date()
+        syncService?.updateCachedTask(tasks[index])
+    }
+
+    /// Sets a task's completion progress (clamped to 0...1) and persists it.
+    /// Optimistic, and intentionally does not overwrite the local task with the
+    /// server response so an update that omits labels can't drop the Current
+    /// marker.
+    @MainActor
+    func setProgress(_ task: VTask, percent: Double) async {
+        let clamped = min(max(percent, 0), 1)
+        let original = tasks.first(where: { $0.id == task.id })?.percentDone
+        if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+            tasks[index].percentDone = clamped
+            tasks[index].updated = Date()
+            syncService?.updateCachedTask(tasks[index])
+        }
+        do {
+            _ = try await taskService.updateTask(id: task.id, request: TaskUpdateRequest(percentDone: clamped))
+            WidgetCenter.shared.reloadAllTimelines()
+        } catch {
+            if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+                tasks[index].percentDone = original
+            }
+            handleError(error)
+        }
+    }
+
     @MainActor
     func deleteTask(_ task: VTask) async {
         do {
@@ -797,7 +940,9 @@ final class AppState {
         var changed = true
         while changed {
             changed = false
-            for project in all where project.parentProjectId.map({ ids.contains($0) }) == true && !ids.contains(project.id) {
+            for project in all
+                where project.parentProjectId.map({ ids.contains($0) }) == true && !ids.contains(project.id)
+            {
                 ids.insert(project.id)
                 changed = true
             }

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -524,10 +524,28 @@ final class AppState {
         }
     }
 
+    /// Vikunja's task-update/toggle response returns `labels: null` (it doesn't
+    /// echo the task's labels). Replacing the local task wholesale with that
+    /// response would drop its labels until the next full refresh, which made a
+    /// Current task vanish from its section the moment you edited it (e.g.
+    /// changed its progress). Carry the existing labels forward when the
+    /// response omits them. Only labels are preserved: they're never edited via
+    /// the task-update endpoint (the Current label is toggled through the
+    /// dedicated label endpoints), so this can't mask a user edit. Other
+    /// relations like reminders *are* sent in the update request, so we let the
+    /// response drive them.
+    static func preservingRelations(existing: VTask, response: VTask) -> VTask {
+        var result = response
+        if result.labels == nil { result.labels = existing.labels }
+        return result
+    }
+
     @MainActor
     func toggleTaskDone(_ task: VTask) async {
         do {
-            let updated = try await taskService.toggleDone(task: task)
+            let response = try await taskService.toggleDone(task: task)
+            let updated = tasks.first(where: { $0.id == response.id })
+                .map { Self.preservingRelations(existing: $0, response: response) } ?? response
             if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
                 tasks[index] = updated
             }
@@ -640,7 +658,9 @@ final class AppState {
         }
 
         do {
-            let updated = try await taskService.updateTask(id: task.id, request: TaskUpdateRequest(dueDate: newDate))
+            let response = try await taskService.updateTask(id: task.id, request: TaskUpdateRequest(dueDate: newDate))
+            let updated = tasks.first(where: { $0.id == response.id })
+                .map { Self.preservingRelations(existing: $0, response: response) } ?? response
             if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
                 tasks[index] = updated
             }
@@ -657,7 +677,9 @@ final class AppState {
     @MainActor
     func updateTask(id: Int64, request: TaskUpdateRequest) async {
         do {
-            let updated = try await taskService.updateTask(id: id, request: request)
+            let response = try await taskService.updateTask(id: id, request: request)
+            let updated = tasks.first(where: { $0.id == response.id })
+                .map { Self.preservingRelations(existing: $0, response: response) } ?? response
             if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
                 tasks[index] = updated
             }

--- a/mDone/Models/Label.swift
+++ b/mDone/Models/Label.swift
@@ -23,3 +23,16 @@ struct VLabel: Codable, Identifiable, Hashable {
         return Color(hex: hexColor)
     }
 }
+
+/// Request body for creating a label (`PUT /api/v1/labels`).
+/// Snake-casing (`hexColor` -> `hex_color`) is applied by `APIClient`'s encoder.
+struct LabelCreateRequest: Encodable {
+    var title: String
+    var hexColor: String?
+}
+
+/// Request body for associating a label with a task
+/// (`PUT /api/v1/tasks/{id}/labels`). Snake-cased to `label_id`.
+struct LabelTaskRequest: Encodable {
+    var labelId: Int64
+}

--- a/mDone/Models/VTask.swift
+++ b/mDone/Models/VTask.swift
@@ -161,6 +161,8 @@ struct TaskUpdateRequest: Encodable {
     var labels: [LabelRef]?
     var repeatAfter: Int64?
     var reminders: [TaskReminder]?
+    /// Completion progress, 0...1. Drives the Current section's progress bar.
+    var percentDone: Double?
     var clearDueDate: Bool?
 
     struct LabelRef: Encodable {
@@ -168,7 +170,7 @@ struct TaskUpdateRequest: Encodable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case title, description, done, dueDate, priority, projectId, labels, repeatAfter, reminders
+        case title, description, done, dueDate, priority, projectId, labels, repeatAfter, reminders, percentDone
     }
 
     func encode(to encoder: Encoder) throws {
@@ -186,5 +188,6 @@ struct TaskUpdateRequest: Encodable {
         try container.encodeIfPresent(labels, forKey: .labels)
         try container.encodeIfPresent(repeatAfter, forKey: .repeatAfter)
         try container.encodeIfPresent(reminders, forKey: .reminders)
+        try container.encodeIfPresent(percentDone, forKey: .percentDone)
     }
 }

--- a/mDone/Services/Endpoint.swift
+++ b/mDone/Services/Endpoint.swift
@@ -127,6 +127,21 @@ struct Endpoint {
         ])
     }
 
+    /// Creates a label. Vikunja uses PUT (not POST) for creation.
+    static func createLabel() -> Endpoint {
+        Endpoint(path: "/api/v1/labels", method: .PUT)
+    }
+
+    /// Associates a label with a task. Body: `{ "label_id": <id> }`.
+    static func addLabelToTask(taskId: Int64) -> Endpoint {
+        Endpoint(path: "/api/v1/tasks/\(taskId)/labels", method: .PUT)
+    }
+
+    /// Removes a label association from a task.
+    static func removeLabelFromTask(taskId: Int64, labelId: Int64) -> Endpoint {
+        Endpoint(path: "/api/v1/tasks/\(taskId)/labels/\(labelId)", method: .DELETE)
+    }
+
     // MARK: - Notifications
 
     static func notifications(page: Int = 1) -> Endpoint {

--- a/mDone/Services/LabelService.swift
+++ b/mDone/Services/LabelService.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Label operations: listing, creating, and associating labels with tasks.
+///
+/// Backs the "Current" feature, which marks long-running tasks with a
+/// dedicated Vikunja label so they surface in their own section at the top
+/// of the task list. Like the other services this is an `actor` for thread
+/// safety, and takes an injectable `APIClient` so tests can drive it through
+/// `MockURLProtocol`.
+actor LabelService {
+    private let apiClient: APIClient
+
+    init(apiClient: APIClient = .shared) {
+        self.apiClient = apiClient
+    }
+
+    func createLabel(_ request: LabelCreateRequest) async throws -> VLabel {
+        try await apiClient.send(Endpoint.createLabel(), body: request)
+    }
+
+    /// Associates `labelId` with `taskId`. Vikunja echoes the new relation,
+    /// which we don't need, so the response body is discarded.
+    func addLabel(taskId: Int64, labelId: Int64) async throws {
+        try await apiClient.sendExpectingEmpty(
+            Endpoint.addLabelToTask(taskId: taskId),
+            body: LabelTaskRequest(labelId: labelId)
+        )
+    }
+
+    func removeLabel(taskId: Int64, labelId: Int64) async throws {
+        try await apiClient.delete(Endpoint.removeLabelFromTask(taskId: taskId, labelId: labelId))
+    }
+}

--- a/mDone/Views/Mac/MacTaskDetailView.swift
+++ b/mDone/Views/Mac/MacTaskDetailView.swift
@@ -15,6 +15,7 @@ struct MacTaskDetailView: View {
     @State private var showDeleteConfirm = false
     @State private var isShowingDescriptionPreview: Bool
     @State private var estimateSeconds: TimeInterval?
+    @State private var percentDone: Double
 
     init(task: VTask) {
         self.task = task
@@ -29,6 +30,13 @@ struct MacTaskDetailView: View {
         _reminders = State(initialValue: task.reminders ?? [])
         _isShowingDescriptionPreview = State(initialValue: !initialDescription.isEmpty)
         _estimateSeconds = State(initialValue: task.estimatedSeconds)
+        _percentDone = State(initialValue: task.percentDone ?? 0)
+    }
+
+    /// The live "Current" state from `AppState`, so the toggle label reflects
+    /// changes made while the detail view is open.
+    private var isCurrentNow: Bool {
+        appState.isCurrent(appState.tasks.first(where: { $0.id == task.id }) ?? task)
     }
 
     var body: some View {
@@ -79,6 +87,30 @@ struct MacTaskDetailView: View {
                             .frame(minHeight: 100, maxHeight: 200)
                             .scrollContentBackground(.hidden)
                     }
+                }
+            }
+
+            Section("Current") {
+                Button {
+                    Task { await appState.toggleCurrent(task) }
+                } label: {
+                    Label(
+                        isCurrentNow ? "Remove from Current" : "Mark as Current",
+                        systemImage: isCurrentNow ? "pin.slash" : "pin"
+                    )
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Progress")
+                        Spacer()
+                        Text("\(Int((percentDone * 100).rounded()))%")
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(value: $percentDone, in: 0 ... 1, step: 0.05)
+                        .accessibilityLabel("Progress")
+                        .accessibilityValue("\(Int((percentDone * 100).rounded())) percent")
                 }
             }
 
@@ -207,6 +239,7 @@ struct MacTaskDetailView: View {
             reminders = newTask.reminders ?? []
             isShowingDescriptionPreview = !newDescription.isEmpty
             estimateSeconds = newTask.estimatedSeconds
+            percentDone = newTask.percentDone ?? 0
         }
     }
 
@@ -221,6 +254,7 @@ struct MacTaskDetailView: View {
             projectId: selectedProjectId,
             repeatAfter: repeatInterval,
             reminders: reminders,
+            percentDone: percentDone,
             clearDueDate: !hasDueDate
         )
         Task {

--- a/mDone/Views/Mac/MacTaskListView.swift
+++ b/mDone/Views/Mac/MacTaskListView.swift
@@ -55,31 +55,47 @@ struct MacTaskListView: View {
                 ContentUnavailableView.search(text: appState.searchQuery)
                     .frame(maxHeight: .infinity)
             } else if section == .inbox {
+                let currentTasks = appState.currentTasks
+                let currentIds = Set(currentTasks.map(\.id))
                 List(selection: $selectedTask) {
+                    if !currentTasks.isEmpty {
+                        SmartListSection(
+                            title: "Current",
+                            tasks: currentTasks,
+                            accentColor: Color.accentColor,
+                            showsProgress: true
+                        )
+                    }
                     if calmMode {
-                        let todayAndOverdue = appState.calmModeTodayTasks
+                        let todayAndOverdue = excludingCurrent(appState.calmModeTodayTasks, currentIds: currentIds)
                         if !todayAndOverdue.isEmpty {
                             SmartListSection(title: "Today", tasks: todayAndOverdue, accentColor: Color.accentColor)
                         }
                     } else {
-                        if !appState.overdueTasks.isEmpty {
-                            SmartListSection(title: "Overdue", tasks: appState.overdueTasks, accentColor: .red)
+                        let overdue = excludingCurrent(appState.overdueTasks, currentIds: currentIds)
+                        if !overdue.isEmpty {
+                            SmartListSection(title: "Overdue", tasks: overdue, accentColor: .red)
                         }
-                        if !appState.todayTasks.isEmpty {
-                            SmartListSection(title: "Today", tasks: appState.todayTasks, accentColor: Color.accentColor)
+                        let today = excludingCurrent(appState.todayTasks, currentIds: currentIds)
+                        if !today.isEmpty {
+                            SmartListSection(title: "Today", tasks: today, accentColor: Color.accentColor)
                         }
                     }
-                    if !appState.tomorrowTasks.isEmpty {
-                        SmartListSection(title: "Tomorrow", tasks: appState.tomorrowTasks, accentColor: .orange)
+                    let tomorrow = excludingCurrent(appState.tomorrowTasks, currentIds: currentIds)
+                    if !tomorrow.isEmpty {
+                        SmartListSection(title: "Tomorrow", tasks: tomorrow, accentColor: .orange)
                     }
-                    if !appState.thisWeekTasks.isEmpty {
-                        SmartListSection(title: "This Week", tasks: appState.thisWeekTasks, accentColor: .blue)
+                    let thisWeek = excludingCurrent(appState.thisWeekTasks, currentIds: currentIds)
+                    if !thisWeek.isEmpty {
+                        SmartListSection(title: "This Week", tasks: thisWeek, accentColor: .blue)
                     }
-                    if !appState.upcomingTasks.isEmpty {
-                        SmartListSection(title: "Upcoming", tasks: appState.upcomingTasks, accentColor: .purple)
+                    let upcoming = excludingCurrent(appState.upcomingTasks, currentIds: currentIds)
+                    if !upcoming.isEmpty {
+                        SmartListSection(title: "Upcoming", tasks: upcoming, accentColor: .purple)
                     }
-                    if !appState.noDateTasks.isEmpty {
-                        SmartListSection(title: "No Date", tasks: appState.noDateTasks, accentColor: .secondary)
+                    let noDate = excludingCurrent(appState.noDateTasks, currentIds: currentIds)
+                    if !noDate.isEmpty {
+                        SmartListSection(title: "No Date", tasks: noDate, accentColor: .secondary)
                     }
                 }
                 .listStyle(.inset)
@@ -194,6 +210,12 @@ struct MacTaskListView: View {
         case let .project(project): return appState.tasksForProject(project.id)
         case .archived, .notifications, .calendar, .settings: return []
         }
+    }
+
+    /// Removes tasks already shown in the Current section so they don't appear
+    /// twice in the date-based sections below it.
+    private func excludingCurrent(_ tasks: [VTask], currentIds: Set<Int64>) -> [VTask] {
+        currentIds.isEmpty ? tasks : tasks.filter { !currentIds.contains($0.id) }
     }
 
     private func handleDrop(taskId: Int64, in tasks: [VTask], at location: CGPoint) {

--- a/mDone/Views/Settings/SettingsScreen.swift
+++ b/mDone/Views/Settings/SettingsScreen.swift
@@ -6,8 +6,10 @@ struct SettingsScreen: View {
     @AppStorage("notificationsEnabled") private var notificationsEnabled = false
     @AppStorage("reminderOffset") private var reminderOffset = 30
     @AppStorage(WeekStartPreference.storageKey) private var firstWeekday = WeekStartPreference.system.rawValue
-    @AppStorage(DefaultDueTimePreference.storageKey) private var defaultDueTime = DefaultDueTimePreference.defaultRawValue
+    @AppStorage(DefaultDueTimePreference.storageKey) private var defaultDueTime = DefaultDueTimePreference
+        .defaultRawValue
     @AppStorage("calmMode") private var calmMode = false
+    @AppStorage("currentStallDays") private var currentStallDays = 7
     @State private var showLogoutConfirm = false
     @State private var showAbout = false
 
@@ -48,7 +50,9 @@ struct SettingsScreen: View {
             } header: {
                 Text("Tasks")
             } footer: {
-                Text("Time of day applied to tasks you add to Today without picking a time. Pick a time later in the day to avoid the task showing as overdue right away.")
+                Text(
+                    "Time of day applied to tasks you add to Today without picking a time. Pick a time later in the day to avoid the task showing as overdue right away."
+                )
             }
 
             Section {
@@ -58,7 +62,23 @@ struct SettingsScreen: View {
                         WidgetCenter.shared.reloadAllTimelines()
                     }
             } footer: {
-                Text("Overdue tasks appear like any other — no red, no separate Overdue list or counts. They still show in your lists and widgets.")
+                Text(
+                    "Overdue tasks appear like any other — no red, no separate Overdue list or counts. They still show in your lists and widgets."
+                )
+            }
+
+            Section {
+                Stepper(
+                    "Idle badge after \(currentStallDays) day\(currentStallDays == 1 ? "" : "s")",
+                    value: $currentStallDays,
+                    in: 1 ... 60
+                )
+            } header: {
+                Text("Current Tasks")
+            } footer: {
+                Text(
+                    "Tasks you mark as Current sit at the top of your list with a progress bar. An idle badge appears when one hasn't been touched for this many days."
+                )
             }
 
             Section("Calendar") {

--- a/mDone/Views/Tasks/SmartListSection.swift
+++ b/mDone/Views/Tasks/SmartListSection.swift
@@ -5,11 +5,13 @@ struct SmartListSection: View {
     let title: String
     let tasks: [VTask]
     let accentColor: Color
+    /// Forwarded to each `TaskRow` so the Current section can show progress bars.
+    var showsProgress: Bool = false
 
     var body: some View {
         Section {
             ForEach(tasks) { task in
-                TaskRow(task: task)
+                TaskRow(task: task, showsProgress: showsProgress)
                     .tag(task)
             }
             .onMove { source, destination in

--- a/mDone/Views/Tasks/TaskDetailSheet.swift
+++ b/mDone/Views/Tasks/TaskDetailSheet.swift
@@ -20,6 +20,7 @@ struct TaskDetailSheet: View {
     @State private var isShowingDescriptionPreview: Bool
     /// Loaded from the description's estimate marker; `nil` == no estimate.
     @State private var estimateSeconds: TimeInterval?
+    @State private var percentDone: Double
 
     init(task: VTask) {
         self.task = task
@@ -34,6 +35,14 @@ struct TaskDetailSheet: View {
         _reminders = State(initialValue: task.reminders ?? [])
         _isShowingDescriptionPreview = State(initialValue: !initialDescription.isEmpty)
         _estimateSeconds = State(initialValue: task.estimatedSeconds)
+        _percentDone = State(initialValue: task.percentDone ?? 0)
+    }
+
+    /// The live copy of this task from `AppState`, so the Current toggle label
+    /// reflects changes made while the sheet is open (the `task` field is a
+    /// snapshot taken at init).
+    private var isCurrentNow: Bool {
+        appState.isCurrent(appState.tasks.first(where: { $0.id == task.id }) ?? task)
     }
 
     var body: some View {
@@ -56,7 +65,8 @@ struct TaskDetailSheet: View {
                                     .font(.caption)
                             }
                             .buttonStyle(.borderless)
-                            .accessibilityLabel(isShowingDescriptionPreview ? "Edit description" : "Preview description")
+                            .accessibilityLabel(isShowingDescriptionPreview ? "Edit description" :
+                                "Preview description")
                         }
 
                         if isShowingDescriptionPreview {
@@ -99,6 +109,30 @@ struct TaskDetailSheet: View {
                     FocusHistoryRow(taskId: task.id)
                 }
                 #endif
+
+                Section("Current") {
+                    Button {
+                        Task { await appState.toggleCurrent(task) }
+                    } label: {
+                        Label(
+                            isCurrentNow ? "Remove from Current" : "Mark as Current",
+                            systemImage: isCurrentNow ? "pin.slash" : "pin"
+                        )
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text("Progress")
+                            Spacer()
+                            Text("\(Int((percentDone * 100).rounded()))%")
+                                .monospacedDigit()
+                                .foregroundStyle(.secondary)
+                        }
+                        Slider(value: $percentDone, in: 0 ... 1, step: 0.05)
+                            .accessibilityLabel("Progress")
+                            .accessibilityValue("\(Int((percentDone * 100).rounded())) percent")
+                    }
+                }
 
                 Section {
                     Toggle("Due Date", isOn: $hasDueDate.animation())
@@ -219,6 +253,7 @@ struct TaskDetailSheet: View {
             projectId: selectedProjectId,
             repeatAfter: repeatInterval,
             reminders: reminders,
+            percentDone: percentDone,
             clearDueDate: !hasDueDate
         )
         Task {

--- a/mDone/Views/Tasks/TaskListScreen.swift
+++ b/mDone/Views/Tasks/TaskListScreen.swift
@@ -192,9 +192,21 @@ struct TaskListScreen: View {
 
     @ViewBuilder
     private var smartListSections: some View {
+        let currentTasks = appState.currentTasks
+        let currentIds = Set(currentTasks.map(\.id))
+
+        if !currentTasks.isEmpty {
+            SmartListSection(
+                title: "Current",
+                tasks: currentTasks,
+                accentColor: Color.accentColor,
+                showsProgress: true
+            )
+        }
+
         if calmMode {
-            // Calm Mode: overdue tasks aren't singled out — they fold into Today.
-            let todayAndOverdue = appState.calmModeTodayTasks
+            // Calm Mode: overdue tasks aren't singled out, they fold into Today.
+            let todayAndOverdue = excludingCurrent(appState.calmModeTodayTasks, currentIds: currentIds)
             if !todayAndOverdue.isEmpty {
                 SmartListSection(
                     title: "Today",
@@ -203,18 +215,20 @@ struct TaskListScreen: View {
                 )
             }
         } else {
-            if !appState.overdueTasks.isEmpty {
+            let overdue = excludingCurrent(appState.overdueTasks, currentIds: currentIds)
+            if !overdue.isEmpty {
                 SmartListSection(
                     title: "Overdue",
-                    tasks: sorted(appState.overdueTasks),
+                    tasks: sorted(overdue),
                     accentColor: .red
                 )
             }
 
-            if !appState.todayTasks.isEmpty {
+            let today = excludingCurrent(appState.todayTasks, currentIds: currentIds)
+            if !today.isEmpty {
                 SmartListSection(
                     title: "Today",
-                    tasks: sorted(appState.todayTasks),
+                    tasks: sorted(today),
                     accentColor: Color.accentColor
                 )
             }
@@ -243,34 +257,38 @@ struct TaskListScreen: View {
             }
         }
 
-        if !appState.tomorrowTasks.isEmpty {
+        let tomorrow = excludingCurrent(appState.tomorrowTasks, currentIds: currentIds)
+        if !tomorrow.isEmpty {
             SmartListSection(
                 title: "Tomorrow",
-                tasks: sorted(appState.tomorrowTasks),
+                tasks: sorted(tomorrow),
                 accentColor: .orange
             )
         }
 
-        if !appState.thisWeekTasks.isEmpty {
+        let thisWeek = excludingCurrent(appState.thisWeekTasks, currentIds: currentIds)
+        if !thisWeek.isEmpty {
             SmartListSection(
                 title: "This Week",
-                tasks: sorted(appState.thisWeekTasks),
+                tasks: sorted(thisWeek),
                 accentColor: .blue
             )
         }
 
-        if !appState.upcomingTasks.isEmpty {
+        let upcoming = excludingCurrent(appState.upcomingTasks, currentIds: currentIds)
+        if !upcoming.isEmpty {
             SmartListSection(
                 title: "Upcoming",
-                tasks: sorted(appState.upcomingTasks),
+                tasks: sorted(upcoming),
                 accentColor: .purple
             )
         }
 
-        if !appState.noDateTasks.isEmpty {
+        let noDate = excludingCurrent(appState.noDateTasks, currentIds: currentIds)
+        if !noDate.isEmpty {
             SmartListSection(
                 title: "No Date",
-                tasks: sorted(appState.noDateTasks),
+                tasks: sorted(noDate),
                 accentColor: .secondary
             )
         }
@@ -284,6 +302,12 @@ struct TaskListScreen: View {
                 )
             }
         }
+    }
+
+    /// Removes tasks already shown in the Current section so they don't appear
+    /// twice in the date-based sections below it.
+    private func excludingCurrent(_ tasks: [VTask], currentIds: Set<Int64>) -> [VTask] {
+        currentIds.isEmpty ? tasks : tasks.filter { !currentIds.contains($0.id) }
     }
 
     private func sorted(_ tasks: [VTask]) -> [VTask] {

--- a/mDone/Views/Tasks/TaskRow.swift
+++ b/mDone/Views/Tasks/TaskRow.swift
@@ -9,8 +9,15 @@ struct TaskRow: View {
     /// When true, the row is display-only: no completion toggle, swipe actions,
     /// context menu, or tap-to-edit. Used for archived (read-only) projects.
     var readOnly: Bool = false
+    /// When true, the row shows a progress bar and (when stalled) an idle badge.
+    /// Used by the "Current" section.
+    var showsProgress: Bool = false
     @State private var showDetail = false
     @AppStorage("calmMode") private var calmMode = false
+    @AppStorage("currentStallDays") private var stallDays = 7
+
+    /// Quick-set progress percentages offered in the context menu.
+    private static let progressSteps = [0, 25, 50, 75, 100]
 
     #if os(iOS)
     private var isFocused: Bool {
@@ -67,9 +74,9 @@ struct TaskRow: View {
                 }
             }
         }
-        #if os(iOS)
         .contextMenu {
             if !readOnly {
+                #if os(iOS)
                 if isFocused {
                     Button {
                         focusManager.endFocus()
@@ -84,8 +91,31 @@ struct TaskRow: View {
                         Label("Start Focus", systemImage: "scope")
                     }
                 }
+                #endif
+
+                Button {
+                    Task { await appState.toggleCurrent(task) }
+                } label: {
+                    Label(
+                        appState.isCurrent(task) ? "Remove from Current" : "Mark as Current",
+                        systemImage: appState.isCurrent(task) ? "pin.slash" : "pin"
+                    )
+                }
+
+                if appState.isCurrent(task) {
+                    Menu {
+                        ForEach(Self.progressSteps, id: \.self) { pct in
+                            Button("\(pct)%") {
+                                Task { await appState.setProgress(task, percent: Double(pct) / 100) }
+                            }
+                        }
+                    } label: {
+                        Label("Set Progress", systemImage: "chart.bar")
+                    }
+                }
             }
         }
+        #if os(iOS)
         .sheet(isPresented: $showDetail) {
             TaskDetailSheet(task: task)
         }
@@ -154,6 +184,10 @@ struct TaskRow: View {
                         }
                     }
                 }
+
+                if showsProgress {
+                    CurrentProgressIndicator(percent: task.percentDone ?? 0, stalledDays: stalledDays)
+                }
             }
 
             Spacer()
@@ -203,6 +237,15 @@ struct TaskRow: View {
         return parts.joined(separator: ", ")
     }
 
+    /// Days since the task was last touched, but only once it exceeds the
+    /// configured stall threshold, so the idle badge appears only for tasks
+    /// that have genuinely gone quiet. `nil` otherwise.
+    private var stalledDays: Int? {
+        guard let updated = task.updated else { return nil }
+        let days = Calendar.current.dateComponents([.day], from: updated, to: Date()).day ?? 0
+        return days >= stallDays ? days : nil
+    }
+
     private var priorityColor: Color {
         switch task.priorityLevel {
         case .critical, .urgent: .red
@@ -215,5 +258,47 @@ struct TaskRow: View {
 
     private var checkboxColor: Color {
         task.priorityLevel == .none ? .gray : priorityColor
+    }
+}
+
+/// A thin progress bar with a percentage and, when the task has gone idle past
+/// the stall threshold, an "Idle Nd" badge. Shown on rows in the Current section.
+struct CurrentProgressIndicator: View {
+    let percent: Double
+    let stalledDays: Int?
+
+    private var percentText: String {
+        "\(Int((percent * 100).rounded()))%"
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ProgressView(value: min(max(percent, 0), 1))
+                .progressViewStyle(.linear)
+                .tint(.accentColor)
+
+            Text(percentText)
+                .font(.caption2)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+
+            if let stalledDays {
+                Label("Idle \(stalledDays)d", systemImage: "zzz")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .labelStyle(.titleAndIcon)
+            }
+        }
+        .padding(.top, 2)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityText)
+    }
+
+    private var accessibilityText: String {
+        var parts = ["\(Int((percent * 100).rounded())) percent complete"]
+        if let stalledDays {
+            parts.append("idle \(stalledDays) days")
+        }
+        return parts.joined(separator: ", ")
     }
 }

--- a/mDoneTests/CurrentTasksTests.swift
+++ b/mDoneTests/CurrentTasksTests.swift
@@ -236,4 +236,50 @@ final class CurrentTasksTests: XCTestCase {
         XCTAssertTrue(json.contains("\"percent_done\":0.5"), "percentDone encodes as percent_done")
         XCTAssertFalse(json.contains("\"title\""), "Unset fields stay omitted")
     }
+
+    // MARK: - Label-drop regression (edit makes a Current task vanish)
+
+    func testPreservingRelationsCarriesLabelsForwardWhenResponseNil() {
+        var existing = VTask(id: 1, title: "x", done: false, priority: 0, projectId: 1)
+        existing.labels = [currentLabel()]
+        var response = VTask(id: 1, title: "x", done: false, priority: 0, projectId: 1)
+        response.labels = nil
+
+        let merged = AppState.preservingRelations(existing: existing, response: response)
+        XCTAssertEqual(merged.labels?.map(\.id), [3], "Nil response labels are filled from the existing task")
+    }
+
+    func testPreservingRelationsKeepsNonNilResponseLabels() {
+        var existing = VTask(id: 1, title: "x", done: false, priority: 0, projectId: 1)
+        existing.labels = [currentLabel()]
+        var response = VTask(id: 1, title: "x", done: false, priority: 0, projectId: 1)
+        response.labels = []
+
+        let merged = AppState.preservingRelations(existing: existing, response: response)
+        XCTAssertEqual(merged.labels?.count, 0, "A non-nil response value is authoritative")
+    }
+
+    /// Regression: Vikunja's update response returns labels:null, so editing a
+    /// Current task (e.g. its progress) used to drop the Current label locally,
+    /// making the task vanish from the Current section until the next refresh.
+    func testUpdateTaskKeepsTaskInCurrentSection() async {
+        let appState = await makeAppState()
+        appState.labels = [currentLabel()]
+        var task = VTask(id: 1, title: "Roadmap", done: false, priority: 0, projectId: 1)
+        task.labels = [currentLabel()]
+        appState.tasks = [task]
+
+        MockURLProtocol.requestHandler = { request in
+            // Vikunja echoes percent_done but returns labels: null.
+            let json = #"{"id": 1, "title": "Roadmap", "done": false, "priority": 0, "project_id": 1, "percent_done": 0.5, "labels": null}"#
+                .data(using: .utf8)!
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), json)
+        }
+
+        await appState.updateTask(id: 1, request: TaskUpdateRequest(percentDone: 0.5))
+
+        XCTAssertEqual(appState.tasks[0].percentDone, 0.5, "Progress is applied")
+        XCTAssertTrue(appState.isCurrent(appState.tasks[0]), "The Current label survives the edit")
+        XCTAssertEqual(appState.currentTasks.map(\.id), [1], "Task stays in the Current section after editing")
+    }
 }

--- a/mDoneTests/CurrentTasksTests.swift
+++ b/mDoneTests/CurrentTasksTests.swift
@@ -1,0 +1,239 @@
+import XCTest
+@testable import mDone
+
+@MainActor
+final class CurrentTasksTests: XCTestCase {
+    private let currentLabelIdKey = "currentLabelId"
+
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+        UserDefaults.standard.removeObject(forKey: currentLabelIdKey)
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        UserDefaults.standard.removeObject(forKey: currentLabelIdKey)
+        super.tearDown()
+    }
+
+    /// AppState whose task and label services both talk to `MockURLProtocol`.
+    private func makeAppState() async -> AppState {
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        return AppState(
+            taskService: TaskService(apiClient: client),
+            labelService: LabelService(apiClient: client)
+        )
+    }
+
+    private func currentLabel(id: Int64 = 3) -> VLabel {
+        VLabel(id: id, title: "Current")
+    }
+
+    // MARK: - Resolution & queries (no network)
+
+    func testCurrentLabelResolvesByTitleCaseInsensitively() {
+        let appState = AppState()
+        appState.labels = [VLabel(id: 4, title: "Other"), VLabel(id: 3, title: "current")]
+        XCTAssertEqual(appState.currentLabel?.id, 3)
+    }
+
+    func testCurrentLabelNilWhenNoMatch() {
+        let appState = AppState()
+        appState.labels = [VLabel(id: 4, title: "Other")]
+        XCTAssertNil(appState.currentLabel)
+    }
+
+    func testIsCurrentReflectsLabelPresence() {
+        let appState = AppState()
+        appState.labels = [currentLabel()]
+        var marked = VTask(id: 1, title: "Marked", done: false, priority: 0, projectId: 1)
+        marked.labels = [currentLabel()]
+        let unmarked = VTask(id: 2, title: "Unmarked", done: false, priority: 0, projectId: 1)
+
+        XCTAssertTrue(appState.isCurrent(marked))
+        XCTAssertFalse(appState.isCurrent(unmarked))
+    }
+
+    func testCurrentTasksExcludesDoneAndUnlabeledAndSortsByUpdatedDescending() {
+        let appState = AppState()
+        appState.labels = [currentLabel()]
+
+        var older = VTask(id: 1, title: "Older", done: false, priority: 0, projectId: 1)
+        older.labels = [currentLabel()]
+        older.updated = Date(timeIntervalSince1970: 100)
+
+        var newer = VTask(id: 2, title: "Newer", done: false, priority: 0, projectId: 1)
+        newer.labels = [currentLabel()]
+        newer.updated = Date(timeIntervalSince1970: 200)
+
+        var done = VTask(id: 3, title: "Done", done: true, priority: 0, projectId: 1)
+        done.labels = [currentLabel()]
+
+        let unlabeled = VTask(id: 4, title: "Unlabeled", done: false, priority: 0, projectId: 1)
+
+        appState.tasks = [older, newer, done, unlabeled]
+
+        XCTAssertEqual(appState.currentTasks.map(\.id), [2, 1], "Current tasks: not-done, labeled, newest first")
+    }
+
+    func testCurrentTasksEmptyWhenNoLabelExists() {
+        let appState = AppState()
+        var task = VTask(id: 1, title: "x", done: false, priority: 0, projectId: 1)
+        task.labels = [VLabel(id: 9, title: "Current")] // label not in appState.labels
+        appState.tasks = [task]
+        XCTAssertTrue(appState.currentTasks.isEmpty)
+    }
+
+    // MARK: - toggleCurrent
+
+    func testToggleCurrentAddsLabelOptimistically() async {
+        let appState = await makeAppState()
+        appState.labels = [currentLabel()]
+        let task = VTask(id: 1, title: "x", done: false, priority: 0, projectId: 1)
+        appState.tasks = [task]
+
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), #"{"label_id": 3}"#.data(using: .utf8)!)
+        }
+
+        await appState.toggleCurrent(task)
+
+        XCTAssertTrue(appState.isCurrent(appState.tasks[0]))
+        XCTAssertEqual(MockURLProtocol.capturedRequests.last?.url?.path, "/api/v1/tasks/1/labels")
+        XCTAssertEqual(MockURLProtocol.capturedRequests.last?.httpMethod, "PUT")
+    }
+
+    func testToggleCurrentRemovesLabel() async {
+        let appState = await makeAppState()
+        appState.labels = [currentLabel()]
+        var task = VTask(id: 1, title: "x", done: false, priority: 0, projectId: 1)
+        task.labels = [currentLabel()]
+        appState.tasks = [task]
+
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), #"{"message": "ok"}"#.data(using: .utf8)!)
+        }
+
+        await appState.toggleCurrent(task)
+
+        XCTAssertFalse(appState.isCurrent(appState.tasks[0]))
+        XCTAssertEqual(MockURLProtocol.capturedRequests.last?.httpMethod, "DELETE")
+    }
+
+    func testToggleCurrentRevertsOnFailure() async {
+        let appState = await makeAppState()
+        appState.labels = [currentLabel()]
+        let task = VTask(id: 1, title: "x", done: false, priority: 0, projectId: 1)
+        appState.tasks = [task]
+
+        // 400 fails fast (no retry/backoff).
+        MockURLProtocol.requestHandler = { request in
+            (
+                MockURLProtocol.makeResponse(statusCode: 400, url: request.url),
+                #"{"message": "bad"}"#.data(using: .utf8)!
+            )
+        }
+
+        await appState.toggleCurrent(task)
+
+        XCTAssertFalse(appState.isCurrent(appState.tasks[0]), "A failed add must revert the optimistic label")
+    }
+
+    func testToggleCurrentCreatesLabelWhenMissing() async {
+        let appState = await makeAppState()
+        appState.labels = [] // no Current label yet
+        let task = VTask(id: 1, title: "x", done: false, priority: 0, projectId: 1)
+        appState.tasks = [task]
+
+        MockURLProtocol.requestHandler = { request in
+            if request.url?.path == "/api/v1/labels" {
+                let json = #"{"id": 9, "title": "Current"}"#.data(using: .utf8)!
+                return (MockURLProtocol.makeResponse(statusCode: 201, url: request.url), json)
+            }
+            return (
+                MockURLProtocol.makeResponse(statusCode: 200, url: request.url),
+                #"{"label_id": 9}"#.data(using: .utf8)!
+            )
+        }
+
+        await appState.toggleCurrent(task)
+
+        XCTAssertNotNil(appState.labels.first(where: { $0.id == 9 }), "The Current label is created and cached")
+        XCTAssertTrue(appState.isCurrent(appState.tasks[0]))
+        XCTAssertEqual(
+            UserDefaults.standard.object(forKey: currentLabelIdKey) as? NSNumber,
+            NSNumber(value: 9),
+            "The created label id is persisted"
+        )
+    }
+
+    // MARK: - setProgress
+
+    func testSetProgressUpdatesAndClamps() async {
+        let appState = await makeAppState()
+        let task = VTask(id: 1, title: "x", done: false, priority: 0, projectId: 1)
+        appState.tasks = [task]
+
+        MockURLProtocol.requestHandler = { request in
+            let json = #"{"id": 1, "title": "x", "done": false, "priority": 0, "project_id": 1}"#.data(using: .utf8)!
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), json)
+        }
+
+        await appState.setProgress(task, percent: 1.5)
+
+        XCTAssertEqual(appState.tasks[0].percentDone, 1.0, "Progress is clamped to 0...1")
+    }
+
+    func testSetProgressRevertsOnFailure() async {
+        let appState = await makeAppState()
+        var task = VTask(id: 1, title: "x", done: false, priority: 0, projectId: 1)
+        task.percentDone = 0.2
+        appState.tasks = [task]
+
+        MockURLProtocol.requestHandler = { request in
+            (
+                MockURLProtocol.makeResponse(statusCode: 400, url: request.url),
+                #"{"message": "bad"}"#.data(using: .utf8)!
+            )
+        }
+
+        await appState.setProgress(task, percent: 0.8)
+
+        XCTAssertEqual(appState.tasks[0].percentDone, 0.2, "A failed progress update reverts to the prior value")
+    }
+
+    func testSetProgressPreservesCurrentLabel() async {
+        // The Current label must survive a progress update so the task doesn't
+        // vanish from the Current section after a quick percentage bump.
+        let appState = await makeAppState()
+        appState.labels = [currentLabel()]
+        var task = VTask(id: 1, title: "x", done: false, priority: 0, projectId: 1)
+        task.labels = [currentLabel()]
+        appState.tasks = [task]
+
+        MockURLProtocol.requestHandler = { request in
+            // Server response omits labels entirely.
+            let json = #"{"id": 1, "title": "x", "done": false, "priority": 0, "project_id": 1}"#.data(using: .utf8)!
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), json)
+        }
+
+        await appState.setProgress(task, percent: 0.5)
+
+        XCTAssertEqual(appState.tasks[0].percentDone, 0.5)
+        XCTAssertTrue(appState.isCurrent(appState.tasks[0]), "Progress update must not drop the Current label")
+    }
+
+    // MARK: - Request encoding
+
+    func testTaskUpdateRequestEncodesPercentDoneAsSnakeCase() throws {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(TaskUpdateRequest(percentDone: 0.5))
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertTrue(json.contains("\"percent_done\":0.5"), "percentDone encodes as percent_done")
+        XCTAssertFalse(json.contains("\"title\""), "Unset fields stay omitted")
+    }
+}

--- a/mDoneTests/LabelServiceTests.swift
+++ b/mDoneTests/LabelServiceTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import mDone
+
+final class LabelServiceTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    private func makeService() async -> LabelService {
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        return LabelService(apiClient: client)
+    }
+
+    func testCreateLabelPutsToLabelsAndDecodes() async throws {
+        let service = await makeService()
+        MockURLProtocol.requestHandler = { request in
+            let json = #"{"id": 7, "title": "Current", "hex_color": "1a8cff"}"#.data(using: .utf8)!
+            return (MockURLProtocol.makeResponse(statusCode: 201, url: request.url), json)
+        }
+
+        let label = try await service.createLabel(LabelCreateRequest(title: "Current", hexColor: "1a8cff"))
+
+        XCTAssertEqual(label.id, 7)
+        XCTAssertEqual(label.title, "Current")
+        let request = try XCTUnwrap(MockURLProtocol.capturedRequests.first)
+        XCTAssertEqual(request.url?.path, "/api/v1/labels")
+        XCTAssertEqual(request.httpMethod, "PUT")
+    }
+
+    func testAddLabelPutsToTaskLabelsEndpoint() async throws {
+        let service = await makeService()
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), #"{"label_id": 7}"#.data(using: .utf8)!)
+        }
+
+        try await service.addLabel(taskId: 42, labelId: 7)
+
+        let request = try XCTUnwrap(MockURLProtocol.capturedRequests.first)
+        XCTAssertEqual(request.url?.path, "/api/v1/tasks/42/labels")
+        XCTAssertEqual(request.httpMethod, "PUT")
+    }
+
+    func testRemoveLabelDeletesFromTaskLabelEndpoint() async throws {
+        let service = await makeService()
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), #"{"message": "ok"}"#.data(using: .utf8)!)
+        }
+
+        try await service.removeLabel(taskId: 42, labelId: 7)
+
+        let request = try XCTUnwrap(MockURLProtocol.capturedRequests.first)
+        XCTAssertEqual(request.url?.path, "/api/v1/tasks/42/labels/7")
+        XCTAssertEqual(request.httpMethod, "DELETE")
+    }
+}

--- a/website/index.html
+++ b/website/index.html
@@ -463,6 +463,11 @@ footer{ background:var(--bg-2); border-top:1px solid var(--line); padding:56px 0
         <p>Organise tasks into projects and pin the ones you live in to the sidebar for one-tap access.</p>
       </div>
       <div class="card col-2 reveal">
+        <div class="ic"><svg viewBox="0 0 24 24" fill="none"><path d="M9 3h6l-1 5 3 3v2H7v-2l3-3-1-5z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/><path d="M12 15v6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></div>
+        <h3>Current</h3>
+        <p>Pin long-running tasks to a section above Today, each with a progress bar and an idle nudge when one stalls, so slow-burn projects actually get finished.</p>
+      </div>
+      <div class="card col-2 reveal">
         <div class="ic"><svg viewBox="0 0 24 24" fill="none"><rect x="3" y="3" width="7" height="7" rx="1.5" stroke="currentColor" stroke-width="2"/><rect x="14" y="3" width="7" height="7" rx="1.5" stroke="currentColor" stroke-width="2"/><rect x="3" y="14" width="7" height="7" rx="1.5" stroke="currentColor" stroke-width="2"/><rect x="14" y="14" width="7" height="7" rx="1.5" stroke="currentColor" stroke-width="2"/></svg></div>
         <h3>Home &amp; Lock Screen Widgets</h3>
         <p>Today's agenda, upcoming, and overdue, right on your home or lock screen. Customise size and content.</p>


### PR DESCRIPTION
## Current tasks

Adds a way to keep long-running, slow-burn tasks top of mind so they don't sink out of view and never get finished. Mark a task as **Current** and it stays pinned in its own section at the top of the Inbox, above Today, regardless of due date.

### What it does
- **Mark as Current** from a task's context menu (iPhone + Mac) or its detail view. Backed by a dedicated Vikunja `Current` label, created automatically on first use, so it syncs and works in the Vikunja web UI too.
- **Pinned Current section** at the top of the list, sorted most-recently-touched first, de-duplicated from the date-based sections below it.
- **Editable progress bar** per Current task (`percentDone`): a slider in the detail view, plus quick 0/25/50/75/100% steps in the context menu.
- **Idle nudge**: an "Idle Nd" badge appears once a Current task hasn't been touched past a threshold (Settings → Current Tasks, default 7 days), so stalled work nags gently instead of disappearing.

### Implementation
- New `LabelService` actor for the Vikunja label endpoints (create label, add/remove label on a task).
- `AppState`: `currentLabel` resolution (by stored id, then title), `isCurrent`, `currentTasks`, optimistic `toggleCurrent` (creates the label on first use), and `setProgress`. `TaskUpdateRequest` gains `percentDone`.
- UI: Current section + progress/stall row on `TaskListScreen`/`MacTaskListView`; toggle + progress in `TaskDetailSheet`/`MacTaskDetailView` and `TaskRow`.

### Bug fix included
- Editing a Current task's progress made it briefly vanish from the Current section until refresh. Vikunja's `POST /tasks/{id}` returns `labels: null`, so replacing the local task wholesale dropped its label. `AppState.preservingRelations` now carries labels forward in `updateTask`/`toggleTaskDone`/`postponeTask`.

### Tests
- `CurrentTasksTests` and `LabelServiceTests`: label resolution, toggle (add/remove/revert/create), progress (clamp/revert/label-preservation), the label-drop regression, and request encoding. Full unit suite passes.

### Notes
- Also updates the marketing copy: App Store KEY FEATURES + What's New (`docs/appstore-metadata.md`) and a "Current" card on the landing page (`website/index.html`).
- 1.7.0 (build 46) is already in App Store review on iOS + macOS, built from this branch. The version bump in `project.yml` was build-only and is intentionally **not** in this PR to keep it a clean code diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)