### PR TITLE
Add setting to hide all-day calendar events (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - The Kanban board now shows your tasks again. Columns loaded but sat empty on current Vikunja servers (v0.24 and later, including 2.x) because the app still read tasks from an endpoint that stopped including them; the board now loads columns and cards the way modern Vikunja expects (#130).
-- Rescheduling a task via the long-press "Schedule" menu no longer drops it from the **Current** section until the next refresh (the same server-response quirk fixed for other edits in 1.7.0).
+
+### Added
+- You can now hide all-day calendar events: Settings > Calendar > **Show all-day events**. Turn it off to keep day-long events out of the Calendar and Today views. It stays on by default, so nothing changes unless you flip it (#133).
+
+## [1.10.0] - 2026-07-23
 
 ### Added
 - **Subtasks**: tasks with subtasks now show them indented underneath in every list (Inbox sections, project lists, and the Mac task list), with a "2/5" progress badge on the parent row showing how many are done. Checking a subtask off updates the parent's count immediately (#1).
 - Manage subtasks from a task's detail view: add a new subtask by typing its title, or tap "Link Existing Task" to pick any open task (searchable, from any project, with each task's project shown) and make it a subtask. Check subtasks off or unlink them (unlinking never deletes the task). Tasks that are subtasks also show their parent, and any other relations created in Vikunja (Blocked By, Precedes, Duplicates, …) are listed and can be removed (#1).
+
+### Fixed
+- Rescheduling a task via the long-press "Schedule" menu no longer drops it from the **Current** section until the next refresh (the same server-response quirk fixed for other edits in 1.7.0).
 
 ## [1.9.0] - 2026-07-20
 

--- a/docs/appstore-metadata.md
+++ b/docs/appstore-metadata.md
@@ -83,6 +83,14 @@ Steps to test:
 
 This is a private test server maintained by the developer for App Store review purposes.
 
+## What's New (v1.11.0)
+
+Hide all-day calendar events, plus a Kanban fix.
+
+- New setting to hide all-day calendar events: Settings > Calendar > "Show all-day events". Turn it off to keep day-long events out of your Calendar and Today views. It stays on by default, so nothing changes unless you flip it.
+- The Kanban board shows your tasks again on current Vikunja servers (v0.24 and later). Columns previously loaded but sat empty.
+- Available on both iPhone and Mac.
+
 ## What's New (v1.10.0)
 
 Subtasks: break big tasks into steps.

--- a/mDone/App/CalendarPreferences.swift
+++ b/mDone/App/CalendarPreferences.swift
@@ -11,7 +11,9 @@ enum WeekStartPreference: Int, CaseIterable, Identifiable {
 
     static let storageKey = "firstWeekday"
 
-    var id: Int { rawValue }
+    var id: Int {
+        rawValue
+    }
 
     var label: String {
         switch self {
@@ -33,5 +35,30 @@ extension Calendar {
             calendar.firstWeekday = stored
         }
         return calendar
+    }
+}
+
+/// Persists whether all-day calendar events appear in mDone.
+///
+/// We store the *hide* flag rather than a "show" flag so the natural `false`
+/// default for a missing key means all-day events keep showing, matching
+/// behaviour from before this setting existed.
+struct AllDayEventPreference {
+    static let storageKey = "hideAllDayEvents"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var hidesAllDayEvents: Bool {
+        defaults.bool(forKey: Self.storageKey)
+    }
+
+    /// Pure filter: strips all-day events when the user has hidden them.
+    func visibleEvents(_ events: [CalendarEvent]) -> [CalendarEvent] {
+        guard hidesAllDayEvents else { return events }
+        return events.filter { !$0.isAllDay }
     }
 }

--- a/mDone/Services/CalendarService.swift
+++ b/mDone/Services/CalendarService.swift
@@ -4,9 +4,14 @@ import Foundation
 actor CalendarService {
     private let eventStore = EKEventStore()
     private let hiddenStore: HiddenCalendarStore
+    private let allDayPreference: AllDayEventPreference
 
-    init(hiddenStore: HiddenCalendarStore = HiddenCalendarStore()) {
+    init(
+        hiddenStore: HiddenCalendarStore = HiddenCalendarStore(),
+        allDayPreference: AllDayEventPreference = AllDayEventPreference()
+    ) {
         self.hiddenStore = hiddenStore
+        self.allDayPreference = allDayPreference
     }
 
     var authorizationStatus: EKAuthorizationStatus {
@@ -34,7 +39,7 @@ actor CalendarService {
         let ekEvents = eventStore.events(matching: predicate)
         let events = ekEvents.map { CalendarEvent(from: $0) }
             .sorted { $0.startDate < $1.startDate }
-        return hiddenStore.visibleEvents(events)
+        return allDayPreference.visibleEvents(hiddenStore.visibleEvents(events))
     }
 
     /// Fetch events for a single day

--- a/mDone/Views/Settings/SettingsScreen.swift
+++ b/mDone/Views/Settings/SettingsScreen.swift
@@ -9,6 +9,7 @@ struct SettingsScreen: View {
     @AppStorage(DefaultDueTimePreference.storageKey) private var defaultDueTime = DefaultDueTimePreference
         .defaultRawValue
     @AppStorage("calmMode") private var calmMode = false
+    @AppStorage(AllDayEventPreference.storageKey) private var hideAllDayEvents = false
     @AppStorage("currentStallDays") private var currentStallDays = 7
     @AppStorage(TaskListDensity.storageKey) private var taskListDensity = TaskListDensity.standard.rawValue
     @State private var showLogoutConfirm = false
@@ -94,12 +95,18 @@ struct SettingsScreen: View {
                 )
             }
 
-            Section("Calendar") {
+            Section {
                 NavigationLink {
                     CalendarSelectionView()
                 } label: {
                     Label("Calendars in mDone", systemImage: "calendar")
                 }
+
+                Toggle("Show all-day events", isOn: showAllDayEventsBinding)
+            } header: {
+                Text("Calendar")
+            } footer: {
+                Text("Turn off to hide all-day events from mDone's Calendar and Today views.")
             }
 
             Section("Notifications") {
@@ -186,6 +193,18 @@ struct SettingsScreen: View {
         } message: {
             Text("This will remove your server configuration. You'll need to reconnect.")
         }
+    }
+
+    /// The toggle reads positively ("show") while storage keeps the hide flag,
+    /// so a missing key defaults to showing all-day events.
+    private var showAllDayEventsBinding: Binding<Bool> {
+        Binding(
+            get: { !hideAllDayEvents },
+            set: { shown in
+                hideAllDayEvents = !shown
+                Task { await appState.calendarSelectionDidChange() }
+            }
+        )
     }
 
     private static var versionString: String {

--- a/mDoneTests/AllDayEventPreferenceTests.swift
+++ b/mDoneTests/AllDayEventPreferenceTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import mDone
+
+final class AllDayEventPreferenceTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "AllDayEventPreferenceTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    private func makePreference() -> AllDayEventPreference {
+        AllDayEventPreference(defaults: defaults)
+    }
+
+    private func event(_ id: String, isAllDay: Bool) -> CalendarEvent {
+        CalendarEvent(
+            id: id,
+            title: "Event \(id)",
+            startDate: Date(timeIntervalSince1970: 0),
+            endDate: Date(timeIntervalSince1970: 3600),
+            isAllDay: isAllDay,
+            calendarIdentifier: "work"
+        )
+    }
+
+    // MARK: - Default (missing key)
+
+    func testMissingKeyShowsAllDayEvents() {
+        let preference = makePreference()
+        XCTAssertFalse(preference.hidesAllDayEvents)
+
+        let events = [event("1", isAllDay: true), event("2", isAllDay: false)]
+        XCTAssertEqual(preference.visibleEvents(events).map(\.id), ["1", "2"])
+    }
+
+    func testExplicitFalseShowsAllDayEvents() {
+        defaults.set(false, forKey: AllDayEventPreference.storageKey)
+        let preference = makePreference()
+        XCTAssertFalse(preference.hidesAllDayEvents)
+
+        let events = [event("1", isAllDay: true), event("2", isAllDay: false)]
+        XCTAssertEqual(preference.visibleEvents(events).map(\.id), ["1", "2"])
+    }
+
+    // MARK: - Hidden
+
+    func testHiddenFiltersOnlyAllDayEvents() {
+        defaults.set(true, forKey: AllDayEventPreference.storageKey)
+        let preference = makePreference()
+        XCTAssertTrue(preference.hidesAllDayEvents)
+
+        let events = [
+            event("1", isAllDay: true),
+            event("2", isAllDay: false),
+            event("3", isAllDay: true),
+            event("4", isAllDay: false)
+        ]
+        XCTAssertEqual(preference.visibleEvents(events).map(\.id), ["2", "4"])
+    }
+
+    func testHiddenWithOnlyTimedEventsKeepsAll() {
+        defaults.set(true, forKey: AllDayEventPreference.storageKey)
+        let preference = makePreference()
+
+        let events = [event("1", isAllDay: false), event("2", isAllDay: false)]
+        XCTAssertEqual(preference.visibleEvents(events).map(\.id), ["1", "2"])
+    }
+
+    func testHiddenWithEmptyInputReturnsEmpty() {
+        defaults.set(true, forKey: AllDayEventPreference.storageKey)
+        let preference = makePreference()
+        XCTAssertTrue(preference.visibleEvents([]).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- New **Settings > Calendar > Show all-day events** toggle, on by default so existing users see no change (closes #133)
- Storage keeps a `hideAllDayEvents` flag (missing key = show), following the `HiddenCalendarStore` precedent of defaulting to visible
- Filtering happens once in `CalendarService.fetchEvents`, so the Calendar month grid, day list, Today section, and Mac sidebar count are all covered; widgets never render calendar events
- Flipping the toggle refreshes immediately via `calendarSelectionDidChange()`, same as the calendar selection screen
- Also reconciles the changelog: subtasks (#1) and the reschedule fix shipped as 1.10.0 on 2026-07-23, so they move out of Unreleased; the kanban fix (#130, TestFlight only) stays

## Testing
- 5 new unit tests in `AllDayEventPreferenceTests` (default shows, explicit false shows, hidden strips only all-day events)
- Full `mDoneTests` suite: 463 tests, 0 failures (iPhone 17 simulator)
- macOS app builds clean; SwiftLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)