### PR TITLE
Add subtasks and task relations (#1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
-- The "Quick Add Task" action in the Shortcuts app now works. It opens mDone with the quick-add bar focused and ready to type. Previously the action always failed with "an internal error occurred" because it ran from the widget extension instead of the app (#121).
 - Rescheduling a task via the long-press "Schedule" menu no longer drops it from the **Current** section until the next refresh (the same server-response quirk fixed for other edits in 1.7.0).
 
 ### Added
 - **Subtasks**: tasks with subtasks now show them indented underneath in every list (Inbox sections, project lists, and the Mac task list), with a "2/5" progress badge on the parent row showing how many are done. Checking a subtask off updates the parent's count immediately (#1).
 - Manage subtasks from a task's detail view: add a new subtask by typing its title, or tap "Link Existing Task" to pick any open task — searchable, from any project, with each task's project shown — and make it a subtask. Check subtasks off or unlink them (unlinking never deletes the task). Tasks that are subtasks also show their parent, and any other relations created in Vikunja (Blocked By, Precedes, Duplicates, …) are listed and can be removed (#1).
+
+## [1.9.0] - 2026-07-20
+
+### Added
+- You can now choose how big tasks appear in your lists: Settings > Appearance > **Task row size** offers Compact, Standard, and Large. Compact shrinks the text and tightens the rows so more tasks fit on screen, Large makes them easier to read, and Standard keeps the app's original look (and stays the default). Applies to the Inbox, project lists, the calendar's day list, and the Mac task list, matching the size options the widgets already offer (#122).
 - "Quick Add Task" is now a proper App Shortcut: it appears automatically in the Shortcuts app, can be run by voice with Siri ("Add a task in mDone"), and works on Mac as well as iPhone.
+
+### Fixed
+- The "Quick Add Task" action in the Shortcuts app now works. It opens mDone with the quick-add bar focused and ready to type. Previously the action always failed with "an internal error occurred" because it ran from the widget extension instead of the app (#121).
 
 ### Removed
 - The "Open Task" action no longer appears in the Shortcuts app. It never worked (it failed with the same internal error as Quick Add Task) and offered no way to pick a task, so it has been removed rather than left broken.
@@ -21,7 +28,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [1.8.0] - 2026-07-13
 
 ### Added
-- You can now choose how big tasks appear in your lists: Settings > Appearance > **Task row size** offers Compact, Standard, and Large. Compact shrinks the text and tightens the rows so more tasks fit on screen, Large makes them easier to read, and Standard keeps the app's original look (and stays the default). Applies to the Inbox, project lists, the calendar's day list, and the Mac task list, matching the size options the widgets already offer (#122).
 - Projects now display as a hierarchy: sub-projects nest under their parent with an indent and an expand/collapse chevron, matching Vikunja's folder structure on the web. Both the iPhone project list and the Mac sidebar are sorted by each project's position (then name), so the ordering is stable instead of showing sub-projects jumbled at the top. Collapsed projects stay collapsed across app launches (#118).
 - You can now build and rearrange that hierarchy from the app: pick a **Parent Project** when creating or editing a project, and **Move to…** a project under a different parent (or back to the top level) from its right-click / long-press menu. Options that would create a loop (moving a project under itself or one of its own sub-projects) are hidden (#118).
 - Tasks now show the color you assign them in Vikunja. Each colored task tints its leading accent bar and completion circle with its hex color, so color-coded contexts (work, personal, clients) are visible at a glance in every list. Uncolored tasks are unchanged (#112).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - The "Quick Add Task" action in the Shortcuts app now works. It opens mDone with the quick-add bar focused and ready to type. Previously the action always failed with "an internal error occurred" because it ran from the widget extension instead of the app (#121).
+- Rescheduling a task via the long-press "Schedule" menu no longer drops it from the **Current** section until the next refresh (the same server-response quirk fixed for other edits in 1.7.0).
 
 ### Added
+- **Subtasks**: tasks with subtasks now show them indented underneath in every list (Inbox sections, project lists, and the Mac task list), with a "2/5" progress badge on the parent row showing how many are done. Checking a subtask off updates the parent's count immediately (#1).
+- Manage subtasks from a task's detail view: add a new subtask by typing its title, link an existing task from the same project, check subtasks off, or unlink one (unlinking never deletes the task). Tasks that are subtasks also show their parent, and any other relations created in Vikunja (Blocked By, Precedes, Duplicates, …) are listed and can be removed (#1).
 - "Quick Add Task" is now a proper App Shortcut: it appears automatically in the Shortcuts app, can be run by voice with Siri ("Add a task in mDone"), and works on Mac as well as iPhone.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - **Subtasks**: tasks with subtasks now show them indented underneath in every list (Inbox sections, project lists, and the Mac task list), with a "2/5" progress badge on the parent row showing how many are done. Checking a subtask off updates the parent's count immediately (#1).
-- Manage subtasks from a task's detail view: add a new subtask by typing its title, link an existing task from the same project, check subtasks off, or unlink one (unlinking never deletes the task). Tasks that are subtasks also show their parent, and any other relations created in Vikunja (Blocked By, Precedes, Duplicates, …) are listed and can be removed (#1).
+- Manage subtasks from a task's detail view: add a new subtask by typing its title, or tap "Link Existing Task" to pick any open task — searchable, from any project, with each task's project shown — and make it a subtask. Check subtasks off or unlink them (unlinking never deletes the task). Tasks that are subtasks also show their parent, and any other relations created in Vikunja (Blocked By, Precedes, Duplicates, …) are listed and can be removed (#1).
 - "Quick Add Task" is now a proper App Shortcut: it appears automatically in the Shortcuts app, can be run by voice with Siri ("Add a task in mDone"), and works on Mac as well as iPhone.
 
 ### Removed

--- a/docs/appstore-metadata.md
+++ b/docs/appstore-metadata.md
@@ -83,10 +83,21 @@ Steps to test:
 
 This is a private test server maintained by the developer for App Store review purposes.
 
-## What's New (v1.8.1)
+## What's New (v1.10.0)
 
-Shortcuts and Siri fixes.
+Subtasks: break big tasks into steps.
 
+- Tasks now show their subtasks nested underneath in every list, with a progress badge on the parent (e.g. 2/5 done).
+- Add subtasks from a task's detail view, or link any existing task — from any project — as a subtask, with search.
+- Tick subtasks off right from the parent task's detail view; the progress badge updates instantly.
+- Relations created in Vikunja on the web (Blocked By, Precedes, Duplicates and more) now show on the task and can be removed.
+- Available on both iPhone and Mac.
+
+## What's New (v1.9.0)
+
+Task row sizes, plus Shortcuts and Siri fixes.
+
+- Choose how big tasks appear in your lists: Settings > Appearance > Task row size offers Compact, Standard, and Large.
 - The "Quick Add Task" action in the Shortcuts app now works: it opens mDone with the quick-add bar ready to type. It previously failed with an internal error.
 - Quick Add Task is now a proper App Shortcut, so it appears in the Shortcuts app automatically and works with Siri: just say "Add a task in mDone".
 - Removed the broken "Open Task" action.

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -564,19 +564,20 @@ final class AppState {
         }
     }
 
-    /// Vikunja's task-update/toggle response returns `labels: null` (it doesn't
-    /// echo the task's labels). Replacing the local task wholesale with that
-    /// response would drop its labels until the next full refresh, which made a
-    /// Current task vanish from its section the moment you edited it (e.g.
-    /// changed its progress). Carry the existing labels forward when the
-    /// response omits them. Only labels are preserved: they're never edited via
-    /// the task-update endpoint (the Current label is toggled through the
-    /// dedicated label endpoints), so this can't mask a user edit. Other
-    /// relations like reminders *are* sent in the update request, so we let the
+    /// Vikunja's task-update/toggle response returns `labels: null` and
+    /// `related_tasks: null` (it doesn't echo either). Replacing the local task
+    /// wholesale with that response would drop its labels until the next full
+    /// refresh, which made a Current task vanish from its section the moment
+    /// you edited it (e.g. changed its progress) — and would likewise wipe its
+    /// subtask list and count. Carry both forward when the response omits them.
+    /// Neither is edited via the task-update endpoint (labels use the label
+    /// endpoints, relations the relation endpoints), so this can't mask a user
+    /// edit. Reminders *are* sent in the update request, so we let the
     /// response drive them.
     static func preservingRelations(existing: VTask, response: VTask) -> VTask {
         var result = response
         if result.labels == nil { result.labels = existing.labels }
+        if result.relatedTasks == nil { result.relatedTasks = existing.relatedTasks }
         return result
     }
 
@@ -588,7 +589,13 @@ final class AppState {
                 .map { Self.preservingRelations(existing: $0, response: response) } ?? response
             if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
                 tasks[index] = updated
+            } else {
+                // Subtasks toggled from a parent's detail view may not be in
+                // the live list (some server versions omit done tasks) —
+                // insert so subsequent toggles and counts see fresh state.
+                tasks.append(updated)
             }
+            syncEmbeddedRelations(with: updated)
             syncService?.updateCachedTask(updated)
             if updated.done {
                 recordCompletionForUndo(task)
@@ -628,6 +635,7 @@ final class AppState {
             } else {
                 tasks.append(restored)
             }
+            syncEmbeddedRelations(with: restored)
             syncService?.updateCachedTask(restored)
             #if os(iOS)
             UINotificationFeedbackGenerator().notificationOccurred(.success)
@@ -704,6 +712,7 @@ final class AppState {
             if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
                 tasks[index] = updated
             }
+            syncEmbeddedRelations(with: updated)
             syncService?.updateCachedTask(updated)
             WidgetCenter.shared.reloadAllTimelines()
         } catch {
@@ -727,10 +736,13 @@ final class AppState {
         }
 
         do {
-            let updated = try await taskService.updateTask(id: task.id, request: TaskUpdateRequest(dueDate: newDate))
+            let response = try await taskService.updateTask(id: task.id, request: TaskUpdateRequest(dueDate: newDate))
+            let updated = tasks.first(where: { $0.id == response.id })
+                .map { Self.preservingRelations(existing: $0, response: response) } ?? response
             if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
                 tasks[index] = updated
             }
+            syncEmbeddedRelations(with: updated)
             syncService?.updateCachedTask(updated)
             WidgetCenter.shared.reloadAllTimelines()
         } catch {
@@ -750,10 +762,120 @@ final class AppState {
             if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
                 tasks[index] = updated
             }
+            syncEmbeddedRelations(with: updated)
             syncService?.updateCachedTask(updated)
             WidgetCenter.shared.reloadAllTimelines()
         } catch {
             handleError(error)
+        }
+    }
+
+    // MARK: - Subtasks & Relations
+
+    /// Links `childId` as a subtask of `parentId`, then refreshes both tasks
+    /// so each side's `related_tasks` reflects the server's view. Returns
+    /// `true` on success.
+    @MainActor
+    @discardableResult
+    func addSubtaskRelation(parentId: Int64, childId: Int64) async -> Bool {
+        do {
+            try await taskService.createRelation(taskId: parentId, otherTaskId: childId, kind: .subtask)
+            await refreshTasksAfterRelationChange(ids: [parentId, childId])
+            #if os(iOS)
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            #endif
+            return true
+        } catch {
+            handleError(error)
+            return false
+        }
+    }
+
+    /// Creates a new task in the parent's project and links it as a subtask.
+    /// Returns `true` when both steps succeed.
+    @MainActor
+    @discardableResult
+    func createSubtask(title: String, parent: VTask) async -> Bool {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        guard let newTask = await createTask(title: trimmed, projectId: parent.projectId) else { return false }
+        return await addSubtaskRelation(parentId: parent.id, childId: newTask.id)
+    }
+
+    /// Removes the `kind` relation between `taskId` and `otherTaskId` (the
+    /// server drops the inverse too), then refreshes both tasks. Removing a
+    /// `subtask` relation only unlinks the tasks — neither is deleted.
+    @MainActor
+    func removeRelation(taskId: Int64, otherTaskId: Int64, kind: RelationKind) async {
+        do {
+            try await taskService.deleteRelation(taskId: taskId, otherTaskId: otherTaskId, kind: kind)
+            await refreshTasksAfterRelationChange(ids: [taskId, otherTaskId])
+        } catch {
+            handleError(error)
+        }
+    }
+
+    /// Refetches the tasks touched by a relation change and merges them into
+    /// the live list. Single-task GETs return authoritative `related_tasks`,
+    /// unlike the relation endpoints (which return only the relation).
+    @MainActor
+    private func refreshTasksAfterRelationChange(ids: [Int64]) async {
+        for id in ids {
+            guard let fresh = try? await taskService.fetchTask(id: id) else { continue }
+            if let index = tasks.firstIndex(where: { $0.id == fresh.id }) {
+                tasks[index] = fresh
+            } else {
+                tasks.append(fresh)
+            }
+            syncEmbeddedRelations(with: fresh)
+            syncService?.updateCachedTask(fresh)
+        }
+    }
+
+    /// Mirrors an updated task into the embedded related-task snapshots other
+    /// tasks hold (`relatedTasks` copies), so subtask counts and nested rows
+    /// stay fresh without a refetch — e.g. checking a subtask off updates its
+    /// parent's "2/5 done" badge immediately.
+    @MainActor
+    private func syncEmbeddedRelations(with updatedTask: VTask) {
+        // Embedded snapshots never carry their own relations (the server
+        // doesn't recurse), so strip them before mirroring.
+        var snapshot = updatedTask
+        snapshot.relatedTasks = nil
+        for index in tasks.indices where tasks[index].id != updatedTask.id {
+            guard let related = tasks[index].relatedTasks else { continue }
+            var updatedMap = related
+            var changed = false
+            for (kind, list) in related where list.contains(where: { $0.id == updatedTask.id }) {
+                updatedMap[kind] = list.map { $0.id == updatedTask.id ? snapshot : $0 }
+                changed = true
+            }
+            if changed {
+                tasks[index].relatedTasks = updatedMap
+            }
+        }
+    }
+
+    /// Strips a deleted task out of every other task's embedded relation
+    /// snapshots so counts don't keep counting a task that no longer exists.
+    @MainActor
+    private func removeEmbeddedRelations(taskId: Int64) {
+        for index in tasks.indices {
+            guard let related = tasks[index].relatedTasks else { continue }
+            var updatedMap = related
+            var changed = false
+            for (kind, list) in related where list.contains(where: { $0.id == taskId }) {
+                let filtered = list.filter { $0.id != taskId }
+                if filtered.isEmpty {
+                    updatedMap.removeValue(forKey: kind)
+                } else {
+                    updatedMap[kind] = filtered
+                }
+                changed = true
+            }
+            if changed {
+                tasks[index].relatedTasks = updatedMap.isEmpty ? nil : updatedMap
+            }
         }
     }
 
@@ -763,7 +885,9 @@ final class AppState {
     /// exist yet. Persists the id so it survives a later rename.
     @MainActor
     private func ensureCurrentLabel() async throws -> VLabel {
-        if let existing = currentLabel { return existing }
+        if let existing = currentLabel {
+            return existing
+        }
         let created = try await labelService.createLabel(
             LabelCreateRequest(title: Self.currentLabelTitle, hexColor: "1a8cff")
         )
@@ -855,6 +979,7 @@ final class AppState {
             let taskId = task.id
             try await taskService.deleteTask(id: taskId)
             tasks.removeAll { $0.id == taskId }
+            removeEmbeddedRelations(taskId: taskId)
             syncService?.deleteCachedTask(id: taskId)
             onTaskDeleted?(taskId)
             #if os(iOS)
@@ -1152,7 +1277,9 @@ final class AppState {
             } else {
                 archivedProjects.append(project)
             }
-            if selectedProject?.id == project.id { selectedProject = nil }
+            if selectedProject?.id == project.id {
+                selectedProject = nil
+            }
         } else {
             archivedProjects.removeAll { $0.id == project.id }
             if let idx = projects.firstIndex(where: { $0.id == project.id }) {
@@ -1160,7 +1287,9 @@ final class AppState {
             } else {
                 projects.append(project)
             }
-            if selectedProject?.id == project.id { selectedProject = project }
+            if selectedProject?.id == project.id {
+                selectedProject = project
+            }
         }
     }
 

--- a/mDone/Models/TaskRelation.swift
+++ b/mDone/Models/TaskRelation.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// The kinds of relations Vikunja supports between two tasks.
+/// Raw values match the API's `relation_kind` strings exactly (all lowercase,
+/// no underscores — so they survive the snake-case key decoding untouched).
+enum RelationKind: String, Codable, CaseIterable, Identifiable {
+    case unknown
+    case subtask
+    case parenttask
+    case related
+    case duplicateof
+    case duplicates
+    case blocking
+    case blocked
+    case precedes
+    case follows
+    case copiedfrom
+    case copiedto
+
+    var id: String {
+        rawValue
+    }
+
+    /// Human-readable name, matching the wording of the Vikunja web frontend.
+    var label: String {
+        switch self {
+        case .unknown: "Unknown"
+        case .subtask: "Subtask"
+        case .parenttask: "Parent Task"
+        case .related: "Related"
+        case .duplicateof: "Duplicate Of"
+        case .duplicates: "Duplicates"
+        case .blocking: "Blocking"
+        case .blocked: "Blocked By"
+        case .precedes: "Precedes"
+        case .follows: "Follows"
+        case .copiedfrom: "Copied From"
+        case .copiedto: "Copied To"
+        }
+    }
+
+    /// Display name for a raw kind string, falling back to the raw value for
+    /// kinds a future server version might add.
+    static func label(forRawKind raw: String) -> String {
+        RelationKind(rawValue: raw)?.label ?? raw.capitalized
+    }
+}
+
+/// A single task relation as returned by `PUT /api/v1/tasks/{id}/relations`.
+struct TaskRelation: Codable, Hashable {
+    var taskId: Int64
+    var otherTaskId: Int64
+    var relationKind: String
+    var created: Date?
+}
+
+/// Request body for creating a relation. `relation_kind` encodes as the enum's
+/// raw string; key snake-casing is applied by `APIClient`'s encoder.
+struct TaskRelationRequest: Encodable {
+    var otherTaskId: Int64
+    var relationKind: RelationKind
+}
+
+/// A task list entry with its nesting depth (0 = top level, 1+ = subtask of
+/// the row above it at a lower depth).
+struct TaskListRow: Identifiable, Hashable {
+    let task: VTask
+    let depth: Int
+
+    var id: Int64 {
+        task.id
+    }
+}
+
+/// Orders a task list depth-first so each task's subtasks appear directly
+/// beneath it, indented. Pure and view-independent so it can be unit-tested.
+enum TaskNesting {
+    /// Returns `tasks` reordered for nested display. A task nests under a
+    /// parent only when that parent is itself in `tasks`; otherwise it stays
+    /// at the top level, so no task ever disappears from a filtered list
+    /// (e.g. a subtask due today whose parent is due next week).
+    ///
+    /// Every input task is emitted exactly once: an `emitted` guard makes the
+    /// walk safe against relation cycles and tasks with multiple parents
+    /// (both representable in Vikunja), and a final sweep catches tasks whose
+    /// parents form a cycle among themselves.
+    static func rows(for tasks: [VTask]) -> [TaskListRow] {
+        let presentIds = Set(tasks.map(\.id))
+
+        var childrenByParent: [Int64: [VTask]] = [:]
+        var childIds = Set<Int64>()
+        for task in tasks {
+            for parent in task.parentTasks where parent.id != task.id && presentIds.contains(parent.id) {
+                childrenByParent[parent.id, default: []].append(task)
+                childIds.insert(task.id)
+            }
+        }
+
+        // Fast path: nothing to nest, keep the caller's ordering untouched.
+        guard !childIds.isEmpty else {
+            return tasks.map { TaskListRow(task: $0, depth: 0) }
+        }
+
+        var result: [TaskListRow] = []
+        var emitted = Set<Int64>()
+
+        func emit(_ task: VTask, depth: Int) {
+            guard emitted.insert(task.id).inserted else { return }
+            result.append(TaskListRow(task: task, depth: depth))
+            for child in childrenByParent[task.id] ?? [] {
+                emit(child, depth: depth + 1)
+            }
+        }
+
+        for task in tasks where !childIds.contains(task.id) {
+            emit(task, depth: 0)
+        }
+        // Tasks unreachable from any top-level task (their parents form a
+        // cycle) still need to show up — surface them flat.
+        for task in tasks {
+            emit(task, depth: 0)
+        }
+        return result
+    }
+}

--- a/mDone/Models/TaskRelation.swift
+++ b/mDone/Models/TaskRelation.swift
@@ -72,6 +72,32 @@ struct TaskListRow: Identifiable, Hashable {
     }
 }
 
+/// Filters and orders the tasks eligible to become subtasks of a given parent.
+/// Pure and view-independent so it can be unit-tested.
+enum SubtaskLinkCandidates {
+    /// Open tasks from ANY project (Vikunja allows cross-project relations)
+    /// that aren't the parent itself and aren't already directly related to
+    /// it. The parent's own project lists first, then everything else,
+    /// alphabetically within each group.
+    static func candidates(for parent: VTask, in tasks: [VTask]) -> [VTask] {
+        let subtaskIds = Set(parent.subtasks.map(\.id))
+        let parentIds = Set(parent.parentTasks.map(\.id))
+        return tasks
+            .filter {
+                !$0.done
+                    && $0.id != parent.id
+                    && !subtaskIds.contains($0.id)
+                    && !parentIds.contains($0.id)
+            }
+            .sorted { a, b in
+                let aInProject = a.projectId == parent.projectId
+                let bInProject = b.projectId == parent.projectId
+                if aInProject != bInProject { return aInProject }
+                return a.title.localizedCompare(b.title) == .orderedAscending
+            }
+    }
+}
+
 /// Orders a task list depth-first so each task's subtasks appear directly
 /// beneath it, indented. Pure and view-independent so it can be unit-tested.
 enum TaskNesting {

--- a/mDone/Models/VTask.swift
+++ b/mDone/Models/VTask.swift
@@ -28,9 +28,42 @@ struct VTask: Codable, Identifiable, Hashable {
     var updated: Date?
     var bucketId: Int64?
     var coverImageAttachmentId: Int64?
+    /// Tasks related to this one, keyed by the raw relation kind (`"subtask"`,
+    /// `"parenttask"`, `"blocking"`, …). Kept as raw strings so a kind added
+    /// by a future server version can't fail decoding. The embedded tasks are
+    /// snapshots without their own relations (`related_tasks` is `null` one
+    /// level down — the server doesn't recurse).
+    var relatedTasks: [String: [VTask]]?
 
     var priorityLevel: PriorityLevel {
         PriorityLevel(rawValue: Int(priority)) ?? .none
+    }
+
+    /// The related tasks of one kind, in server order. Empty when none.
+    func relatedTasks(of kind: RelationKind) -> [VTask] {
+        relatedTasks?[kind.rawValue] ?? []
+    }
+
+    /// Direct subtasks of this task (including completed ones).
+    var subtasks: [VTask] {
+        relatedTasks(of: .subtask)
+    }
+
+    /// Tasks this one is a subtask of. Vikunja allows more than one parent.
+    var parentTasks: [VTask] {
+        relatedTasks(of: .parenttask)
+    }
+
+    var hasParentTask: Bool {
+        !parentTasks.isEmpty
+    }
+
+    /// Completed/total counts across direct subtasks, driving the "2/5 done"
+    /// badge. `nil` when the task has no subtasks.
+    var subtaskCounts: (done: Int, total: Int)? {
+        let subs = subtasks
+        guard !subs.isEmpty else { return nil }
+        return (subs.filter(\.done).count, subs.count)
     }
 
     var isRepeating: Bool {

--- a/mDone/Services/Endpoint.swift
+++ b/mDone/Services/Endpoint.swift
@@ -111,6 +111,10 @@ struct Endpoint {
         if let orderBy, !orderBy.isEmpty {
             items.append(URLQueryItem(name: "order_by", value: orderBy))
         }
+        // Ask the server to embed each task's subtask relations. Current
+        // Vikunja (2.x) populates `related_tasks` in list responses anyway,
+        // but versions that gate it behind `expand` need this to be explicit.
+        items.append(URLQueryItem(name: "expand", value: "subtasks"))
         return Endpoint(path: "/api/v1/tasks", queryItems: items)
     }
 
@@ -118,6 +122,7 @@ struct Endpoint {
         Endpoint(path: "/api/v1/projects/\(projectId)/views/\(viewId)/tasks", queryItems: [
             URLQueryItem(name: "page", value: "\(page)"),
             URLQueryItem(name: "per_page", value: "\(perPage)"),
+            URLQueryItem(name: "expand", value: "subtasks"),
         ])
     }
 
@@ -135,6 +140,22 @@ struct Endpoint {
 
     static func task(id: Int64) -> Endpoint {
         Endpoint(path: "/api/v1/tasks/\(id)")
+    }
+
+    // MARK: - Task Relations
+
+    /// Creates a relation between two tasks. Vikunja uses PUT (not POST) for
+    /// creation, with a body of `{ "other_task_id": <id>, "relation_kind": "<kind>" }`.
+    /// The inverse relation (e.g. `parenttask` on the other task when creating
+    /// a `subtask`) is created server-side automatically.
+    static func createTaskRelation(taskId: Int64) -> Endpoint {
+        Endpoint(path: "/api/v1/tasks/\(taskId)/relations", method: .PUT)
+    }
+
+    /// Removes a relation; the server also removes the inverse relation from
+    /// the other task.
+    static func deleteTaskRelation(taskId: Int64, relationKind: String, otherTaskId: Int64) -> Endpoint {
+        Endpoint(path: "/api/v1/tasks/\(taskId)/relations/\(relationKind)/\(otherTaskId)", method: .DELETE)
     }
 
     // MARK: - Labels

--- a/mDone/Services/TaskService.swift
+++ b/mDone/Services/TaskService.swift
@@ -43,6 +43,23 @@ actor TaskService {
         try await apiClient.sendExpectingEmpty(Endpoint.updateTaskPosition(taskId: taskId), body: request)
     }
 
+    /// Links `otherTaskId` to `taskId` with the given relation kind — e.g.
+    /// `.subtask` makes `otherTaskId` a subtask of `taskId`. The server creates
+    /// the inverse relation on the other task automatically.
+    @discardableResult
+    func createRelation(taskId: Int64, otherTaskId: Int64, kind: RelationKind) async throws -> TaskRelation {
+        let request = TaskRelationRequest(otherTaskId: otherTaskId, relationKind: kind)
+        return try await apiClient.send(Endpoint.createTaskRelation(taskId: taskId), body: request)
+    }
+
+    /// Removes the `kind` relation between `taskId` and `otherTaskId`; the
+    /// server drops the inverse relation as well.
+    func deleteRelation(taskId: Int64, otherTaskId: Int64, kind: RelationKind) async throws {
+        try await apiClient.delete(
+            Endpoint.deleteTaskRelation(taskId: taskId, relationKind: kind.rawValue, otherTaskId: otherTaskId)
+        )
+    }
+
     /// Moves a task into a kanban bucket (column) within a project view.
     func moveTaskToBucket(taskId: Int64, projectId: Int64, viewId: Int64, bucketId: Int64) async throws {
         let request = TaskBucketRequest(taskId: taskId)

--- a/mDone/Views/Mac/MacTaskDetailView.swift
+++ b/mDone/Views/Mac/MacTaskDetailView.swift
@@ -114,6 +114,8 @@ struct MacTaskDetailView: View {
                 }
             }
 
+            TaskRelationsSections(task: task)
+
             Section("Due Date") {
                 Toggle("Has due date", isOn: $hasDueDate.animation())
 

--- a/mDone/Views/Mac/MacTaskListView.swift
+++ b/mDone/Views/Mac/MacTaskListView.swift
@@ -100,11 +100,11 @@ struct MacTaskListView: View {
                 }
                 .listStyle(.inset)
             } else {
-                List(tasks, selection: $selectedTask) { task in
-                    TaskRow(task: task)
-                        .tag(task)
-                        .draggable(String(task.id)) {
-                            Text(task.title)
+                List(TaskNesting.rows(for: tasks), selection: $selectedTask) { row in
+                    TaskRow(task: row.task, indentLevel: row.depth)
+                        .tag(row.task)
+                        .draggable(String(row.task.id)) {
+                            Text(row.task.title)
                                 .padding(8)
                                 .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
                         }

--- a/mDone/Views/Tasks/SmartListSection.swift
+++ b/mDone/Views/Tasks/SmartListSection.swift
@@ -9,13 +9,24 @@ struct SmartListSection: View {
     var showsProgress: Bool = false
 
     var body: some View {
+        let rows = TaskNesting.rows(for: tasks)
         Section {
-            ForEach(tasks) { task in
-                TaskRow(task: task, showsProgress: showsProgress)
-                    .tag(task)
-            }
-            .onMove { source, destination in
-                handleMove(from: source, to: destination)
+            if rows.contains(where: { $0.depth > 0 }) {
+                // Nested display: subtasks sit indented beneath their parent.
+                // Drag-reorder is disabled here because the visual order no
+                // longer matches the flat position order Vikunja stores.
+                ForEach(rows) { row in
+                    TaskRow(task: row.task, showsProgress: showsProgress, indentLevel: row.depth)
+                        .tag(row.task)
+                }
+            } else {
+                ForEach(tasks) { task in
+                    TaskRow(task: task, showsProgress: showsProgress)
+                        .tag(task)
+                }
+                .onMove { source, destination in
+                    handleMove(from: source, to: destination)
+                }
             }
         } header: {
             HStack {

--- a/mDone/Views/Tasks/SmartListSection.swift
+++ b/mDone/Views/Tasks/SmartListSection.swift
@@ -10,23 +10,22 @@ struct SmartListSection: View {
 
     var body: some View {
         let rows = TaskNesting.rows(for: tasks)
+        let hasNesting = rows.contains { $0.depth > 0 }
         Section {
-            if rows.contains(where: { $0.depth > 0 }) {
-                // Nested display: subtasks sit indented beneath their parent.
-                // Drag-reorder is disabled here because the visual order no
-                // longer matches the flat position order Vikunja stores.
-                ForEach(rows) { row in
-                    TaskRow(task: row.task, showsProgress: showsProgress, indentLevel: row.depth)
-                        .tag(row.task)
-                }
-            } else {
-                ForEach(tasks) { task in
-                    TaskRow(task: task, showsProgress: showsProgress)
-                        .tag(task)
-                }
-                .onMove { source, destination in
-                    handleMove(from: source, to: destination)
-                }
+            // One ForEach for both flat and nested display, so a row's
+            // identity survives the list gaining/losing nesting — otherwise a
+            // detail sheet presented from a row gets torn down the moment its
+            // task's first subtask is linked. Reorder stays flat-only (nested
+            // visual order doesn't match Vikunja's flat position order);
+            // when flat, `rows` preserves `tasks`' order so `handleMove`
+            // indices line up.
+            ForEach(rows) { row in
+                TaskRow(task: row.task, showsProgress: showsProgress, indentLevel: row.depth)
+                    .tag(row.task)
+                    .moveDisabled(hasNesting)
+            }
+            .onMove { source, destination in
+                handleMove(from: source, to: destination)
             }
         } header: {
             HStack {

--- a/mDone/Views/Tasks/TaskDetailSheet.swift
+++ b/mDone/Views/Tasks/TaskDetailSheet.swift
@@ -134,6 +134,8 @@ struct TaskDetailSheet: View {
                     }
                 }
 
+                TaskRelationsSections(task: task)
+
                 Section {
                     Toggle("Due Date", isOn: $hasDueDate.animation())
 

--- a/mDone/Views/Tasks/TaskListScreen.swift
+++ b/mDone/Views/Tasks/TaskListScreen.swift
@@ -117,25 +117,21 @@ struct TaskListScreen: View {
                             }
                         } else {
                             let rows = TaskNesting.rows(for: projectTasks)
+                            let hasNesting = rows.contains { $0.depth > 0 }
                             Section {
-                                if readOnly {
-                                    ForEach(rows) { row in
-                                        TaskRow(task: row.task, readOnly: true, indentLevel: row.depth)
-                                    }
-                                } else if rows.contains(where: { $0.depth > 0 }) {
-                                    // Nested display: drag-reorder is disabled
-                                    // because visual order no longer matches the
-                                    // flat position order Vikunja stores.
-                                    ForEach(rows) { row in
-                                        TaskRow(task: row.task, indentLevel: row.depth)
-                                    }
-                                } else {
-                                    ForEach(projectTasks) { task in
-                                        TaskRow(task: task)
-                                    }
-                                    .onMove { source, destination in
-                                        handleMove(tasks: projectTasks, from: source, to: destination)
-                                    }
+                                // Single ForEach for flat and nested display so
+                                // row identity survives the list gaining/losing
+                                // nesting (else a presented detail sheet gets
+                                // dismissed when the first subtask is linked).
+                                // Reorder is flat-only; when flat, `rows`
+                                // preserves `projectTasks`' order so the move
+                                // indices line up.
+                                ForEach(rows) { row in
+                                    TaskRow(task: row.task, readOnly: readOnly, indentLevel: row.depth)
+                                        .moveDisabled(readOnly || hasNesting)
+                                }
+                                .onMove { source, destination in
+                                    handleMove(tasks: projectTasks, from: source, to: destination)
                                 }
                             }
                         }

--- a/mDone/Views/Tasks/TaskListScreen.swift
+++ b/mDone/Views/Tasks/TaskListScreen.swift
@@ -116,10 +116,18 @@ struct TaskListScreen: View {
                                 )
                             }
                         } else {
+                            let rows = TaskNesting.rows(for: projectTasks)
                             Section {
                                 if readOnly {
-                                    ForEach(projectTasks) { task in
-                                        TaskRow(task: task, readOnly: true)
+                                    ForEach(rows) { row in
+                                        TaskRow(task: row.task, readOnly: true, indentLevel: row.depth)
+                                    }
+                                } else if rows.contains(where: { $0.depth > 0 }) {
+                                    // Nested display: drag-reorder is disabled
+                                    // because visual order no longer matches the
+                                    // flat position order Vikunja stores.
+                                    ForEach(rows) { row in
+                                        TaskRow(task: row.task, indentLevel: row.depth)
                                     }
                                 } else {
                                     ForEach(projectTasks) { task in

--- a/mDone/Views/Tasks/TaskRelationsSections.swift
+++ b/mDone/Views/Tasks/TaskRelationsSections.swift
@@ -10,6 +10,7 @@ struct TaskRelationsSections: View {
 
     @State private var newSubtaskTitle = ""
     @State private var isAddingSubtask = false
+    @State private var showLinkSheet = false
 
     /// The freshest copy of the task we can get: live from AppState when
     /// loaded, else the snapshot the detail view was opened with.
@@ -46,18 +47,13 @@ struct TaskRelationsSections: View {
                 .accessibilityLabel("Add subtask")
             }
 
-            if !linkCandidates.isEmpty {
-                Menu {
-                    ForEach(linkCandidates) { candidate in
-                        Button(candidate.title) {
-                            Task {
-                                await appState.addSubtaskRelation(parentId: liveTask.id, childId: candidate.id)
-                            }
-                        }
-                    }
-                } label: {
-                    Label("Link Existing Task", systemImage: "link")
-                }
+            Button {
+                showLinkSheet = true
+            } label: {
+                Label("Link Existing Task…", systemImage: "link")
+            }
+            .sheet(isPresented: $showLinkSheet) {
+                LinkSubtaskSheet(parent: liveTask)
             }
         } header: {
             HStack {
@@ -68,6 +64,8 @@ struct TaskRelationsSections: View {
                         .monospacedDigit()
                 }
             }
+        } footer: {
+            Text("Subtasks nest under this task in your lists. Unlinking never deletes a task.")
         }
     }
 
@@ -198,23 +196,92 @@ struct TaskRelationsSections: View {
         }
     }
 
-    /// Same-project tasks that could become subtasks of this one: not done,
-    /// not itself, not already a subtask, and not one of its parents (which
-    /// would create an immediate cycle). Capped to keep the menu usable.
-    private var linkCandidates: [VTask] {
-        let current = liveTask
-        let subtaskIds = Set(current.subtasks.map(\.id))
-        let parentIds = Set(current.parentTasks.map(\.id))
-        return appState.tasks
-            .filter {
-                $0.projectId == current.projectId
-                    && !$0.done
-                    && $0.id != current.id
-                    && !subtaskIds.contains($0.id)
-                    && !parentIds.contains($0.id)
+}
+
+/// Full-screen-friendly picker for turning an existing task into a subtask of
+/// `parent`. Lists every eligible open task across all projects (Vikunja
+/// supports cross-project relations), the parent's own project first, with a
+/// search field and each task's project shown underneath its title.
+struct LinkSubtaskSheet: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+    let parent: VTask
+
+    @State private var searchText = ""
+    @State private var isLinking = false
+
+    private var candidates: [VTask] {
+        let all = SubtaskLinkCandidates.candidates(for: parent, in: appState.tasks)
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return all }
+        return all.filter { $0.title.localizedCaseInsensitiveContains(query) }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if candidates.isEmpty {
+                    EmptyStateView(
+                        icon: "link",
+                        title: searchText.isEmpty ? "No Tasks to Link" : "No Matches",
+                        subtitle: searchText.isEmpty
+                            ? "Every other open task is already related to this one."
+                            : "No open task titles match your search."
+                    )
+                } else {
+                    List {
+                        Section {
+                            ForEach(candidates) { candidate in
+                                candidateRow(for: candidate)
+                            }
+                        } header: {
+                            Text("The task you pick becomes a subtask of \"\(parent.title)\". It stays in its own project.")
+                                .textCase(nil)
+                        }
+                    }
+                }
             }
-            .sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
-            .prefix(30)
-            .map { $0 }
+            .searchable(text: $searchText, prompt: "Search tasks")
+            .navigationTitle("Link Subtask")
+            #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+            #endif
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+        }
+        #if os(macOS)
+        .frame(minWidth: 400, minHeight: 440)
+        #endif
+    }
+
+    private func candidateRow(for candidate: VTask) -> some View {
+        Button {
+            guard !isLinking else { return }
+            isLinking = true
+            Task {
+                let linked = await appState.addSubtaskRelation(parentId: parent.id, childId: candidate.id)
+                isLinking = false
+                if linked { dismiss() }
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(candidate.title)
+                    .foregroundStyle(Color.primary)
+                Text(projectName(for: candidate))
+                    .font(.caption)
+                    .foregroundStyle(Color.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .disabled(isLinking)
+        .accessibilityLabel("Link \(candidate.title) as subtask")
+    }
+
+    private func projectName(for task: VTask) -> String {
+        appState.projects.first(where: { $0.id == task.projectId })?.title ?? "Project \(task.projectId)"
     }
 }

--- a/mDone/Views/Tasks/TaskRelationsSections.swift
+++ b/mDone/Views/Tasks/TaskRelationsSections.swift
@@ -1,0 +1,220 @@
+import SwiftUI
+
+/// The Subtasks / Parent Task / Related Tasks sections shared by the iOS
+/// detail sheet and the macOS detail view. Reads the live copy of the task
+/// from `AppState` (the passed-in value is a snapshot from when the detail
+/// view opened) so relation edits show up immediately.
+struct TaskRelationsSections: View {
+    @Environment(AppState.self) private var appState
+    let task: VTask
+
+    @State private var newSubtaskTitle = ""
+    @State private var isAddingSubtask = false
+
+    /// The freshest copy of the task we can get: live from AppState when
+    /// loaded, else the snapshot the detail view was opened with.
+    private var liveTask: VTask {
+        appState.tasks.first(where: { $0.id == task.id }) ?? task
+    }
+
+    var body: some View {
+        subtasksSection
+        if liveTask.hasParentTask {
+            parentSection
+        }
+        if !otherRelationEntries.isEmpty {
+            otherRelationsSection
+        }
+    }
+
+    // MARK: - Subtasks
+
+    private var subtasksSection: some View {
+        Section {
+            ForEach(liveTask.subtasks) { subtask in
+                subtaskRow(for: live(subtask))
+            }
+
+            HStack {
+                TextField("Add subtask", text: $newSubtaskTitle)
+                    .onSubmit(addNewSubtask)
+                Button(action: addNewSubtask) {
+                    Image(systemName: "plus.circle.fill")
+                }
+                .buttonStyle(.borderless)
+                .disabled(trimmedNewTitle.isEmpty || isAddingSubtask)
+                .accessibilityLabel("Add subtask")
+            }
+
+            if !linkCandidates.isEmpty {
+                Menu {
+                    ForEach(linkCandidates) { candidate in
+                        Button(candidate.title) {
+                            Task {
+                                await appState.addSubtaskRelation(parentId: liveTask.id, childId: candidate.id)
+                            }
+                        }
+                    }
+                } label: {
+                    Label("Link Existing Task", systemImage: "link")
+                }
+            }
+        } header: {
+            HStack {
+                Text("Subtasks")
+                Spacer()
+                if let counts = liveTask.subtaskCounts {
+                    Text("\(counts.done)/\(counts.total) done")
+                        .monospacedDigit()
+                }
+            }
+        }
+    }
+
+    private func subtaskRow(for subtask: VTask) -> some View {
+        HStack(spacing: 12) {
+            Button {
+                Task { await appState.toggleTaskDone(subtask) }
+            } label: {
+                Image(systemName: subtask.done ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(subtask.done ? .green : .gray)
+                    .contentTransition(.symbolEffect(.replace))
+            }
+            .buttonStyle(.borderless)
+            .accessibilityLabel(
+                subtask.done ? "Mark \(subtask.title) as incomplete" : "Mark \(subtask.title) as complete"
+            )
+            .accessibilityAddTraits(.isToggle)
+
+            Text(subtask.title)
+                .strikethrough(subtask.done)
+                .foregroundStyle(subtask.done ? .secondary : .primary)
+
+            Spacer()
+
+            unlinkButton(otherTaskId: subtask.id, kind: .subtask, title: subtask.title)
+        }
+    }
+
+    // MARK: - Parent
+
+    private var parentSection: some View {
+        Section("Parent Task") {
+            ForEach(liveTask.parentTasks) { parent in
+                let parentTask = live(parent)
+                HStack(spacing: 12) {
+                    Image(systemName: "arrow.turn.up.left")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                    Text(parentTask.title)
+                        .strikethrough(parentTask.done)
+                    Spacer()
+                    unlinkButton(otherTaskId: parent.id, kind: .parenttask, title: parentTask.title)
+                }
+            }
+        }
+    }
+
+    // MARK: - Other relation kinds
+
+    /// Relations other than subtask/parenttask (blocking, related, …), one
+    /// entry per (kind, task) pair. Unknown kinds a newer server might send
+    /// still display; they just can't be unlinked from mDone.
+    private struct RelationEntry: Identifiable {
+        let rawKind: String
+        let task: VTask
+        var id: String {
+            "\(rawKind)-\(task.id)"
+        }
+
+        var kind: RelationKind? {
+            RelationKind(rawValue: rawKind)
+        }
+    }
+
+    private var otherRelationEntries: [RelationEntry] {
+        guard let related = liveTask.relatedTasks else { return [] }
+        return related
+            .filter { $0.key != RelationKind.subtask.rawValue && $0.key != RelationKind.parenttask.rawValue }
+            .sorted { $0.key < $1.key }
+            .flatMap { kind, tasks in tasks.map { RelationEntry(rawKind: kind, task: $0) } }
+    }
+
+    private var otherRelationsSection: some View {
+        Section("Related Tasks") {
+            ForEach(otherRelationEntries) { entry in
+                let relatedTask = live(entry.task)
+                HStack(spacing: 12) {
+                    Text(RelationKind.label(forRawKind: entry.rawKind))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.secondary.opacity(0.15), in: Capsule())
+                    Text(relatedTask.title)
+                        .strikethrough(relatedTask.done)
+                    Spacer()
+                    if let kind = entry.kind {
+                        unlinkButton(otherTaskId: entry.task.id, kind: kind, title: relatedTask.title)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func unlinkButton(otherTaskId: Int64, kind: RelationKind, title: String) -> some View {
+        Button {
+            Task {
+                await appState.removeRelation(taskId: liveTask.id, otherTaskId: otherTaskId, kind: kind)
+            }
+        } label: {
+            Image(systemName: "xmark.circle")
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.borderless)
+        .accessibilityLabel("Remove \(kind.label.lowercased()) relation to \(title)")
+    }
+
+    private func live(_ snapshot: VTask) -> VTask {
+        appState.tasks.first(where: { $0.id == snapshot.id }) ?? snapshot
+    }
+
+    private var trimmedNewTitle: String {
+        newSubtaskTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func addNewSubtask() {
+        let title = trimmedNewTitle
+        guard !title.isEmpty, !isAddingSubtask else { return }
+        isAddingSubtask = true
+        Task {
+            if await appState.createSubtask(title: title, parent: liveTask) {
+                newSubtaskTitle = ""
+            }
+            isAddingSubtask = false
+        }
+    }
+
+    /// Same-project tasks that could become subtasks of this one: not done,
+    /// not itself, not already a subtask, and not one of its parents (which
+    /// would create an immediate cycle). Capped to keep the menu usable.
+    private var linkCandidates: [VTask] {
+        let current = liveTask
+        let subtaskIds = Set(current.subtasks.map(\.id))
+        let parentIds = Set(current.parentTasks.map(\.id))
+        return appState.tasks
+            .filter {
+                $0.projectId == current.projectId
+                    && !$0.done
+                    && $0.id != current.id
+                    && !subtaskIds.contains($0.id)
+                    && !parentIds.contains($0.id)
+            }
+            .sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
+            .prefix(30)
+            .map { $0 }
+    }
+}

--- a/mDone/Views/Tasks/TaskRow.swift
+++ b/mDone/Views/Tasks/TaskRow.swift
@@ -12,6 +12,9 @@ struct TaskRow: View {
     /// When true, the row shows a progress bar and (when stalled) an idle badge.
     /// Used by the "Current" section.
     var showsProgress: Bool = false
+    /// Nesting depth when the row renders as a subtask beneath its parent
+    /// (0 = top level). Indentation is capped so deep trees stay readable.
+    var indentLevel: Int = 0
     @State private var showDetail = false
     @AppStorage("calmMode") private var calmMode = false
     @AppStorage("currentStallDays") private var stallDays = 7
@@ -150,6 +153,13 @@ struct TaskRow: View {
 
     private var rowContent: some View {
         HStack(spacing: 12) {
+            if indentLevel > 0 {
+                Image(systemName: "arrow.turn.down.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
+            }
+
             RoundedRectangle(cornerRadius: 2)
                 .fill(accentColor)
                 .frame(width: 4, height: density.accentBarHeight)
@@ -202,6 +212,16 @@ struct TaskRow: View {
                         .foregroundStyle(.secondary)
                     }
 
+                    if let counts = task.subtaskCounts {
+                        HStack(spacing: 4) {
+                            Image(systemName: "checklist")
+                            Text("\(counts.done)/\(counts.total)")
+                                .monospacedDigit()
+                        }
+                        .font(density.metadataFont)
+                        .foregroundStyle(counts.done == counts.total ? Color.green : Color.secondary)
+                    }
+
                     if let labels = task.labels, !labels.isEmpty {
                         HStack(spacing: 4) {
                             ForEach(labels.prefix(3)) { label in
@@ -232,6 +252,7 @@ struct TaskRow: View {
             }
             #endif
         }
+        .padding(.leading, CGFloat(min(indentLevel, 4)) * 16)
         .padding(.vertical, density.rowVerticalPadding)
         .opacity(task.done ? 0.6 : 1)
         .accessibilityElement(children: .combine)
@@ -241,8 +262,14 @@ struct TaskRow: View {
     private var taskAccessibilityLabel: String {
         var parts: [String] = []
         parts.append(task.title)
+        if indentLevel > 0 {
+            parts.append("subtask")
+        }
         if task.done {
             parts.append("completed")
+        }
+        if let counts = task.subtaskCounts {
+            parts.append("\(counts.done) of \(counts.total) subtasks done")
         }
         if task.priority > 0 {
             parts.append("priority \(task.priorityLevel.label)")

--- a/mDoneTests/Helpers/MockURLProtocol.swift
+++ b/mDoneTests/Helpers/MockURLProtocol.swift
@@ -67,4 +67,24 @@ final class MockURLProtocol: URLProtocol {
         config.protocolClasses = [MockURLProtocol.self]
         return URLSession(configuration: config)
     }
+
+    /// Returns a request's body. URLSession hands URLProtocol the body as a
+    /// stream (`httpBody` is nil by the time the request reaches the handler),
+    /// so tests asserting on request bodies must go through this.
+    static func bodyData(from request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            guard read > 0 else { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
 }

--- a/mDoneTests/TaskRelationTests.swift
+++ b/mDoneTests/TaskRelationTests.swift
@@ -1,0 +1,497 @@
+import XCTest
+@testable import mDone
+
+/// Covers the task-relations feature (issue #1): the `related_tasks` model,
+/// relation endpoints/service calls, nesting order for list display, and the
+/// AppState flows that keep relation snapshots fresh.
+final class TaskRelationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    // MARK: - Fixtures
+
+    /// Task JSON in the server's snake_case shape, matching what Vikunja
+    /// v2.4.0 returns (null-able fields, zero-dates, created_by).
+    private static func taskJSON(
+        id: Int64,
+        title: String,
+        done: Bool = false,
+        projectId: Int64 = 1,
+        relatedTasks: String = "null"
+    ) -> String {
+        """
+        {"id": \(id), "title": "\(title)", "done": \(done), "priority": 0, "project_id": \(projectId),
+         "due_date": "0001-01-01T00:00:00Z", "labels": null, "assignees": null, "reactions": null,
+         "attachments": null, "identifier": "", "index": \(id), "percent_done": 0, "is_favorite": false,
+         "created": "2026-07-19T21:47:37Z", "updated": "2026-07-19T21:47:37Z", "created_by": null,
+         "related_tasks": \(relatedTasks)}
+        """
+    }
+
+    private func makeConfiguredService() async -> TaskService {
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        return TaskService(apiClient: client)
+    }
+
+    @MainActor
+    private func makeMockedAppState() async -> AppState {
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        return AppState(taskService: TaskService(apiClient: client))
+    }
+
+    private func makeTask(
+        id: Int64,
+        title: String = "Task",
+        done: Bool = false,
+        projectId: Int64 = 1,
+        relatedTasks: [String: [VTask]]? = nil
+    ) -> VTask {
+        VTask(id: id, title: title, done: done, priority: 0, projectId: projectId, relatedTasks: relatedTasks)
+    }
+
+    // MARK: - Decoding
+
+    func testFetchTaskDecodesRelatedTasks() async throws {
+        let service = await makeConfiguredService()
+        // The exact shape Vikunja v2.4.0 returns from GET /api/v1/tasks/{id}
+        // for a parent with three subtasks, one of them done.
+        let json = try XCTUnwrap(Self.taskJSON(
+            id: 1, title: "Parent task",
+            relatedTasks: """
+            {"subtask": [
+                \(Self.taskJSON(id: 2, title: "Child one", done: true)),
+                \(Self.taskJSON(id: 3, title: "Child two")),
+                \(Self.taskJSON(id: 4, title: "Child three"))
+            ]}
+            """
+        ).data(using: .utf8))
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), json)
+        }
+
+        let task = try await service.fetchTask(id: 1)
+        XCTAssertEqual(task.subtasks.map(\.id), [2, 3, 4])
+        XCTAssertEqual(task.subtasks.filter(\.done).map(\.id), [2])
+        let counts = try XCTUnwrap(task.subtaskCounts)
+        XCTAssertEqual(counts.done, 1)
+        XCTAssertEqual(counts.total, 3)
+        // Zero-dates inside embedded tasks map to distantPast -> no effective due date.
+        XCTAssertNil(task.subtasks[0].effectiveDueDate)
+        // Embedded tasks carry no relations of their own (server doesn't recurse).
+        XCTAssertNil(task.subtasks[0].relatedTasks)
+    }
+
+    func testFetchTaskDecodesParenttaskDirection() async throws {
+        let service = await makeConfiguredService()
+        let json = try XCTUnwrap(Self.taskJSON(
+            id: 3, title: "Child two",
+            relatedTasks: "{\"parenttask\": [\(Self.taskJSON(id: 1, title: "Parent task"))]}"
+        ).data(using: .utf8))
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), json)
+        }
+
+        let task = try await service.fetchTask(id: 3)
+        XCTAssertTrue(task.hasParentTask)
+        XCTAssertEqual(task.parentTasks.map(\.id), [1])
+        XCTAssertNil(task.subtaskCounts, "A task with no subtasks has no counts")
+    }
+
+    func testUnknownRelationKindStillDecodes() async throws {
+        let service = await makeConfiguredService()
+        let json = try XCTUnwrap(Self.taskJSON(
+            id: 5, title: "Future",
+            relatedTasks: "{\"somefuturekind\": [\(Self.taskJSON(id: 6, title: "Other"))]}"
+        ).data(using: .utf8))
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), json)
+        }
+
+        let task = try await service.fetchTask(id: 5)
+        XCTAssertEqual(task.relatedTasks?["somefuturekind"]?.map(\.id), [6])
+        XCTAssertTrue(task.subtasks.isEmpty)
+    }
+
+    // MARK: - RelationKind
+
+    func testRelationKindLabels() {
+        XCTAssertEqual(RelationKind.subtask.label, "Subtask")
+        XCTAssertEqual(RelationKind.parenttask.label, "Parent Task")
+        XCTAssertEqual(RelationKind.blocked.label, "Blocked By")
+        XCTAssertEqual(RelationKind.label(forRawKind: "duplicateof"), "Duplicate Of")
+        XCTAssertEqual(RelationKind.label(forRawKind: "somefuturekind"), "Somefuturekind")
+    }
+
+    func testRelationKindCoversVikunjaKinds() {
+        let expected: Set = [
+            "unknown", "subtask", "parenttask", "related", "duplicateof", "duplicates",
+            "blocking", "blocked", "precedes", "follows", "copiedfrom", "copiedto",
+        ]
+        XCTAssertEqual(Set(RelationKind.allCases.map(\.rawValue)), expected)
+    }
+
+    func testTaskRelationRequestEncoding() throws {
+        let request = TaskRelationRequest(otherTaskId: 9, relationKind: .subtask)
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let json = try JSONSerialization.jsonObject(with: encoder.encode(request)) as? [String: Any]
+
+        XCTAssertEqual(json?["other_task_id"] as? Int, 9)
+        XCTAssertEqual(json?["relation_kind"] as? String, "subtask")
+    }
+
+    // MARK: - Endpoints
+
+    func testRelationEndpoints() {
+        let create = Endpoint.createTaskRelation(taskId: 7)
+        XCTAssertEqual(create.path, "/api/v1/tasks/7/relations")
+        XCTAssertEqual(create.method, .PUT)
+
+        let delete = Endpoint.deleteTaskRelation(taskId: 7, relationKind: "subtask", otherTaskId: 9)
+        XCTAssertEqual(delete.path, "/api/v1/tasks/7/relations/subtask/9")
+        XCTAssertEqual(delete.method, .DELETE)
+    }
+
+    func testTaskListEndpointsRequestSubtaskExpansion() {
+        let all = Endpoint.allTasks()
+        XCTAssertTrue(all.queryItems?.contains(URLQueryItem(name: "expand", value: "subtasks")) == true)
+
+        let project = Endpoint.projectTasks(projectId: 1, viewId: 2)
+        XCTAssertTrue(project.queryItems?.contains(URLQueryItem(name: "expand", value: "subtasks")) == true)
+    }
+
+    // MARK: - TaskService
+
+    func testCreateRelationSendsCorrectRequest() async throws {
+        let service = await makeConfiguredService()
+        let responseJSON = """
+        {"task_id": 1, "other_task_id": 2, "relation_kind": "subtask",
+         "created_by": {"id": 1, "username": "probe"}, "created": "2026-07-19T21:48:02.120342215Z"}
+        """.data(using: .utf8)!
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/tasks/1/relations")
+            XCTAssertEqual(request.httpMethod, "PUT")
+            if let body = MockURLProtocol.bodyData(from: request),
+               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any]
+            {
+                XCTAssertEqual(json["other_task_id"] as? Int, 2)
+                XCTAssertEqual(json["relation_kind"] as? String, "subtask")
+            } else {
+                XCTFail("Missing request body")
+            }
+            return (MockURLProtocol.makeResponse(statusCode: 201, url: request.url), responseJSON)
+        }
+
+        let relation = try await service.createRelation(taskId: 1, otherTaskId: 2, kind: .subtask)
+        XCTAssertEqual(relation.taskId, 1)
+        XCTAssertEqual(relation.otherTaskId, 2)
+        XCTAssertEqual(relation.relationKind, "subtask")
+    }
+
+    func testDeleteRelationCallsDeleteEndpoint() async throws {
+        let service = await makeConfiguredService()
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/tasks/1/relations/subtask/2")
+            XCTAssertEqual(request.httpMethod, "DELETE")
+            let body = #"{"message":"Successfully deleted."}"#.data(using: .utf8)!
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), body)
+        }
+
+        try await service.deleteRelation(taskId: 1, otherTaskId: 2, kind: .subtask)
+        XCTAssertEqual(MockURLProtocol.capturedRequests.count, 1)
+    }
+
+    func testCreateRelationSurfacesConflictError() async {
+        let service = await makeConfiguredService()
+        MockURLProtocol.requestHandler = { request in
+            let body = #"{"code": 4008, "message": "The task relation already exists."}"#.data(using: .utf8)!
+            return (MockURLProtocol.makeResponse(statusCode: 409, url: request.url), body)
+        }
+
+        do {
+            _ = try await service.createRelation(taskId: 1, otherTaskId: 2, kind: .subtask)
+            XCTFail("Expected serverError")
+        } catch let NetworkError.serverError(statusCode, message) {
+            XCTAssertEqual(statusCode, 409)
+            XCTAssertEqual(message, "The task relation already exists.")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - TaskNesting
+
+    func testNestingKeepsFlatListOrderWhenNoRelations() {
+        let tasks = [makeTask(id: 1), makeTask(id: 2), makeTask(id: 3)]
+        let rows = TaskNesting.rows(for: tasks)
+        XCTAssertEqual(rows.map(\.id), [1, 2, 3])
+        XCTAssertTrue(rows.allSatisfy { $0.depth == 0 })
+    }
+
+    func testNestingPlacesSubtaskUnderParent() {
+        let tasks = [
+            makeTask(id: 2, title: "Unrelated"),
+            makeTask(id: 3, title: "Child", relatedTasks: ["parenttask": [makeTask(id: 1)]]),
+            makeTask(id: 1, title: "Parent"),
+        ]
+        let rows = TaskNesting.rows(for: tasks)
+        XCTAssertEqual(rows.map(\.id), [2, 1, 3], "Child moves directly beneath its parent")
+        XCTAssertEqual(rows.map(\.depth), [0, 0, 1])
+    }
+
+    func testNestingSupportsGrandchildren() {
+        let tasks = [
+            makeTask(id: 1, title: "Parent"),
+            makeTask(id: 2, title: "Child", relatedTasks: ["parenttask": [makeTask(id: 1)]]),
+            makeTask(id: 3, title: "Grandchild", relatedTasks: ["parenttask": [makeTask(id: 2)]]),
+        ]
+        let rows = TaskNesting.rows(for: tasks)
+        XCTAssertEqual(rows.map(\.id), [1, 2, 3])
+        XCTAssertEqual(rows.map(\.depth), [0, 1, 2])
+    }
+
+    func testNestingLeavesOrphanedSubtaskAtTopLevel() {
+        // Parent (id 9) is not in the visible list — e.g. filtered into another
+        // smart section — so the subtask must not disappear.
+        let tasks = [
+            makeTask(id: 2, title: "Child", relatedTasks: ["parenttask": [makeTask(id: 9)]]),
+            makeTask(id: 3),
+        ]
+        let rows = TaskNesting.rows(for: tasks)
+        XCTAssertEqual(rows.map(\.id), [2, 3])
+        XCTAssertTrue(rows.allSatisfy { $0.depth == 0 })
+    }
+
+    func testNestingEmitsEveryTaskExactlyOnceWithRelationCycle() {
+        // A <-> B parent cycle (representable server-side) must not hang or
+        // drop tasks.
+        let tasks = [
+            makeTask(id: 1, relatedTasks: ["parenttask": [makeTask(id: 2)]]),
+            makeTask(id: 2, relatedTasks: ["parenttask": [makeTask(id: 1)]]),
+            makeTask(id: 3),
+        ]
+        let rows = TaskNesting.rows(for: tasks)
+        XCTAssertEqual(Set(rows.map(\.id)), [1, 2, 3])
+        XCTAssertEqual(rows.count, 3)
+    }
+
+    func testNestingEmitsMultiParentChildOnce() {
+        let tasks = [
+            makeTask(id: 1, title: "Parent A"),
+            makeTask(id: 2, title: "Parent B"),
+            makeTask(id: 3, title: "Shared child", relatedTasks: ["parenttask": [makeTask(id: 1), makeTask(id: 2)]]),
+        ]
+        let rows = TaskNesting.rows(for: tasks)
+        XCTAssertEqual(rows.count, 3)
+        XCTAssertEqual(rows.filter { $0.id == 3 }.count, 1)
+        XCTAssertEqual(rows.map(\.id), [1, 3, 2], "Child nests under the first parent encountered")
+    }
+
+    // MARK: - preservingRelations
+
+    func testPreservingRelationsCarriesRelatedTasksForward() {
+        let existing = makeTask(
+            id: 1, relatedTasks: ["subtask": [makeTask(id: 2, done: true), makeTask(id: 3)]]
+        )
+        // Server update responses null out labels and related_tasks.
+        let response = makeTask(id: 1, title: "Edited")
+
+        let merged = AppState.preservingRelations(existing: existing, response: response)
+        XCTAssertEqual(merged.title, "Edited")
+        XCTAssertEqual(merged.subtasks.map(\.id), [2, 3])
+        XCTAssertEqual(merged.subtaskCounts?.done, 1)
+    }
+
+    func testPreservingRelationsPrefersResponseWhenPresent() {
+        let existing = makeTask(id: 1, relatedTasks: ["subtask": [makeTask(id: 2)]])
+        let response = makeTask(id: 1, relatedTasks: ["subtask": [makeTask(id: 2), makeTask(id: 3)]])
+
+        let merged = AppState.preservingRelations(existing: existing, response: response)
+        XCTAssertEqual(merged.subtasks.map(\.id), [2, 3])
+    }
+
+    // MARK: - AppState flows
+
+    @MainActor
+    func testToggleSubtaskDoneUpdatesParentCounts() async throws {
+        let appState = await makeMockedAppState()
+        let child = makeTask(id: 2, title: "Child")
+        let parent = makeTask(id: 1, title: "Parent", relatedTasks: ["subtask": [child]])
+        appState.tasks = [parent, child]
+
+        let toggleResponse = try XCTUnwrap(Self.taskJSON(id: 2, title: "Child", done: true).data(using: .utf8))
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/tasks/2")
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), toggleResponse)
+        }
+
+        await appState.toggleTaskDone(child)
+
+        let updatedParent = appState.tasks.first { $0.id == 1 }
+        XCTAssertEqual(updatedParent?.subtaskCounts?.done, 1)
+        XCTAssertEqual(updatedParent?.subtaskCounts?.total, 1)
+        XCTAssertEqual(appState.tasks.first { $0.id == 2 }?.done, true)
+    }
+
+    @MainActor
+    func testDeleteTaskStripsEmbeddedRelationCopies() async {
+        let appState = await makeMockedAppState()
+        let child = makeTask(id: 2, title: "Child")
+        let parent = makeTask(id: 1, title: "Parent", relatedTasks: ["subtask": [child]])
+        appState.tasks = [parent, child]
+
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data())
+        }
+
+        await appState.deleteTask(child)
+
+        XCTAssertNil(appState.tasks.first { $0.id == 1 }?.subtaskCounts)
+        XCTAssertNil(appState.tasks.first { $0.id == 1 }?.relatedTasks)
+        XCTAssertFalse(appState.tasks.contains { $0.id == 2 })
+    }
+
+    @MainActor
+    func testAddSubtaskRelationLinksAndRefreshesBothTasks() async throws {
+        let appState = await makeMockedAppState()
+        appState.tasks = [makeTask(id: 1, title: "Parent"), makeTask(id: 2, title: "Child")]
+
+        let relationResponse = #"{"task_id": 1, "other_task_id": 2, "relation_kind": "subtask"}"#
+            .data(using: .utf8)!
+        let parentResponse = try XCTUnwrap(Self.taskJSON(
+            id: 1, title: "Parent",
+            relatedTasks: "{\"subtask\": [\(Self.taskJSON(id: 2, title: "Child"))]}"
+        ).data(using: .utf8))
+        let childResponse = try XCTUnwrap(Self.taskJSON(
+            id: 2, title: "Child",
+            relatedTasks: "{\"parenttask\": [\(Self.taskJSON(id: 1, title: "Parent"))]}"
+        ).data(using: .utf8))
+
+        MockURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            switch (request.httpMethod, path) {
+            case ("PUT", "/api/v1/tasks/1/relations"):
+                return (MockURLProtocol.makeResponse(statusCode: 201, url: request.url), relationResponse)
+            case ("GET", "/api/v1/tasks/1"):
+                return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), parentResponse)
+            case ("GET", "/api/v1/tasks/2"):
+                return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), childResponse)
+            default:
+                XCTFail("Unexpected request: \(request.httpMethod ?? "?") \(path)")
+                return (MockURLProtocol.makeResponse(statusCode: 404, url: request.url), Data())
+            }
+        }
+
+        let success = await appState.addSubtaskRelation(parentId: 1, childId: 2)
+
+        XCTAssertTrue(success)
+        XCTAssertEqual(appState.tasks.first { $0.id == 1 }?.subtasks.map(\.id), [2])
+        XCTAssertEqual(appState.tasks.first { $0.id == 2 }?.parentTasks.map(\.id), [1])
+    }
+
+    @MainActor
+    func testRemoveRelationUnlinksBothTasks() async throws {
+        let appState = await makeMockedAppState()
+        let child = makeTask(id: 2, title: "Child", relatedTasks: ["parenttask": [makeTask(id: 1)]])
+        let parent = makeTask(id: 1, title: "Parent", relatedTasks: ["subtask": [makeTask(id: 2)]])
+        appState.tasks = [parent, child]
+
+        let deleteResponse = #"{"message":"Successfully deleted."}"#.data(using: .utf8)!
+        let parentResponse = try XCTUnwrap(Self.taskJSON(id: 1, title: "Parent").data(using: .utf8))
+        let childResponse = try XCTUnwrap(Self.taskJSON(id: 2, title: "Child").data(using: .utf8))
+
+        MockURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            switch (request.httpMethod, path) {
+            case ("DELETE", "/api/v1/tasks/1/relations/subtask/2"):
+                return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), deleteResponse)
+            case ("GET", "/api/v1/tasks/1"):
+                return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), parentResponse)
+            case ("GET", "/api/v1/tasks/2"):
+                return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), childResponse)
+            default:
+                XCTFail("Unexpected request: \(request.httpMethod ?? "?") \(path)")
+                return (MockURLProtocol.makeResponse(statusCode: 404, url: request.url), Data())
+            }
+        }
+
+        await appState.removeRelation(taskId: 1, otherTaskId: 2, kind: .subtask)
+
+        XCTAssertNil(appState.tasks.first { $0.id == 1 }?.subtaskCounts)
+        XCTAssertFalse(appState.tasks.first { $0.id == 2 }?.hasParentTask ?? true)
+    }
+
+    @MainActor
+    func testCreateSubtaskCreatesTaskThenLinksIt() async throws {
+        let appState = await makeMockedAppState()
+        let parent = makeTask(id: 1, title: "Parent", projectId: 5)
+        appState.tasks = [parent]
+
+        let newTaskResponse = try XCTUnwrap(Self.taskJSON(id: 99, title: "New subtask", projectId: 5)
+            .data(using: .utf8))
+        let relationResponse = #"{"task_id": 1, "other_task_id": 99, "relation_kind": "subtask"}"#
+            .data(using: .utf8)!
+        let parentResponse = try XCTUnwrap(Self.taskJSON(
+            id: 1, title: "Parent", projectId: 5,
+            relatedTasks: "{\"subtask\": [\(Self.taskJSON(id: 99, title: "New subtask", projectId: 5))]}"
+        ).data(using: .utf8))
+        let childResponse = try XCTUnwrap(Self.taskJSON(
+            id: 99, title: "New subtask", projectId: 5,
+            relatedTasks: "{\"parenttask\": [\(Self.taskJSON(id: 1, title: "Parent", projectId: 5))]}"
+        ).data(using: .utf8))
+
+        MockURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            switch (request.httpMethod, path) {
+            case ("PUT", "/api/v1/projects/5/tasks"):
+                return (MockURLProtocol.makeResponse(statusCode: 201, url: request.url), newTaskResponse)
+            case ("PUT", "/api/v1/tasks/1/relations"):
+                if let requestBody = MockURLProtocol.bodyData(from: request),
+                   let json = try? JSONSerialization.jsonObject(with: requestBody) as? [String: Any]
+                {
+                    XCTAssertEqual(json["other_task_id"] as? Int, 99)
+                    XCTAssertEqual(json["relation_kind"] as? String, "subtask")
+                } else {
+                    XCTFail("Missing relation request body")
+                }
+                return (MockURLProtocol.makeResponse(statusCode: 201, url: request.url), relationResponse)
+            case ("GET", "/api/v1/tasks/1"):
+                return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), parentResponse)
+            case ("GET", "/api/v1/tasks/99"):
+                return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), childResponse)
+            default:
+                XCTFail("Unexpected request: \(request.httpMethod ?? "?") \(path)")
+                return (MockURLProtocol.makeResponse(statusCode: 404, url: request.url), Data())
+            }
+        }
+
+        let success = await appState.createSubtask(title: "New subtask", parent: parent)
+
+        XCTAssertTrue(success)
+        XCTAssertEqual(appState.tasks.first { $0.id == 1 }?.subtasks.map(\.id), [99])
+        XCTAssertEqual(appState.tasks.first { $0.id == 99 }?.parentTasks.map(\.id), [1])
+    }
+
+    @MainActor
+    func testCreateSubtaskRejectsBlankTitle() async {
+        let appState = await makeMockedAppState()
+        MockURLProtocol.requestHandler = { request in
+            XCTFail("Blank subtask title must not hit the network")
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data())
+        }
+
+        let success = await appState.createSubtask(title: "   ", parent: makeTask(id: 1))
+        XCTAssertFalse(success)
+        XCTAssertTrue(MockURLProtocol.capturedRequests.isEmpty)
+    }
+}

--- a/mDoneTests/TaskRelationTests.swift
+++ b/mDoneTests/TaskRelationTests.swift
@@ -297,6 +297,44 @@ final class TaskRelationTests: XCTestCase {
         XCTAssertEqual(rows.map(\.id), [1, 3, 2], "Child nests under the first parent encountered")
     }
 
+    // MARK: - SubtaskLinkCandidates
+
+    func testLinkCandidatesExcludeIneligibleTasks() {
+        let parent = makeTask(
+            id: 1, projectId: 5,
+            relatedTasks: [
+                "subtask": [makeTask(id: 2)],
+                "parenttask": [makeTask(id: 3)],
+            ]
+        )
+        let tasks = [
+            parent,
+            makeTask(id: 2, title: "Already a subtask", projectId: 5),
+            makeTask(id: 3, title: "Is the parent", projectId: 5),
+            makeTask(id: 4, title: "Done task", done: true, projectId: 5),
+            makeTask(id: 5, title: "Eligible", projectId: 5),
+        ]
+
+        let candidates = SubtaskLinkCandidates.candidates(for: parent, in: tasks)
+        XCTAssertEqual(candidates.map(\.id), [5])
+    }
+
+    func testLinkCandidatesIncludeOtherProjectsAfterOwnProject() {
+        let parent = makeTask(id: 1, projectId: 5)
+        let tasks = [
+            parent,
+            makeTask(id: 2, title: "Zebra (same project)", projectId: 5),
+            makeTask(id: 3, title: "Alpha (other project)", projectId: 9),
+            makeTask(id: 4, title: "Alpha (same project)", projectId: 5),
+        ]
+
+        let candidates = SubtaskLinkCandidates.candidates(for: parent, in: tasks)
+        XCTAssertEqual(
+            candidates.map(\.id), [4, 2, 3],
+            "Own project sorts first (alphabetical), then other projects"
+        )
+    }
+
     // MARK: - preservingRelations
 
     func testPreservingRelationsCarriesRelatedTasksForward() {


### PR DESCRIPTION
## Summary

Adds full subtask/relation support against the Vikunja relations API:

- **`related_tasks` on `VTask`** — decoded as a kind-keyed map (raw string keys, so future server kinds can't break decoding), with `subtasks` / `parentTasks` / `subtaskCounts` helpers. New `RelationKind` enum covers all 12 Vikunja kinds.
- **Nested display** — subtasks render indented under their parent (depth-first via a pure, unit-tested `TaskNesting` ordering with cycle and multi-parent guards) in the Inbox smart sections, project lists, and the Mac task list. A subtask whose parent isn't in the visible list stays at top level so filtered views never hide a task. Drag-reorder is disabled only when a list actually shows nesting.
- **"2/5"-style done badge** on parent rows, updating immediately when a subtask is checked off (AppState mirrors task mutations into other tasks' embedded relation snapshots).
- **Detail-view management** (iOS sheet + macOS detail): a Subtasks section with a done count in the header, tap-to-toggle subtask rows, an inline "Add subtask" field (creates the task in the parent's project and links it), a "Link Existing Task" menu, an unlink control per row, a Parent Task section, and a read-only-plus-unlink list of any other relation kinds (Blocked By, Precedes, …).
- **API layer** — `PUT /tasks/{id}/relations`, `DELETE /tasks/{id}/relations/{kind}/{otherId}`, and `expand=subtasks` on task list fetches.
- **Correctness fix folded in**: task update responses null out `related_tasks` exactly like `labels`, so `preservingRelations` now carries relations forward too — and `rescheduleTask` uses it as well, fixing a latent bug where quick-scheduling dropped a task's labels (and would have dropped its subtask badge).

Offline note: relations aren't persisted in the SwiftData cache yet, so subtask info simply doesn't render while offline; nothing breaks.

## Related Issues

Fixes #1

## Testing

- **API contract verified empirically** against a live Vikunja v2.4.0 spun up from `docker-compose.dev.yml`: relation create/delete semantics (inverse handled server-side), the exact `related_tasks` JSON shape (used verbatim as test fixtures), 409 duplicate behavior, and the fact that update responses null out `related_tasks`.
- **454 unit tests pass** (21 new in `TaskRelationTests`: decoding, endpoints, service calls, nesting order incl. cycles, preservation, and AppState flows through a mocked `APIClient`). New-code coverage: Endpoint 100%, TaskService 94%, TaskRelation 96%, VTask 97%.
- **End-to-end in the simulator** against the local server: verified nested rows + 1/3 badge in the Inbox, live count update to 2/3 when toggling a subtask in the detail sheet, and add-subtask creating + linking a task on the server (checked via the API afterwards).
- MockURLProtocol gained a `bodyData(from:)` helper because URLSession delivers bodies to URLProtocol as a stream — existing body assertions were silently skipping.

## Checklist

- [x] Builds on iOS and macOS
- [x] Tests pass
- [x] Ran `swiftlint lint --quiet` and `swiftformat .` (formatting applied to touched files only; a repo-wide `swiftformat .` reformats ~45 untouched files and was reverted)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)