### PR TITLE
Remove em-dashes from the 1.10.0 release copy and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - **Subtasks**: tasks with subtasks now show them indented underneath in every list (Inbox sections, project lists, and the Mac task list), with a "2/5" progress badge on the parent row showing how many are done. Checking a subtask off updates the parent's count immediately (#1).
-- Manage subtasks from a task's detail view: add a new subtask by typing its title, or tap "Link Existing Task" to pick any open task — searchable, from any project, with each task's project shown — and make it a subtask. Check subtasks off or unlink them (unlinking never deletes the task). Tasks that are subtasks also show their parent, and any other relations created in Vikunja (Blocked By, Precedes, Duplicates, …) are listed and can be removed (#1).
+- Manage subtasks from a task's detail view: add a new subtask by typing its title, or tap "Link Existing Task" to pick any open task (searchable, from any project, with each task's project shown) and make it a subtask. Check subtasks off or unlink them (unlinking never deletes the task). Tasks that are subtasks also show their parent, and any other relations created in Vikunja (Blocked By, Precedes, Duplicates, …) are listed and can be removed (#1).
 
 ## [1.9.0] - 2026-07-20
 

--- a/docs/appstore-metadata.md
+++ b/docs/appstore-metadata.md
@@ -88,7 +88,7 @@ This is a private test server maintained by the developer for App Store review p
 Subtasks: break big tasks into steps.
 
 - Tasks now show their subtasks nested underneath in every list, with a progress badge on the parent (e.g. 2/5 done).
-- Add subtasks from a task's detail view, or link any existing task — from any project — as a subtask, with search.
+- Add subtasks from a task's detail view, or link any existing task from any project as a subtask, with search.
 - Tick subtasks off right from the parent task's detail view; the progress badge updates instantly.
 - Relations created in Vikunja on the web (Blocked By, Precedes, Duplicates and more) now show on the task and can be removed.
 - Available on both iPhone and Mac.

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -568,7 +568,7 @@ final class AppState {
     /// `related_tasks: null` (it doesn't echo either). Replacing the local task
     /// wholesale with that response would drop its labels until the next full
     /// refresh, which made a Current task vanish from its section the moment
-    /// you edited it (e.g. changed its progress) — and would likewise wipe its
+    /// you edited it (e.g. changed its progress), and would likewise wipe its
     /// subtask list and count. Carry both forward when the response omits them.
     /// Neither is edited via the task-update endpoint (labels use the label
     /// endpoints, relations the relation endpoints), so this can't mask a user
@@ -591,8 +591,8 @@ final class AppState {
                 tasks[index] = updated
             } else {
                 // Subtasks toggled from a parent's detail view may not be in
-                // the live list (some server versions omit done tasks) —
-                // insert so subsequent toggles and counts see fresh state.
+                // the live list (some server versions omit done tasks),
+                // so insert it here to keep later toggles and counts fresh.
                 tasks.append(updated)
             }
             syncEmbeddedRelations(with: updated)
@@ -804,7 +804,7 @@ final class AppState {
 
     /// Removes the `kind` relation between `taskId` and `otherTaskId` (the
     /// server drops the inverse too), then refreshes both tasks. Removing a
-    /// `subtask` relation only unlinks the tasks — neither is deleted.
+    /// `subtask` relation only unlinks the tasks; neither is deleted.
     @MainActor
     func removeRelation(taskId: Int64, otherTaskId: Int64, kind: RelationKind) async {
         do {
@@ -834,7 +834,7 @@ final class AppState {
 
     /// Mirrors an updated task into the embedded related-task snapshots other
     /// tasks hold (`relatedTasks` copies), so subtask counts and nested rows
-    /// stay fresh without a refetch — e.g. checking a subtask off updates its
+    /// stay fresh without a refetch: checking a subtask off updates its
     /// parent's "2/5 done" badge immediately.
     @MainActor
     private func syncEmbeddedRelations(with updatedTask: VTask) {

--- a/mDone/Models/TaskRelation.swift
+++ b/mDone/Models/TaskRelation.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// The kinds of relations Vikunja supports between two tasks.
 /// Raw values match the API's `relation_kind` strings exactly (all lowercase,
-/// no underscores — so they survive the snake-case key decoding untouched).
+/// no underscores, so they survive the snake-case key decoding untouched).
 enum RelationKind: String, Codable, CaseIterable, Identifiable {
     case unknown
     case subtask
@@ -142,7 +142,7 @@ enum TaskNesting {
             emit(task, depth: 0)
         }
         // Tasks unreachable from any top-level task (their parents form a
-        // cycle) still need to show up — surface them flat.
+        // cycle) still need to show up; surface them flat.
         for task in tasks {
             emit(task, depth: 0)
         }

--- a/mDone/Models/VTask.swift
+++ b/mDone/Models/VTask.swift
@@ -32,7 +32,7 @@ struct VTask: Codable, Identifiable, Hashable {
     /// `"parenttask"`, `"blocking"`, …). Kept as raw strings so a kind added
     /// by a future server version can't fail decoding. The embedded tasks are
     /// snapshots without their own relations (`related_tasks` is `null` one
-    /// level down — the server doesn't recurse).
+    /// level down; the server doesn't recurse).
     var relatedTasks: [String: [VTask]]?
 
     var priorityLevel: PriorityLevel {

--- a/mDone/Services/TaskService.swift
+++ b/mDone/Services/TaskService.swift
@@ -43,7 +43,7 @@ actor TaskService {
         try await apiClient.sendExpectingEmpty(Endpoint.updateTaskPosition(taskId: taskId), body: request)
     }
 
-    /// Links `otherTaskId` to `taskId` with the given relation kind — e.g.
+    /// Links `otherTaskId` to `taskId` with the given relation kind, e.g.
     /// `.subtask` makes `otherTaskId` a subtask of `taskId`. The server creates
     /// the inverse relation on the other task automatically.
     @discardableResult

--- a/mDone/Views/Tasks/SmartListSection.swift
+++ b/mDone/Views/Tasks/SmartListSection.swift
@@ -13,7 +13,7 @@ struct SmartListSection: View {
         let hasNesting = rows.contains { $0.depth > 0 }
         Section {
             // One ForEach for both flat and nested display, so a row's
-            // identity survives the list gaining/losing nesting — otherwise a
+            // identity survives the list gaining/losing nesting; otherwise a
             // detail sheet presented from a row gets torn down the moment its
             // task's first subtask is linked. Reorder stays flat-only (nested
             // visual order doesn't match Vikunja's flat position order);

--- a/mDoneTests/TaskRelationTests.swift
+++ b/mDoneTests/TaskRelationTests.swift
@@ -261,8 +261,8 @@ final class TaskRelationTests: XCTestCase {
     }
 
     func testNestingLeavesOrphanedSubtaskAtTopLevel() {
-        // Parent (id 9) is not in the visible list — e.g. filtered into another
-        // smart section — so the subtask must not disappear.
+        // Parent (id 9) is not in the visible list (e.g. filtered into another
+        // smart section), so the subtask must not disappear.
         let tasks = [
             makeTask(id: 2, title: "Child", relatedTasks: ["parenttask": [makeTask(id: 9)]]),
             makeTask(id: 3),


### PR DESCRIPTION
## Summary

House style cleanup: removes every em-dash introduced by the subtasks work (PR #128) from the CHANGELOG, App Store metadata doc, code comments, and test comments, replacing each with punctuation that fits the sentence (comma, colon, semicolon, or parentheses). Pre-existing em-dashes from earlier releases are left as they are.

The App Store "What's New" text for the in-review 1.10.0 was already fixed directly in App Store Connect (whatsNew is editable while WAITING_FOR_REVIEW), so this PR brings the repo copy in line with what Apple will show.

## Related Issues

Follow-up to #128 / #1.

## Testing

Punctuation-only diff; no executable code changed. Full unit suite run anyway: 456 tests, 0 failures. iOS build succeeds.

## Checklist

- [x] Builds on iOS and macOS
- [x] Tests pass
- [x] Ran `swiftlint lint --quiet` and `swiftformat .` (not applicable: comment/doc punctuation only)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)