### PR TITLE
Rename Pages workflow to "Pages Deploy"

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy website to GitHub Pages
+name: Pages Deploy
 
 # Publishes the static marketing site in website/ to GitHub Pages.
 # Only runs when the site (or this workflow) changes, so ordinary app


### PR DESCRIPTION
## Summary

Renames the Pages workflow from "Deploy website to GitHub Pages" to "Pages Deploy" so the Actions sidebar reads cleanly next to "iOS Tests" and "CodeQL". Name-only change; triggers, permissions, and steps are untouched. Note the workflow's own path filter includes this file, so merging will trigger one (no-op) site redeploy.

Part of the Actions-sidebar cleanup: the stale dynamic entries (leftover default-setup CodeQL, two Copilot workflows, pages-build-deployment) were removed by purging their run history.

## Related Issues

None.

## Testing

Config-only change, no app code touched. The workflow list API confirms the rename takes effect from the default branch once merged.

## Checklist

- [x] Builds on iOS and macOS (no code changes)
- [x] Tests pass (CI runs on this PR)
- [x] Ran `swiftlint lint --quiet` and `swiftformat .` (not applicable, YAML only)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
