### PR TITLE
docs: stamp 1.12.0 in changelog and add App Store What's New

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-08-10
+
 ### Fixed
 - Kanban columns now show every card. A column holding more than 50 tasks stopped at 50, with nothing on the board to say the rest existed. Project lists are ordered correctly all the way down too: tasks past the 50th used to collect at the bottom instead of sitting in their proper place (#141).
 - All of your projects and labels now load, not just the first 50. The app only ever asked the server for one page, so anyone with more than 50 projects lost the rest everywhere: sidebar, project pickers, favourites and sync, with no error to explain why. Raising the page size would not have helped, since Vikunja caps it server-side, so the app now walks through every page (#139).
-- The Kanban board now shows your tasks again. Columns loaded but sat empty on current Vikunja servers (v0.24 and later, including 2.x) because the app still read tasks from an endpoint that stopped including them; the board now loads columns and cards the way modern Vikunja expects (#130).
 
 ### Added
 - You can now set optional start and end dates from a task's detail view on iPhone and Mac. Tasks spanning several days appear on every included day in the calendar while their due date remains an additional occurrence, and synchronized ranges remain available from the offline cache (#17).
+
+## [1.11.0] - 2026-08-02
+
+### Added
 - You can now hide all-day calendar events: Settings > Calendar > **Show all-day events**. Turn it off to keep day-long events out of the Calendar and Today views. It stays on by default, so nothing changes unless you flip it (#133).
+
+### Fixed
+- The Kanban board now shows your tasks again. Columns loaded but sat empty on current Vikunja servers (v0.24 and later, including 2.x) because the app still read tasks from an endpoint that stopped including them; the board now loads columns and cards the way modern Vikunja expects (#130).
 
 ## [1.10.0] - 2026-07-23
 

--- a/docs/appstore-metadata.md
+++ b/docs/appstore-metadata.md
@@ -83,6 +83,15 @@ Steps to test:
 
 This is a private test server maintained by the developer for App Store review purposes.
 
+## What's New (v1.12.0)
+
+Task date ranges, plus fixes for busy accounts.
+
+- Give a task an optional start and end date from its detail view. Tasks spanning several days now appear on every included day in the calendar, so multi-day work stays visible.
+- All of your projects and labels now load, not just the first 50. Larger accounts previously lost projects from the sidebar and pickers with no explanation.
+- Kanban columns now show every card, and long project lists keep their order all the way down. Columns with more than 50 tasks previously stopped at 50.
+- Available on both iPhone and Mac.
+
 ## What's New (v1.11.0)
 
 Hide all-day calendar events, plus a Kanban fix.


### PR DESCRIPTION
Release housekeeping for 1.12.0 (build 57), which is on TestFlight and submitted for App Store review on both platforms.

- CHANGELOG.md: splits the old `[Unreleased]` pile into `[1.11.0] - 2026-08-02` (all-day events setting #133, Kanban empty-board fix #130, which shipped in 1.11.0) and `[1.12.0] - 2026-08-10` (task date ranges #17, projects/labels pagination #139, Kanban column pagination and list order #141)
- docs/appstore-metadata.md: adds the v1.12.0 What's New section, mirroring the ASC submission text

🤖 Generated with [Claude Code](https://claude.com/claude-code)