### PR TITLE
Add quick-schedule long-press options for tasks (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - **Current tasks**: mark a long-running task as "Current" to pin it to a dedicated section at the top of your Inbox, above Today, so slow-burn projects stay top of mind instead of sinking out of view. Each Current task shows a progress bar you can update (from its detail view, or quickly via the right-click / long-press menu), and an "Idle" badge appears when a Current task hasn't been touched for a while. Set how many idle days trigger the badge in Settings under "Current Tasks". Mark or unmark a task as Current from its context menu or detail view, on both iPhone and Mac.
+- Long-press (or right-click) a task and pick "Schedule" to reschedule it to Today, Tomorrow, Later This Week, Next Week, or Next Month. These set an absolute due date (they ignore the task's current date, unlike the +24h swipe), and "Next Week" follows your "Start week on" preference (#67).
 
 ## [1.6.2] - 2026-06-08
 

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -674,6 +674,33 @@ final class AppState {
         }
     }
 
+    /// Reschedules a task to an absolute due date, ignoring its current date.
+    /// Backs the quick-schedule long-press options (Today, Tomorrow, Next Week, …).
+    @MainActor
+    func rescheduleTask(_ task: VTask, to newDate: Date) async {
+        let originalDueDate: Date?
+        if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+            originalDueDate = tasks[index].dueDate
+            tasks[index].dueDate = newDate
+        } else {
+            originalDueDate = nil
+        }
+
+        do {
+            let updated = try await taskService.updateTask(id: task.id, request: TaskUpdateRequest(dueDate: newDate))
+            if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
+                tasks[index] = updated
+            }
+            syncService?.updateCachedTask(updated)
+            WidgetCenter.shared.reloadAllTimelines()
+        } catch {
+            if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+                tasks[index].dueDate = originalDueDate
+            }
+            handleError(error)
+        }
+    }
+
     @MainActor
     func updateTask(id: Int64, request: TaskUpdateRequest) async {
         do {

--- a/mDone/App/QuickSchedule.swift
+++ b/mDone/App/QuickSchedule.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Quick "reschedule to" presets surfaced in the task long-press menu (issue #67).
+///
+/// Each option resolves to an *absolute* date that ignores the task's current due
+/// date, set to the start of the target day (date-only, no specific time). This is
+/// distinct from the `+24h` swipe action, which shifts relative to the existing date.
+enum QuickSchedule: String, CaseIterable, Identifiable {
+    case today
+    case tomorrow
+    case laterThisWeek
+    case nextWeek
+    case nextMonth
+
+    var id: String {
+        rawValue
+    }
+
+    var label: String {
+        switch self {
+        case .today: "Today"
+        case .tomorrow: "Tomorrow"
+        case .laterThisWeek: "Later This Week"
+        case .nextWeek: "Next Week"
+        case .nextMonth: "Next Month"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .today: "sun.max"
+        case .tomorrow: "sunrise"
+        case .laterThisWeek: "calendar.badge.clock"
+        case .nextWeek: "calendar"
+        case .nextMonth: "calendar.badge.plus"
+        }
+    }
+
+    /// Resolves the option to a concrete due date at the start of the target day.
+    ///
+    /// `now`/`calendar` are injectable for testing; production callers use the app
+    /// calendar, which honours the user's "Start week on" preference (issue #60).
+    func resolvedDate(now: Date = Date(), calendar: Calendar = .app) -> Date? {
+        let startOfToday = calendar.startOfDay(for: now)
+        switch self {
+        case .today:
+            return startOfToday
+        case .tomorrow:
+            return calendar.date(byAdding: .day, value: 1, to: startOfToday)
+        case .laterThisWeek:
+            // `weekOfYear` interval ends at the start of next week; step back one
+            // day for the last day of the current week.
+            guard let weekEnd = calendar.dateInterval(of: .weekOfYear, for: now)?.end else { return nil }
+            return calendar.date(byAdding: .day, value: -1, to: weekEnd)
+        case .nextWeek:
+            // Start of next week, honouring the user's first-weekday preference.
+            return calendar.dateInterval(of: .weekOfYear, for: now)?.end
+        case .nextMonth:
+            // First day of the following month.
+            return calendar.dateInterval(of: .month, for: now)?.end
+        }
+    }
+
+    /// The options worth showing in the menu for the given moment.
+    ///
+    /// "Later This Week" is dropped when it would resolve to tomorrow or earlier
+    /// (e.g. near the weekend), since it would just duplicate "Today"/"Tomorrow".
+    static func options(now: Date = Date(), calendar: Calendar = .app) -> [QuickSchedule] {
+        let tomorrow = QuickSchedule.tomorrow.resolvedDate(now: now, calendar: calendar)
+        return allCases.filter { option in
+            guard option == .laterThisWeek else { return true }
+            guard let later = option.resolvedDate(now: now, calendar: calendar), let tomorrow else { return true }
+            return later > tomorrow
+        }
+    }
+}

--- a/mDone/Views/Tasks/TaskRow.swift
+++ b/mDone/Views/Tasks/TaskRow.swift
@@ -76,6 +76,21 @@ struct TaskRow: View {
         }
         .contextMenu {
             if !readOnly {
+                if !task.done {
+                    Menu {
+                        ForEach(QuickSchedule.options()) { option in
+                            Button {
+                                guard let date = option.resolvedDate() else { return }
+                                Task { await appState.rescheduleTask(task, to: date) }
+                            } label: {
+                                Label(option.label, systemImage: option.systemImage)
+                            }
+                        }
+                    } label: {
+                        Label("Schedule", systemImage: "calendar")
+                    }
+                }
+
                 #if os(iOS)
                 if isFocused {
                     Button {

--- a/mDoneTests/AppStateTests.swift
+++ b/mDoneTests/AppStateTests.swift
@@ -135,7 +135,11 @@ final class AppStateTests: XCTestCase {
         }
 
         await appState.deleteProject(appState.projects[0]) // delete Parent (3)
-        XCTAssertEqual(appState.projects.map(\.id).sorted(), [9], "Parent and all descendants are removed; unrelated kept")
+        XCTAssertEqual(
+            appState.projects.map(\.id).sorted(),
+            [9],
+            "Parent and all descendants are removed; unrelated kept"
+        )
         XCTAssertEqual(appState.tasks.map(\.id).sorted(), [3], "Tasks of the parent and its descendants are removed")
     }
 
@@ -500,6 +504,62 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(appState.undoableCompletion?.id, 11)
     }
 
+    // MARK: - Reschedule (#67)
+
+    func testRescheduleTaskUpdatesDueDateOnSuccess() async throws {
+        let appState = await makeMockedAppState()
+        var task = VTask(id: 50, title: "Renew passport", done: false, priority: 1, projectId: 4)
+        task.dueDate = Date(timeIntervalSince1970: 1_700_000_000)
+        appState.tasks = [task]
+        let newDate = Date(timeIntervalSince1970: 1_760_000_000)
+
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 200, url: request.url!)
+            // Vikunja echoes the new due date back as ISO8601.
+            let iso = ISO8601DateFormatter().string(from: newDate)
+            let json = """
+            {"id": 50, "title": "Renew passport", "done": false, "priority": 1, \
+            "project_id": 4, "due_date": "\(iso)"}
+            """
+            return (response, Data(json.utf8))
+        }
+
+        await appState.rescheduleTask(task, to: newDate)
+
+        XCTAssertEqual(appState.tasks.count, 1, "Reschedule must not duplicate the task")
+        XCTAssertEqual(appState.tasks.first?.id, 50)
+        let resolved = try XCTUnwrap(appState.tasks.first?.effectiveDueDate)
+        XCTAssertEqual(
+            resolved.timeIntervalSince1970,
+            newDate.timeIntervalSince1970,
+            accuracy: 1,
+            "Reschedule must adopt the new due date returned by the server"
+        )
+    }
+
+    func testRescheduleTaskRollsBackOnFailure() async {
+        let appState = await makeMockedAppState()
+        let original = Date(timeIntervalSince1970: 1_700_000_000)
+        var task = VTask(id: 51, title: "Book dentist", done: false, priority: 0, projectId: 2)
+        task.dueDate = original
+        appState.tasks = [task]
+        let newDate = Date(timeIntervalSince1970: 1_760_000_000)
+
+        // 400 (not 5xx) so APIClient fails fast instead of retrying with backoff.
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 400, url: request.url!)
+            return (response, Data("{\"message\": \"bad request\"}".utf8))
+        }
+
+        await appState.rescheduleTask(task, to: newDate)
+
+        XCTAssertEqual(
+            appState.tasks.first?.dueDate,
+            original,
+            "A failed reschedule must restore the original due date"
+        )
+    }
+
     // MARK: - Calm Mode (#68)
 
     /// Seeds a deterministic spread of due dates: overdue, due-today,
@@ -509,15 +569,39 @@ final class AppStateTests: XCTestCase {
         let cal = Calendar.current
         let todayEndOfDay = try XCTUnwrap(cal.date(bySettingHour: 23, minute: 59, second: 59, of: now))
         appState.tasks = [
-            VTask(id: 1, title: "Overdue", done: false,
-                  dueDate: cal.date(byAdding: .day, value: -2, to: now), priority: 0, projectId: 1),
-            VTask(id: 2, title: "Today", done: false,
-                  dueDate: todayEndOfDay, priority: 0, projectId: 1),
-            VTask(id: 3, title: "Upcoming", done: false,
-                  dueDate: cal.date(byAdding: .day, value: 3, to: now), priority: 0, projectId: 1),
+            VTask(
+                id: 1,
+                title: "Overdue",
+                done: false,
+                dueDate: cal.date(byAdding: .day, value: -2, to: now),
+                priority: 0,
+                projectId: 1
+            ),
+            VTask(
+                id: 2,
+                title: "Today",
+                done: false,
+                dueDate: todayEndOfDay,
+                priority: 0,
+                projectId: 1
+            ),
+            VTask(
+                id: 3,
+                title: "Upcoming",
+                done: false,
+                dueDate: cal.date(byAdding: .day, value: 3, to: now),
+                priority: 0,
+                projectId: 1
+            ),
             VTask(id: 4, title: "No date", done: false, priority: 0, projectId: 1),
-            VTask(id: 5, title: "Done overdue", done: true,
-                  dueDate: cal.date(byAdding: .day, value: -3, to: now), priority: 0, projectId: 1),
+            VTask(
+                id: 5,
+                title: "Done overdue",
+                done: true,
+                dueDate: cal.date(byAdding: .day, value: -3, to: now),
+                priority: 0,
+                projectId: 1
+            ),
         ]
     }
 

--- a/mDoneTests/QuickScheduleTests.swift
+++ b/mDoneTests/QuickScheduleTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import mDone
+
+final class QuickScheduleTests: XCTestCase {
+    /// A fixed calendar (Gregorian, Monday-start, UTC) so date math is deterministic
+    /// regardless of the test machine's locale or timezone.
+    private var calendar: Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        cal.firstWeekday = 2 // Monday
+        return cal
+    }
+
+    /// Builds a UTC date for the given components.
+    private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 0, _ minute: Int = 0) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        return calendar.date(from: components)!
+    }
+
+    func testTodayResolvesToStartOfToday() {
+        // Wednesday 2026-06-17, 14:30
+        let now = date(2026, 6, 17, 14, 30)
+        XCTAssertEqual(QuickSchedule.today.resolvedDate(now: now, calendar: calendar), date(2026, 6, 17))
+    }
+
+    func testTomorrowResolvesToStartOfNextDay() {
+        let now = date(2026, 6, 17, 14, 30)
+        XCTAssertEqual(QuickSchedule.tomorrow.resolvedDate(now: now, calendar: calendar), date(2026, 6, 18))
+    }
+
+    func testLaterThisWeekResolvesToLastDayOfWeek() {
+        // Wednesday 2026-06-17; Monday-start week ends Sunday 2026-06-21.
+        let now = date(2026, 6, 17, 14, 30)
+        XCTAssertEqual(QuickSchedule.laterThisWeek.resolvedDate(now: now, calendar: calendar), date(2026, 6, 21))
+    }
+
+    func testNextWeekResolvesToStartOfFollowingWeek() {
+        // Wednesday 2026-06-17; next Monday is 2026-06-22.
+        let now = date(2026, 6, 17, 14, 30)
+        XCTAssertEqual(QuickSchedule.nextWeek.resolvedDate(now: now, calendar: calendar), date(2026, 6, 22))
+    }
+
+    func testNextMonthResolvesToFirstOfFollowingMonth() {
+        let now = date(2026, 6, 17, 14, 30)
+        XCTAssertEqual(QuickSchedule.nextMonth.resolvedDate(now: now, calendar: calendar), date(2026, 7, 1))
+    }
+
+    func testNextMonthRollsOverYearBoundary() {
+        let now = date(2026, 12, 20)
+        XCTAssertEqual(QuickSchedule.nextMonth.resolvedDate(now: now, calendar: calendar), date(2027, 1, 1))
+    }
+
+    func testResolvedDatesAreDateOnlyMidnight() throws {
+        let now = date(2026, 6, 17, 9, 15)
+        for option in QuickSchedule.allCases {
+            let resolved = option.resolvedDate(now: now, calendar: calendar)
+            let components = try calendar.dateComponents([.hour, .minute, .second], from: XCTUnwrap(resolved))
+            XCTAssertEqual(components.hour, 0, "\(option.label) should land at midnight")
+            XCTAssertEqual(components.minute, 0)
+            XCTAssertEqual(components.second, 0)
+        }
+    }
+
+    func testOptionsHideLaterThisWeekMidWeekWhenItEqualsTomorrowOrEarlier() {
+        // Saturday 2026-06-20: "later this week" is Sunday 21st, which is still
+        // strictly after tomorrow (Sunday 21st == tomorrow) → should be hidden.
+        let now = date(2026, 6, 20, 10, 0)
+        let options = QuickSchedule.options(now: now, calendar: calendar)
+        XCTAssertFalse(options.contains(.laterThisWeek))
+    }
+
+    func testOptionsKeepLaterThisWeekEarlyInWeek() {
+        // Monday 2026-06-15: "later this week" is Sunday 21st, well after tomorrow.
+        let now = date(2026, 6, 15, 10, 0)
+        let options = QuickSchedule.options(now: now, calendar: calendar)
+        XCTAssertTrue(options.contains(.laterThisWeek))
+        XCTAssertEqual(options.first, .today)
+    }
+
+    func testOptionsAlwaysIncludeCoreChoices() {
+        let now = date(2026, 6, 17, 14, 30)
+        let options = QuickSchedule.options(now: now, calendar: calendar)
+        for required in [QuickSchedule.today, .tomorrow, .nextWeek, .nextMonth] {
+            XCTAssertTrue(options.contains(required), "\(required.label) should always be offered")
+        }
+    }
+}


