### PR TITLE
Fix empty Kanban board on Vikunja v0.24+ (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- The Kanban board now shows your tasks again. Columns loaded but sat empty on current Vikunja servers (v0.24 and later, including 2.x) because the app still read tasks from an endpoint that stopped including them; the board now loads columns and cards the way modern Vikunja expects (#130).
 - Rescheduling a task via the long-press "Schedule" menu no longer drops it from the **Current** section until the next refresh (the same server-response quirk fixed for other edits in 1.7.0).
 
 ### Added

--- a/mDone/Models/Bucket.swift
+++ b/mDone/Models/Bucket.swift
@@ -1,9 +1,10 @@
 import Foundation
 
 /// A Kanban column. In Vikunja, buckets belong to a project's *kanban* view and
-/// carry the tasks placed in that column. The view-tasks endpoint embeds each
-/// bucket's tasks directly (`tasks`), so a single buckets fetch is enough to
-/// render a board.
+/// carry the tasks placed in that column. The view-tasks endpoint
+/// (`/views/{view}/tasks`) returns these buckets with their tasks embedded
+/// (`tasks`), so a single fetch is enough to render a board. `tasks` is omitted
+/// entirely for empty buckets (Vikunja marshals it with `omitempty`).
 struct Bucket: Codable, Identifiable, Hashable {
     let id: Int64
     var title: String

--- a/mDone/Services/Endpoint.swift
+++ b/mDone/Services/Endpoint.swift
@@ -58,7 +58,7 @@ struct Endpoint {
     /// endpoint: for a kanban view it returns buckets populated with tasks,
     /// while `/views/{view}/buckets` returns bucket metadata only.
     /// `page`/`per_page` paginate the tasks *within each bucket*, not the
-    /// buckets themselves — every bucket is always returned.
+    /// buckets themselves; every bucket is always returned.
     static func kanbanBuckets(projectId: Int64, viewId: Int64, page: Int = 1, perPage: Int = 50) -> Endpoint {
         Endpoint(path: "/api/v1/projects/\(projectId)/views/\(viewId)/tasks", queryItems: [
             URLQueryItem(name: "page", value: "\(page)"),

--- a/mDone/Services/Endpoint.swift
+++ b/mDone/Services/Endpoint.swift
@@ -54,9 +54,13 @@ struct Endpoint {
     // MARK: - Kanban Buckets
 
     /// Lists the buckets (columns) of a project's kanban view, with each
-    /// bucket's tasks embedded.
-    static func projectBuckets(projectId: Int64, viewId: Int64, page: Int = 1, perPage: Int = 100) -> Endpoint {
-        Endpoint(path: "/api/v1/projects/\(projectId)/views/\(viewId)/buckets", queryItems: [
+    /// bucket's tasks embedded. Since Vikunja v0.24 this is the *view tasks*
+    /// endpoint: for a kanban view it returns buckets populated with tasks,
+    /// while `/views/{view}/buckets` returns bucket metadata only.
+    /// `page`/`per_page` paginate the tasks *within each bucket*, not the
+    /// buckets themselves — every bucket is always returned.
+    static func kanbanBuckets(projectId: Int64, viewId: Int64, page: Int = 1, perPage: Int = 50) -> Endpoint {
+        Endpoint(path: "/api/v1/projects/\(projectId)/views/\(viewId)/tasks", queryItems: [
             URLQueryItem(name: "page", value: "\(page)"),
             URLQueryItem(name: "per_page", value: "\(perPage)"),
         ])

--- a/mDone/Services/ProjectService.swift
+++ b/mDone/Services/ProjectService.swift
@@ -20,9 +20,11 @@ actor ProjectService {
     }
 
     /// Fetches the kanban buckets (columns) for a project view, each with its
-    /// embedded tasks.
+    /// embedded tasks. Uses the view *tasks* endpoint: for a kanban view it
+    /// returns bucket objects with tasks inside (the `/buckets` endpoint stopped
+    /// embedding tasks in Vikunja v0.24).
     func fetchBuckets(projectId: Int64, viewId: Int64) async throws -> [Bucket] {
-        try await apiClient.fetch(Endpoint.projectBuckets(projectId: projectId, viewId: viewId))
+        try await apiClient.fetch(Endpoint.kanbanBuckets(projectId: projectId, viewId: viewId))
     }
 
     func createProject(_ request: ProjectCreateRequest) async throws -> Project {

--- a/mDoneTests/KanbanTests.swift
+++ b/mDoneTests/KanbanTests.swift
@@ -100,8 +100,11 @@ final class KanbanTests: XCTestCase {
     // MARK: - Endpoints
 
     func testBucketEndpointPaths() {
-        let read = Endpoint.projectBuckets(projectId: 7, viewId: 3)
-        XCTAssertEqual(read.path, "/api/v1/projects/7/views/3/buckets")
+        // Regression for #130: buckets with tasks come from the view *tasks*
+        // endpoint. `/views/{view}/buckets` returns metadata only since
+        // Vikunja v0.24, which left every board column empty.
+        let read = Endpoint.kanbanBuckets(projectId: 7, viewId: 3)
+        XCTAssertEqual(read.path, "/api/v1/projects/7/views/3/tasks")
         XCTAssertEqual(read.method, .GET)
 
         let move = Endpoint.moveTaskToBucket(projectId: 7, viewId: 3, bucketId: 9)
@@ -116,24 +119,31 @@ final class KanbanTests: XCTestCase {
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         let service = ProjectService(apiClient: client)
 
+        // Shaped like a real v2.x kanban view-tasks response: `tasks` is
+        // omitted for empty buckets, and `count`/`limit` are always present.
         let bucketsJSON = """
         [
-            {"id": 1, "title": "Backlog", "project_view_id": 3, "position": 1.0, "tasks": []},
-            {"id": 2, "title": "Done", "project_view_id": 3, "position": 2.0, "tasks": [
-                {"id": 50, "title": "Ship it", "done": false, "priority": 0, "project_id": 7}
+            {"id": 1, "title": "Backlog", "project_view_id": 3, "limit": 0, "count": 0, "position": 1.0},
+            {"id": 2, "title": "Done", "project_view_id": 3, "limit": 0, "count": 1, "position": 2.0, "tasks": [
+                {"id": 50, "title": "Ship it", "done": false, "priority": 0, "project_id": 7, "bucket_id": 2}
             ]}
         ]
         """.data(using: .utf8)!
 
         MockURLProtocol.requestHandler = { request in
-            XCTAssertEqual(request.url?.path, "/api/v1/projects/7/views/3/buckets")
+            // Must be the view-tasks endpoint — the buckets endpoint stopped
+            // embedding tasks in Vikunja v0.24 (#130).
+            XCTAssertEqual(request.url?.path, "/api/v1/projects/7/views/3/tasks")
             XCTAssertEqual(request.httpMethod, "GET")
             return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), bucketsJSON)
         }
 
         let buckets = try await service.fetchBuckets(projectId: 7, viewId: 3)
         XCTAssertEqual(buckets.map(\.title), ["Backlog", "Done"])
+        XCTAssertNil(buckets[0].tasks)
+        XCTAssertTrue(buckets[0].activeTasks.isEmpty)
         XCTAssertEqual(buckets[1].tasks?.first?.id, 50)
+        XCTAssertEqual(buckets[1].tasks?.first?.bucketId, 2)
     }
 
     // MARK: - TaskService.moveTaskToBucket
@@ -155,6 +165,59 @@ final class KanbanTests: XCTestCase {
         let body = try XCTUnwrap(request.bodyStreamData() ?? request.httpBody)
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
         XCTAssertEqual(object["task_id"] as? Int, 42)
+    }
+
+    // MARK: - AppState.fetchBuckets
+
+    @MainActor
+    func testAppStateFetchBucketsSortsAndMergesTasks() async {
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        let appState = AppState(projectService: ProjectService(apiClient: client))
+
+        let project = Project(
+            id: 7,
+            title: "Work",
+            views: [ProjectView(id: 3, title: "Kanban", projectId: 7, viewKind: "kanban")]
+        )
+
+        let bucketsJSON = """
+        [
+            {"id": 2, "title": "Doing", "project_view_id": 3, "limit": 0, "count": 1, "position": 2.0, "tasks": [
+                {"id": 50, "title": "Ship it", "done": false, "priority": 0, "project_id": 7, "bucket_id": 2}
+            ]},
+            {"id": 1, "title": "Backlog", "project_view_id": 3, "limit": 0, "count": 0, "position": 1.0}
+        ]
+        """.data(using: .utf8)!
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/projects/7/views/3/tasks")
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), bucketsJSON)
+        }
+
+        let buckets = await appState.fetchBuckets(project: project)
+        XCTAssertEqual(buckets.map(\.title), ["Backlog", "Doing"])
+        // Embedded tasks are merged into the global task list.
+        XCTAssertEqual(appState.tasks.map(\.id), [50])
+    }
+
+    @MainActor
+    func testAppStateFetchBucketsWithoutKanbanViewReturnsEmpty() async {
+        let appState = AppState()
+        let project = Project(
+            id: 7,
+            title: "Work",
+            views: [ProjectView(id: 100, title: "List", projectId: 7, viewKind: "list")]
+        )
+
+        MockURLProtocol.requestHandler = { _ in
+            XCTFail("A project without a kanban view must not hit the network")
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: nil), Data())
+        }
+
+        let buckets = await appState.fetchBuckets(project: project)
+        XCTAssertTrue(buckets.isEmpty)
+        XCTAssertTrue(MockURLProtocol.capturedRequests.isEmpty)
     }
 
     // MARK: - AppState.moveTask(toBucket:)

--- a/mDoneTests/KanbanTests.swift
+++ b/mDoneTests/KanbanTests.swift
@@ -131,7 +131,7 @@ final class KanbanTests: XCTestCase {
         """.data(using: .utf8)!
 
         MockURLProtocol.requestHandler = { request in
-            // Must be the view-tasks endpoint — the buckets endpoint stopped
+            // Must be the view-tasks endpoint: the buckets endpoint stopped
             // embedding tasks in Vikunja v0.24 (#130).
             XCTAssertEqual(request.url?.path, "/api/v1/projects/7/views/3/tasks")
             XCTAssertEqual(request.httpMethod, "GET")


### PR DESCRIPTION
Fixes #130.

## What was wrong

The board loaded columns via `GET /projects/{id}/views/{view}/buckets` and rendered `Bucket.tasks`. Vikunja removed embedded tasks from that endpoint in v0.24.0 (upstream breaking change [`238baf8`](https://github.com/go-vikunja/vikunja/commit/238baf86f74c515e5232d220b24fbfef1521b179)); it now returns bucket metadata only, so every column rendered empty on any modern server (including 2.x).

## The fix

`ProjectService.fetchBuckets` now fetches `GET /projects/{id}/views/{view}/tasks` (new `Endpoint.kanbanBuckets`). For a kanban view that endpoint returns the buckets **with their tasks embedded**, which is exactly what the board renders. No UI changes needed; move-to-bucket was unaffected.

Contract verified two ways:
- v2.3.0 source: `Bucket.ReadAll` returns metadata only (its doc comment says to use the tasks endpoint); `TaskCollection.ReadAll` returns `[]*Bucket` with tasks for kanban views. `per_page` paginates tasks per bucket; all buckets always return; `tasks` is omitted for empty buckets.
- Live v2.4.0 (docker-compose.dev.yml): `/buckets` returns no `tasks` key at all; `/views/{view}/tasks` returns populated buckets. End-to-end in the simulator, the board now shows cards in their columns (screenshot below from the local dev server).

## Tests

- `KanbanTests` updated: endpoint path assertions now pin the view-tasks path (regression guard for #130), service fixture reshaped to the real v2.x response (omitted `tasks` key on empty buckets), plus new `AppState.fetchBuckets` coverage (position sorting, task merge into the global list, no-network when a project has no kanban view).
- Full `mDoneTests` target green locally on the iPhone 17 simulator.

| Before (issue) | After (local v2.4.0) |
|---|---|
| Columns render, all empty | Cards render in their buckets |

🤖 Generated with [Claude Code](https://claude.com/claude-code)