### PR TITLE
Add Dependabot config to keep GitHub Actions pins updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # The app has no external package dependencies (pure Swift, no SPM),
+  # so the only thing to keep fresh is the action pins in our workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds a Dependabot config that keeps the action pins in our GitHub Actions workflows up to date, checked weekly and grouped into a single PR. The app itself has no external package dependencies (pure Swift, no SPM), so `github-actions` is the only ecosystem covered.

This lands alongside repo-settings changes enabled via the API in the same session: secret scanning alerts + push protection, Dependabot alerts + security updates, and a "Protect main" ruleset (PRs required, `Unit tests (iOS Simulator)` as a required check, force pushes and deletion blocked).

## Related Issues

None.

## Testing

Config-only change, no app code touched. YAML follows the documented Dependabot v2 schema; Dependabot validates it on merge (visible under Insights, Dependency graph, Dependabot).

## Checklist

- [x] Builds on iOS and macOS (no code changes)
- [x] Tests pass (CI runs on this PR)
- [x] Ran `swiftlint lint --quiet` and `swiftformat .` (not applicable, YAML only)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