### PR DESCRIPTION
Closes #67.

## What

Long-press (or right-click) a task and pick the new **Schedule** menu to reschedule it to one of:

- **Today**
- **Tomorrow**
- **Later This Week** (last day of the current week)
- **Next Week** (start of next week)
- **Next Month** (1st of the following month)

These set an **absolute** due date that ignores the task's current date — unlike the existing `+24h` swipe, which shifts relative to the current date (as the issue requested: *"they would ignore the current date"*). All presets land at the start of the target day (date-only, no specific time).

"Next Week" honours the user's **Start week on** preference (the setting added in #60), so it points at the right day whether your week starts Monday or Sunday.

## How

- New `QuickSchedule` enum (`mDone/App/QuickSchedule.swift`) resolves each preset to a concrete date using `Calendar.app` (which respects the week-start preference). The calendar and "now" are injectable so the date math is deterministic in tests. `QuickSchedule.options()` hides "Later This Week" near the weekend when it would just duplicate Today/Tomorrow.
- `AppState.rescheduleTask(_:to:)` optimistically updates the due date and rolls back on failure, mirroring the existing `postponeTask`.
- The Schedule submenu is added to the task context menu in `TaskRow`. It sits outside the iOS-only Focus block, so it works on both iPhone and Mac.

## Tests

- 10 tests for `QuickSchedule` date resolution and option filtering (year rollover, week-start, midnight, etc.).
- 2 tests for `rescheduleTask` (success adopts the server date; failure rolls back).

All 46 `mDoneTests` in the affected suites pass; the macOS target builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)