### PR TITLE
Render Vikunja task colors in task rows (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - A task no longer briefly disappears from the **Current** section when you change its progress (or otherwise edit it). The task stayed gone until the next refresh because the server's update response omits labels; the app now keeps the task's labels through an edit.
 
 ### Added
+- Tasks now show the color you assign them in Vikunja. Each colored task tints its leading accent bar and completion circle with its hex color, so color-coded contexts (work, personal, clients) are visible at a glance in every list. Uncolored tasks are unchanged (#112).
 - **Current tasks**: mark a long-running task as "Current" to pin it to a dedicated section at the top of your Inbox, above Today, so slow-burn projects stay top of mind instead of sinking out of view. Each Current task shows a progress bar you can update (from its detail view, or quickly via the right-click / long-press menu), and an "Idle" badge appears when a Current task hasn't been touched for a while. Set how many idle days trigger the badge in Settings under "Current Tasks". Mark or unmark a task as Current from its context menu or detail view, on both iPhone and Mac.
 - Long-press (or right-click) a task and pick "Schedule" to reschedule it to Today, Tomorrow, Later This Week, Next Week, or Next Month. These set an absolute due date (they ignore the task's current date, unlike the +24h swipe), and "Next Week" follows your "Start week on" preference (#67).
 

--- a/mDone/Models/VTask.swift
+++ b/mDone/Models/VTask.swift
@@ -37,6 +37,22 @@ struct VTask: Codable, Identifiable, Hashable {
         (repeatAfter ?? 0) > 0
     }
 
+    /// The user-assigned task color from Vikunja, normalized for display.
+    /// Returns `nil` when Vikunja sends no color (an empty string) or a value
+    /// that isn't a valid 3/6/8-digit hex, so uncolored tasks fall back to the
+    /// default styling instead of rendering a stray gray. The leading `#`, if
+    /// present, is stripped.
+    var normalizedHexColor: String? {
+        guard let hexColor else { return nil }
+        let trimmed = hexColor
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        guard [3, 6, 8].contains(trimmed.count),
+              trimmed.allSatisfy(\.isHexDigit)
+        else { return nil }
+        return trimmed
+    }
+
     /// `description` with the mDone estimate marker stripped — what the user
     /// should see in editors and previews. `nil` if the description has no
     /// body once the marker is removed.

--- a/mDone/Views/Tasks/TaskRow.swift
+++ b/mDone/Views/Tasks/TaskRow.swift
@@ -140,7 +140,7 @@ struct TaskRow: View {
     private var rowContent: some View {
         HStack(spacing: 12) {
             RoundedRectangle(cornerRadius: 2)
-                .fill(priorityColor)
+                .fill(accentColor)
                 .frame(width: 4, height: 36)
                 .accessibilityHidden(true)
 
@@ -261,6 +261,18 @@ struct TaskRow: View {
         return days >= stallDays ? days : nil
     }
 
+    /// The task's own Vikunja color, when set. `nil` for uncolored tasks.
+    private var taskColor: Color? {
+        task.normalizedHexColor.map { Color(hex: $0) }
+    }
+
+    /// The leading accent bar prefers the user-assigned task color, falling
+    /// back to the priority color (which is also shown as a badge) so the bar
+    /// keeps signalling priority for uncolored tasks.
+    private var accentColor: Color {
+        taskColor ?? priorityColor
+    }
+
     private var priorityColor: Color {
         switch task.priorityLevel {
         case .critical, .urgent: .red
@@ -272,7 +284,8 @@ struct TaskRow: View {
     }
 
     private var checkboxColor: Color {
-        task.priorityLevel == .none ? .gray : priorityColor
+        if let taskColor { return taskColor }
+        return task.priorityLevel == .none ? .gray : priorityColor
     }
 }
 

--- a/mDoneTests/VTaskColorTests.swift
+++ b/mDoneTests/VTaskColorTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import mDone
+
+final class VTaskColorTests: XCTestCase {
+    func testValidSixDigitHexIsReturned() {
+        XCTAssertEqual(makeTask(hexColor: "F2490C").normalizedHexColor, "F2490C")
+    }
+
+    func testLeadingHashIsStripped() {
+        XCTAssertEqual(makeTask(hexColor: "#4772FA").normalizedHexColor, "4772FA")
+    }
+
+    func testSurroundingWhitespaceIsTrimmed() {
+        XCTAssertEqual(makeTask(hexColor: "  1a8cff \n").normalizedHexColor, "1a8cff")
+    }
+
+    func testThreeAndEightDigitHexAreAccepted() {
+        XCTAssertEqual(makeTask(hexColor: "f00").normalizedHexColor, "f00")
+        XCTAssertEqual(makeTask(hexColor: "FF4444AA").normalizedHexColor, "FF4444AA")
+    }
+
+    func testNilHexColorReturnsNil() {
+        XCTAssertNil(makeTask(hexColor: nil).normalizedHexColor)
+    }
+
+    func testEmptyOrHashOnlyReturnsNil() {
+        // Vikunja sends an empty string for uncolored tasks.
+        XCTAssertNil(makeTask(hexColor: "").normalizedHexColor)
+        XCTAssertNil(makeTask(hexColor: "   ").normalizedHexColor)
+        XCTAssertNil(makeTask(hexColor: "#").normalizedHexColor)
+    }
+
+    func testInvalidLengthReturnsNil() {
+        XCTAssertNil(makeTask(hexColor: "FFFF").normalizedHexColor)
+        XCTAssertNil(makeTask(hexColor: "1234567").normalizedHexColor)
+    }
+
+    func testNonHexCharactersReturnNil() {
+        XCTAssertNil(makeTask(hexColor: "GGGGGG").normalizedHexColor)
+        XCTAssertNil(makeTask(hexColor: "12 34 56").normalizedHexColor)
+    }
+
+    private func makeTask(hexColor: String?) -> VTask {
+        VTask(
+            id: 1,
+            title: "T",
+            description: nil,
+            done: false,
+            doneAt: nil,
+            dueDate: nil,
+            startDate: nil,
+            endDate: nil,
+            priority: 0,
+            projectId: 1,
+            hexColor: hexColor,
+            percentDone: nil,
+            uid: nil,
+            position: nil,
+            isFavorite: nil,
+            repeatAfter: nil,
+            repeatMode: nil,
+            identifier: nil,
+            index: nil,
+            reminders: nil,
+            assignees: nil,
+            labels: nil,
+            createdBy: nil,
+            created: nil,
+            updated: nil,
+            bucketId: nil,
+            coverImageAttachmentId: nil
+        )
+    }
+}


### PR DESCRIPTION
Closes #112.

## What

Vikunja lets you assign a color to a task (its `hex_color`). mDone already **decoded and cached** this field, but never rendered it, so colored tasks looked identical to everything else. This surfaces the color in the UI.

A colored task now tints:
- its **leading accent bar**, and
- its **completion circle**

with the task's own hex color. This matches Vikunja's own list view (left color bar) and the reporter's request to "tint the checkbox circle". Uncolored tasks are completely unchanged: the accent bar still falls back to the priority color and the circle to its priority/gray styling.

## How

- New `VTask.normalizedHexColor` computed property validates the raw value: strips a leading `#` and whitespace, and only accepts a 3/6/8-digit hex. Vikunja sends an empty string for uncolored tasks, so this returns `nil` there (and for any malformed value), preventing a stray gray bar from `Color(hex:)`'s fallback.
- `TaskRow` uses `taskColor` (the task's own color) for the accent bar and checkbox, falling back to `priorityColor` when there's no color.

## Tests

Added `VTaskColorTests` (8 cases): valid 3/6/8-digit hex, `#`-stripping, whitespace trimming, and `nil` for empty/hash-only/invalid-length/non-hex/`nil`. All pass.

## Notes

- Model/cache/API layers already handled `hex_color`; this PR is UI-only plus the validating helper.
- The Kanban board (#55) is a separate in-flight branch and isn't in `main`, so no card view exists here to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)