### PR TITLE
Load every card in a Kanban column and every task's list order (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- Kanban columns now show every card. A column holding more than 50 tasks stopped at 50, with nothing on the board to say the rest existed. Project lists are ordered correctly all the way down too: tasks past the 50th used to collect at the bottom instead of sitting in their proper place (#141).
 - All of your projects and labels now load, not just the first 50. The app only ever asked the server for one page, so anyone with more than 50 projects lost the rest everywhere: sidebar, project pickers, favourites and sync, with no error to explain why. Raising the page size would not have helped, since Vikunja caps it server-side, so the app now walks through every page (#139).
 - The Kanban board now shows your tasks again. Columns loaded but sat empty on current Vikunja servers (v0.24 and later, including 2.x) because the app still read tasks from an endpoint that stopped including them; the board now loads columns and cards the way modern Vikunja expects (#130).
 

--- a/docs/vikunja-api-inventory.md
+++ b/docs/vikunja-api-inventory.md
@@ -828,6 +828,7 @@ Use `order_by` parameter: `asc` (default) or `desc`. Can specify multiple: `sort
 
 - `per_page` is clamped server-side to `maxitemsperpage` (50 by default), so asking for a bigger page does not avoid paging. Always loop until `page >= x-pagination-total-pages`.
 - `GET /projects` appends the caller's **pseudo-projects** (negative ids, e.g. `-2` "My Open Tasks") to *every* page, and they are excluded from `x-pagination-result-count`. Page 1 returned 51 objects with a result count of 50. Anything that concatenates pages must de-duplicate by `id` or it gets one copy of each pseudo-project per page. `GET /labels` does not do this.
+- On a **kanban** view, `GET /projects/:project/views/:view/tasks` paginates the tasks *inside* each bucket: every page repeats all the buckets, each carrying its next slice of tasks. The pagination headers describe the **buckets**, so a 3-bucket board reports `x-pagination-result-count: 3` and `x-pagination-total-pages: 1` even when a bucket has further pages of tasks. Following the header therefore caps each column at `per_page` cards. Page on each bucket's own `count` field instead, and stop when a page returns no tasks. The **list** view of the same endpoint paginates tasks normally and reports honest headers.
 
 ---
 

--- a/mDone/Services/Endpoint.swift
+++ b/mDone/Services/Endpoint.swift
@@ -58,7 +58,9 @@ struct Endpoint {
     /// endpoint: for a kanban view it returns buckets populated with tasks,
     /// while `/views/{view}/buckets` returns bucket metadata only.
     /// `page`/`per_page` paginate the tasks *within each bucket*, not the
-    /// buckets themselves; every bucket is always returned.
+    /// buckets themselves; every bucket is always returned. Note that
+    /// `x-pagination-total-pages` describes the buckets too, so it reads `1`
+    /// even when a bucket has further pages of tasks waiting (issue #141).
     static func kanbanBuckets(projectId: Int64, viewId: Int64, page: Int = 1, perPage: Int = 50) -> Endpoint {
         Endpoint(path: "/api/v1/projects/\(projectId)/views/\(viewId)/tasks", queryItems: [
             URLQueryItem(name: "page", value: "\(page)"),

--- a/mDone/Services/ProjectService.swift
+++ b/mDone/Services/ProjectService.swift
@@ -40,8 +40,61 @@ actor ProjectService {
     /// embedded tasks. Uses the view *tasks* endpoint: for a kanban view it
     /// returns bucket objects with tasks inside (the `/buckets` endpoint stopped
     /// embedding tasks in Vikunja v0.24).
-    func fetchBuckets(projectId: Int64, viewId: Int64) async throws -> [Bucket] {
-        try await apiClient.fetch(Endpoint.kanbanBuckets(projectId: projectId, viewId: viewId))
+    ///
+    /// `page`/`per_page` paginate the tasks *inside* each bucket, not the
+    /// buckets themselves: every page repeats all the buckets, each carrying
+    /// the next slice of its tasks. That makes `fetchAllPages` the wrong tool
+    /// here, because `x-pagination-total-pages` counts the buckets and so
+    /// reads `1` however many pages of tasks there are. Following it stopped
+    /// after one request and capped every column at `per_page` cards, with
+    /// nothing on the board to say cards were missing (issue #141).
+    ///
+    /// So page on the buckets' own `count` instead, and stop as soon as a page
+    /// brings nothing new. That second condition is what protects against
+    /// servers that omit `count` or ignore `page` entirely.
+    func fetchBuckets(projectId: Int64, viewId: Int64, perPage: Int = 100) async throws -> [Bucket] {
+        var buckets: [Bucket] = try await apiClient.fetch(
+            Endpoint.kanbanBuckets(projectId: projectId, viewId: viewId, page: 1, perPage: perPage)
+        )
+        var seenTaskIds = Set(buckets.flatMap { ($0.tasks ?? []).map(\.id) })
+        var page = 2
+
+        while Self.hasIncompleteBucket(buckets) {
+            let nextPage: [Bucket] = try await apiClient.fetch(
+                Endpoint.kanbanBuckets(projectId: projectId, viewId: viewId, page: page, perPage: perPage)
+            )
+
+            var gainedTasks = false
+            for bucket in nextPage {
+                // Dedupe by task id: a bucket whose tasks all arrived already
+                // repeats them rather than returning nothing.
+                let newTasks = (bucket.tasks ?? []).filter { seenTaskIds.insert($0.id).inserted }
+                guard !newTasks.isEmpty else { continue }
+                gainedTasks = true
+                if let index = buckets.firstIndex(where: { $0.id == bucket.id }) {
+                    buckets[index].tasks = (buckets[index].tasks ?? []) + newTasks
+                } else {
+                    var added = bucket
+                    added.tasks = newTasks
+                    buckets.append(added)
+                }
+            }
+
+            guard gainedTasks else { break }
+            page += 1
+        }
+
+        return buckets
+    }
+
+    /// Whether any bucket holds fewer tasks than the server says it has. A
+    /// bucket without a `count` counts as possibly incomplete: one more request
+    /// settles it, and the caller's "nothing new" check ends the loop.
+    private static func hasIncompleteBucket(_ buckets: [Bucket]) -> Bool {
+        buckets.contains { bucket in
+            guard let count = bucket.count else { return true }
+            return (bucket.tasks?.count ?? 0) < count
+        }
     }
 
     func createProject(_ request: ProjectCreateRequest) async throws -> Project {

--- a/mDone/Services/TaskService.swift
+++ b/mDone/Services/TaskService.swift
@@ -17,8 +17,18 @@ actor TaskService {
         try await apiClient.fetch(Endpoint.task(id: id))
     }
 
-    func fetchProjectTasks(projectId: Int64, viewId: Int64, page: Int = 1) async throws -> [VTask] {
-        try await apiClient.fetch(Endpoint.projectTasks(projectId: projectId, viewId: viewId, page: page))
+    /// Fetches a project view's tasks in their stored view order, following
+    /// pagination to the last page.
+    ///
+    /// The order matters more than the tasks here: `AppState` keeps the global
+    /// task list as its source of truth and uses this response only to order a
+    /// project's list. Reading one page left everything past the 50th task out
+    /// of the order map, so those tasks fell to the bottom of the list in
+    /// arbitrary order (issue #141).
+    func fetchProjectTasks(projectId: Int64, viewId: Int64, perPage: Int = 100) async throws -> [VTask] {
+        try await apiClient.fetchAllPages({ page, pp in
+            Endpoint.projectTasks(projectId: projectId, viewId: viewId, page: page, perPage: pp)
+        }, perPage: perPage)
     }
 
     func createTask(projectId: Int64, request: TaskCreateRequest) async throws -> VTask {

--- a/mDoneTests/KanbanTests.swift
+++ b/mDoneTests/KanbanTests.swift
@@ -146,6 +146,158 @@ final class KanbanTests: XCTestCase {
         XCTAssertEqual(buckets[1].tasks?.first?.bucketId, 2)
     }
 
+    // MARK: - fetchBuckets Task Pagination (issue #141)
+
+    private struct BucketSpec {
+        let id: Int
+        let title: String
+        let count: Int?
+        let taskIds: [Int]
+    }
+
+    /// A kanban view-tasks response. `tasks` is omitted for empty buckets and
+    /// `count` can be left out, matching what the server actually sends.
+    private static func bucketsJSON(_ specs: [BucketSpec]) throws -> Data {
+        let objects: [[String: Any]] = specs.map { spec in
+            var bucket: [String: Any] = [
+                "id": spec.id,
+                "title": spec.title,
+                "project_view_id": 3,
+                "limit": 0,
+                "position": Double(spec.id),
+            ]
+            if let count = spec.count {
+                bucket["count"] = count
+            }
+            if !spec.taskIds.isEmpty {
+                bucket["tasks"] = spec.taskIds.map { id in
+                    [
+                        "id": id, "title": "Task \(id)", "done": false,
+                        "priority": 0, "project_id": 7, "bucket_id": spec.id,
+                    ] as [String: Any]
+                }
+            }
+            return bucket
+        }
+        return try JSONSerialization.data(withJSONObject: objects)
+    }
+
+    private static func pageParam(of request: URLRequest) -> Int {
+        guard let url = request.url,
+              let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+              let raw = items.first(where: { $0.name == "page" })?.value,
+              let page = Int(raw)
+        else { return 1 }
+        return page
+    }
+
+    private func makeBucketService() async -> ProjectService {
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        return ProjectService(apiClient: client)
+    }
+
+    /// The board capped every column at one page of cards. `x-pagination-total-pages`
+    /// cannot drive this loop: it counts buckets, so it says `1` even while a
+    /// bucket still has tasks on later pages. The bucket's own `count` does.
+    func testFetchBucketsPagesUntilEveryBucketReachesItsCount() async throws {
+        let service = await makeBucketService()
+        let page1 = try Self.bucketsJSON([BucketSpec(id: 2, title: "To-Do", count: 60, taskIds: Array(1 ... 50))])
+        let page2 = try Self.bucketsJSON([BucketSpec(id: 2, title: "To-Do", count: 60, taskIds: Array(51 ... 60))])
+
+        MockURLProtocol.requestHandler = { request in
+            // The header lies about task pages, exactly as the server sends it.
+            let response = MockURLProtocol.makeResponse(
+                statusCode: 200,
+                url: request.url,
+                headers: ["x-pagination-total-pages": "1"]
+            )
+            return (response, Self.pageParam(of: request) == 1 ? page1 : page2)
+        }
+
+        let buckets = try await service.fetchBuckets(projectId: 7, viewId: 3)
+
+        XCTAssertEqual(MockURLProtocol.capturedRequests.count, 2)
+        XCTAssertEqual(buckets.count, 1)
+        XCTAssertEqual(buckets.first?.tasks?.count, 60)
+        XCTAssertEqual(buckets.first?.tasks?.last?.id, 60, "later pages must append, not replace")
+    }
+
+    func testFetchBucketsRoutesLaterPagesIntoTheMatchingBucket() async throws {
+        let service = await makeBucketService()
+        let page1 = try Self.bucketsJSON([
+            BucketSpec(id: 2, title: "To-Do", count: 3, taskIds: [1, 2]),
+            BucketSpec(id: 3, title: "Doing", count: 2, taskIds: [10]),
+        ])
+        let page2 = try Self.bucketsJSON([
+            BucketSpec(id: 2, title: "To-Do", count: 3, taskIds: [3]),
+            BucketSpec(id: 3, title: "Doing", count: 2, taskIds: [11]),
+        ])
+
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 200, url: request.url)
+            return (response, Self.pageParam(of: request) == 1 ? page1 : page2)
+        }
+
+        let buckets = try await service.fetchBuckets(projectId: 7, viewId: 3)
+
+        XCTAssertEqual(buckets.first(where: { $0.id == 2 })?.tasks?.map(\.id), [1, 2, 3])
+        XCTAssertEqual(buckets.first(where: { $0.id == 3 })?.tasks?.map(\.id), [10, 11])
+    }
+
+    /// Small boards are the common case, so a complete first page must not
+    /// cost a second request.
+    func testFetchBucketsMakesOneRequestWhenTheFirstPageIsComplete() async throws {
+        let service = await makeBucketService()
+        let page = try Self.bucketsJSON([
+            BucketSpec(id: 2, title: "To-Do", count: 2, taskIds: [1, 2]),
+            BucketSpec(id: 3, title: "Done", count: 0, taskIds: []),
+        ])
+
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), page)
+        }
+
+        let buckets = try await service.fetchBuckets(projectId: 7, viewId: 3)
+
+        XCTAssertEqual(MockURLProtocol.capturedRequests.count, 1)
+        XCTAssertEqual(buckets.count, 2)
+    }
+
+    /// A server that ignores `page` (or reports a `count` it never delivers)
+    /// keeps handing back the same tasks. Give up instead of looping forever.
+    func testFetchBucketsStopsWhenAPageRepeatsTasksItAlreadyHas() async throws {
+        let service = await makeBucketService()
+        let page = try Self.bucketsJSON([BucketSpec(id: 2, title: "To-Do", count: 60, taskIds: Array(1 ... 50))])
+
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), page)
+        }
+
+        let buckets = try await service.fetchBuckets(projectId: 7, viewId: 3)
+
+        XCTAssertEqual(MockURLProtocol.capturedRequests.count, 2, "must give up after a page adds nothing")
+        XCTAssertEqual(buckets.first?.tasks?.count, 50)
+    }
+
+    /// Older servers may omit `count`. Treat that as "might have more", then
+    /// stop on the empty page.
+    func testFetchBucketsWithoutCountStopsAfterAPageWithNoTasks() async throws {
+        let service = await makeBucketService()
+        let page1 = try Self.bucketsJSON([BucketSpec(id: 2, title: "To-Do", count: nil, taskIds: [1, 2])])
+        let page2 = try Self.bucketsJSON([BucketSpec(id: 2, title: "To-Do", count: nil, taskIds: [])])
+
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 200, url: request.url)
+            return (response, Self.pageParam(of: request) == 1 ? page1 : page2)
+        }
+
+        let buckets = try await service.fetchBuckets(projectId: 7, viewId: 3)
+
+        XCTAssertEqual(MockURLProtocol.capturedRequests.count, 2)
+        XCTAssertEqual(buckets.first?.tasks?.count, 2)
+    }
+
     // MARK: - TaskService.moveTaskToBucket
 
     func testMoveTaskToBucketSendsTaskId() async throws {

--- a/mDoneTests/TaskServiceTests.swift
+++ b/mDoneTests/TaskServiceTests.swift
@@ -532,6 +532,45 @@ final class TaskServiceTests: XCTestCase {
         XCTAssertTrue(tasks[1].done)
     }
 
+    /// The view response drives the ordering of a project's list, so stopping
+    /// at page 1 left everything past the 50th task with no known position
+    /// (issue #141). Unlike the kanban view, this endpoint reports its task
+    /// pages honestly, so following the header is enough here.
+    func testFetchProjectTasksFollowsPaginationAcrossPages() async throws {
+        let (service, client) = makeTestService()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+
+        func page(ids: ClosedRange<Int>) -> Data {
+            let objects = ids.map { id in
+                """
+                {"id": \(id), "title": "Task \(id)", "done": false, "priority": 0, "project_id": 7, \
+                "created": "2026-03-15T08:00:00Z", "updated": "2026-03-15T08:00:00Z"}
+                """
+            }
+            return "[\(objects.joined(separator: ","))]".data(using: .utf8)!
+        }
+        let page1 = page(ids: 1 ... 50)
+        let page2 = page(ids: 51 ... 60)
+
+        MockURLProtocol.requestHandler = { request in
+            let items = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?.queryItems
+            let pageNumber = Int(items?.first(where: { $0.name == "page" })?.value ?? "1") ?? 1
+            let response = MockURLProtocol.makeResponse(
+                statusCode: 200,
+                url: request.url,
+                headers: ["x-pagination-total-pages": "2"]
+            )
+            return (response, pageNumber == 1 ? page1 : page2)
+        }
+
+        let tasks = try await service.fetchProjectTasks(projectId: 7, viewId: 3)
+
+        XCTAssertEqual(MockURLProtocol.capturedRequests.count, 2)
+        XCTAssertEqual(tasks.count, 60)
+        XCTAssertEqual(tasks.last?.id, 60, "view order must survive to the last page")
+        XCTAssertEqual(MockURLProtocol.capturedRequests.first?.url?.path, "/api/v1/projects/7/views/3/tasks")
+    }
+
     func testFetchTaskReturnsTask() async throws {
         let (service, client) = makeTestService()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")


### PR DESCRIPTION
## Summary

Two per-project reads still asked the server for a single page. They look like the same bug but need **different** fixes, which is the interesting part of this PR.

**Kanban board (the user-visible one).** A column holding more than 50 tasks showed 50 cards, with nothing on the board to say the rest existed. The obvious fix, routing it through `fetchAllPages` the way #139 was fixed, does not work here: on this endpoint `page`/`per_page` paginate the tasks *inside* each bucket, while `x-pagination-total-pages` describes the **buckets**, so it reads `1` however many pages of tasks are waiting. Following the header stops after one request.

`fetchBuckets` now pages on each bucket's own `count` field instead, merging later pages into the matching bucket by id and deduping task ids. It stops as soon as a page brings nothing new, which covers servers that omit `count` or ignore `page` entirely, and it still makes exactly one request when the first page is already complete (the common case, covered by a test).

**Project list ordering.** Worth stating precisely, because no tasks were missing here: `AppState` keeps the global task list as its source of truth and that list is fully paginated. The view response only supplies the *order*. Reading one page left everything past the 50th task with no known position, so those tasks fell to the bottom of the list in arbitrary order and any manual drag-ordering past that point did not hold. This endpoint reports its task pages honestly, so `fetchProjectTasks` simply goes through `fetchAllPages`.

The kanban header quirk is now recorded both on `Endpoint.kanbanBuckets` and in `docs/vikunja-api-inventory.md`, so the next person does not rediscover it the hard way.

## Related Issues

Fixes #141

## Testing

Verified end-to-end against a local Vikunja v2.5.0 with a project whose column holds 60 tasks. The board's column header counts embedded cards, so it is a direct readout of what was fetched:

| | Before | After |
|---|---|---|
| Cards in a 60-task column | 50 | **60** |

502 unit tests pass, including 6 new ones:

- kanban pages until every bucket reaches its `count`, while the response header keeps claiming one page
- later pages are routed into the matching bucket rather than replacing it
- a complete first page still costs exactly one request
- a server that repeats tasks (ignores `page`, or reports a `count` it never delivers) terminates instead of looping forever
- a server that omits `count` stops after an empty page
- the list view follows its honest pagination header across pages

## Checklist

- [x] Builds on iOS and macOS
- [x] Tests pass
- [x] Ran `swiftlint lint --quiet` and `swiftformat .`
- [x] No breaking changes

**On the lint checklist item:** the new multiline literals carry trailing commas, matching `--commas always` in `.swiftformat` and files like `Endpoint.swift`. SwiftLint's `trailing_comma` rule contradicts that config and flags them, which is a pre-existing repo inconsistency (66 such warnings on `main` today). I followed the declared `.swiftformat` style rather than adding a local exception. Disabling `trailing_comma` in `.swiftlint.yml` would settle it, but that felt like scope creep here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
