### PR TITLE
fix: load and save the offline cache (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Offline mode now actually works. Opening the app without a reachable server used to sit on a loading spinner and then show an empty list claiming "All done!", because your tasks were never being saved to the offline cache and the cache was never read back. Your tasks, projects and labels are now saved on every successful sync and appear instantly on launch, before any network call, so the app is usable offline (#144).
+- When the device is offline the app no longer fires requests it can only lose, so there is no wait before your cached tasks appear (#144).
+- A server that cannot be reached now shows "You're offline. Showing your last synced tasks." and a clear "can't reach the server" message, instead of a generic error and a misleading empty list. This covers the case where Wi-Fi is working but your Vikunja is not reachable, for example over a VPN that is down (#144).
+- Requests now time out after 20 seconds instead of 60. On a network that drops packets rather than refusing the connection, the app could sit on a spinner for minutes before giving up (#144).
+
 ## [1.12.0] - 2026-08-10
 
 ### Fixed

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -134,6 +134,18 @@ final class AppState {
         !(networkMonitor?.isConnected ?? true)
     }
 
+    /// True while the visible lists come from the on-device cache because the
+    /// last refresh couldn't reach the server (device offline, or the server
+    /// unreachable on an otherwise-working connection). Drives the offline
+    /// banner and the "no cached data" empty state.
+    private(set) var isShowingCachedData: Bool = false
+
+    /// Cache hydration runs once per session, on the first refresh. Later
+    /// refreshes have either replaced the lists from the network or kept the
+    /// hydrated ones, so re-reading SwiftData would only cost a main-thread
+    /// fetch.
+    private var hasHydratedFromCache = false
+
     /// Polls the APIClient's retry state and updates the published `isRetrying` property.
     @MainActor
     func updateRetryState() async {
@@ -411,7 +423,7 @@ final class AppState {
         print("[mDone] logout() called")
         #endif
         authService.clearAll()
-        await tearDownSession()
+        await tearDownSession(clearingCache: true)
     }
 
     /// Called when the server stops accepting our credentials (refresh failed,
@@ -425,21 +437,72 @@ final class AppState {
         print("[mDone] expireSession() called")
         #endif
         authService.clearSession()
-        await tearDownSession()
+        // Keep the cache: it's the same account, and the user only has to
+        // re-enter their password. Their tasks stay readable in the meantime.
+        await tearDownSession(clearingCache: false)
     }
 
     @MainActor
-    private func tearDownSession() async {
+    private func tearDownSession(clearingCache: Bool) async {
         await APIClient.shared.clearCredentials()
         tasks = []
         projects = []
         labels = []
         notifications = []
         isAuthenticated = false
+        isShowingCachedData = false
+
+        if clearingCache {
+            syncService?.clearCache()
+            pendingOperationsCount = 0
+        }
+        // Let the next session hydrate from whatever cache survives.
+        hasHydratedFromCache = false
 
         // Clear cached widget data and refresh widgets
         SharedKeys.sharedDefaults.removeObject(forKey: SharedKeys.widgetDataKey)
         WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    /// Fills the in-memory lists from the on-device cache so the app has
+    /// content before (and without) a network round trip. Only fills lists that
+    /// are still empty, so it can never clobber fresher data from the server.
+    ///
+    /// Issue #144: nothing ever read the cache, so launching offline sat on a
+    /// blocking spinner for the whole retry backoff and then showed an empty
+    /// list, even though the user had synced moments earlier.
+    @MainActor
+    func hydrateFromCache() {
+        guard let syncService else { return }
+        hasHydratedFromCache = true
+
+        if tasks.isEmpty, let cached = try? syncService.loadCachedTasks(), !cached.isEmpty {
+            tasks = cached
+        }
+        if projects.isEmpty, let cached = try? syncService.loadCachedProjects(), !cached.isEmpty {
+            projects = cached
+        }
+        if labels.isEmpty, let cached = try? syncService.loadCachedLabels(), !cached.isEmpty {
+            labels = cached
+        }
+        updatePendingCount()
+    }
+
+    /// Persists the freshly-fetched lists so the next launch has something to
+    /// show while offline. Cache writes are best-effort: a SwiftData failure
+    /// must not turn a successful refresh into a visible error.
+    @MainActor
+    private func persistToCache() {
+        guard let syncService else { return }
+        do {
+            try syncService.cacheTasks(tasks)
+            try syncService.cacheProjects(projects)
+            try syncService.cacheLabels(labels)
+        } catch {
+            #if DEBUG
+            print("[mDone] persistToCache failed: \(error)")
+            #endif
+        }
     }
 
     @MainActor
@@ -447,6 +510,22 @@ final class AppState {
         #if DEBUG
         print("[mDone] refreshAll() called")
         #endif
+
+        if !hasHydratedFromCache {
+            hydrateFromCache()
+        }
+
+        // Offline: serve the cache instead of firing requests that can only
+        // fail. Skipping the network here is what keeps the loading overlay
+        // from sitting over an empty screen for the whole retry backoff.
+        if isOffline {
+            isShowingCachedData = true
+            #if DEBUG
+            print("[mDone] refreshAll: offline, serving \(tasks.count) cached tasks")
+            #endif
+            return
+        }
+
         isLoading = true
 
         #if os(iOS)
@@ -495,10 +574,12 @@ final class AppState {
 
             errorMessage = nil
             activeError = nil
+            isShowingCachedData = false
             #if DEBUG
             print("[mDone] refreshAll: SUCCESS")
             #endif
 
+            persistToCache()
             pushWidgetData()
             WidgetCenter.shared.reloadAllTimelines()
 
@@ -513,12 +594,29 @@ final class AppState {
                 #endif
                 await expireSession()
             }
+            markCachedIfUnreachable(error)
             handleError(error)
         } catch {
             #if DEBUG
             print("[mDone] refreshAll: other error: \(error)")
             #endif
+            markCachedIfUnreachable(error)
             handleError(error)
+        }
+    }
+
+    /// Flags the UI as showing cached data when a refresh failed for
+    /// connectivity reasons. `NetworkMonitor` only reports the device's own
+    /// link, so a reachable Wi-Fi with an unreachable Vikunja (VPN down, server
+    /// off the LAN) leaves `isOffline` false; without this the user would get a
+    /// stale list with no indication it wasn't refreshed.
+    @MainActor
+    private func markCachedIfUnreachable(_ error: Error) {
+        switch NetworkError.friendly(from: error) {
+        case .networkUnavailable, .timeout, .serverUnreachable:
+            isShowingCachedData = true
+        default:
+            break
         }
     }
 
@@ -750,9 +848,7 @@ final class AppState {
             // Only restore the old target if no newer completion was recorded
             // while this request was in flight — otherwise we'd clobber the more
             // recent undo target and break "undo the most recent completion".
-            if undoableCompletion == nil {
-                undoableCompletion = target
-            }
+            if undoableCompletion == nil { undoableCompletion = target }
             handleError(error)
         }
     }

--- a/mDone/App/mDoneApp.swift
+++ b/mDone/App/mDoneApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @main
 struct mDoneApp: App {
     private let dependencies: AppDependencies
-    @State private var appState = AppState()
+    @State private var appState: AppState
     @Environment(\.scenePhase) private var scenePhase
     #if os(iOS)
     @State private var focusManager: FocusManager
@@ -14,6 +14,22 @@ struct mDoneApp: App {
     init() {
         let deps = AppDependencies()
         dependencies = deps
+
+        // Wire the sync service before the first view appears. It used to be
+        // done in `.onAppear`, which races the child views' `.task` blocks:
+        // whichever refresh ran first would find no sync service and so no
+        // cache to hydrate from (issue #144).
+        let state = AppState()
+        state.configureSyncService(
+            SyncService(
+                taskService: TaskService(),
+                projectService: ProjectService(),
+                modelContainer: deps.modelContainer
+            ),
+            networkMonitor: deps.networkMonitor
+        )
+        _appState = State(initialValue: state)
+
         #if os(iOS)
         let outbox = FocusOutboxService(modelContainer: deps.modelContainer)
         focusOutbox = outbox
@@ -42,13 +58,6 @@ struct mDoneApp: App {
             #endif
                 .modelContainer(dependencies.modelContainer)
                 .onAppear {
-                    let syncService = SyncService(
-                        taskService: TaskService(),
-                        projectService: ProjectService(),
-                        modelContainer: dependencies.modelContainer
-                    )
-                    appState.configureSyncService(syncService, networkMonitor: dependencies.networkMonitor)
-
                     #if os(iOS)
                     appState.onTaskCompleted = { taskId in
                         focusManager.handleTaskCompleted(taskId: taskId)

--- a/mDone/Services/APIClient.swift
+++ b/mDone/Services/APIClient.swift
@@ -17,6 +17,13 @@ actor APIClient {
     private let baseRetryDelay: UInt64 = 1_000_000_000 // 1 second in nanoseconds
     private static let refreshCookieName = "vikunja_refresh_token"
 
+    /// Per-request timeout, in seconds. URLSession's 60s default is far too
+    /// long here: a network that drops packets rather than refusing the
+    /// connection (VPN down, server off the LAN) burned 60s on every one of the
+    /// four attempts, leaving the UI on a loading spinner for minutes (issue
+    /// #144). 20s is still generous for a self-hosted Vikunja on a slow link.
+    static let requestTimeout: TimeInterval = 20
+
     /// Fired when the access token (and optionally its refresh cookie) change
     /// because of a `/login` response or a refresh-on-401. Callers should
     /// persist both to the keychain so the new credentials survive relaunch.
@@ -107,6 +114,7 @@ actor APIClient {
 
         var request = URLRequest(url: url)
         request.httpMethod = endpoint.method.rawValue
+        request.timeoutInterval = APIClient.requestTimeout
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         if let apiToken {
@@ -210,9 +218,14 @@ actor APIClient {
 
                 isRetrying = false
 
-                // Map URLError to NetworkError for non-retryable or exhausted network errors
-                if let urlError = error as? URLError, urlError.code == .notConnectedToInternet {
-                    throw NetworkError.networkUnavailable
+                // Map URLError to NetworkError for non-retryable or exhausted
+                // network errors. This has to cover every connectivity code, not
+                // just `.notConnectedToInternet`: an unreachable server used to
+                // surface as `.unknown`, which hid it from callers checking for
+                // connectivity failures and gave the user a generic banner
+                // instead of "can't reach the server" (issue #144).
+                if let urlError = error as? URLError {
+                    throw NetworkError.from(urlError)
                 }
                 throw NetworkError.unknown(error)
             }
@@ -222,8 +235,8 @@ actor APIClient {
 
         // All retries exhausted — surface the appropriate error
         if let lastError {
-            if let urlError = lastError as? URLError, urlError.code == .notConnectedToInternet {
-                throw NetworkError.networkUnavailable
+            if let urlError = lastError as? URLError {
+                throw NetworkError.from(urlError)
             }
             throw NetworkError.unknown(lastError)
         }

--- a/mDone/Services/NetworkMonitor.swift
+++ b/mDone/Services/NetworkMonitor.swift
@@ -23,6 +23,13 @@ final class NetworkMonitor {
         monitor.start(queue: queue)
     }
 
+    /// Builds a monitor pinned to a fixed state, without starting `NWPathMonitor`.
+    /// Tests need a deterministic offline flag; a started monitor would
+    /// asynchronously overwrite `isConnected` with the host's real path.
+    init(stubbedConnection isConnected: Bool) {
+        self.isConnected = isConnected
+    }
+
     private func getConnectionType(_ path: NWPath) -> ConnectionType {
         if path.usesInterfaceType(.wifi) { return .wifi }
         if path.usesInterfaceType(.cellular) { return .cellular }

--- a/mDone/Services/SyncService.swift
+++ b/mDone/Services/SyncService.swift
@@ -114,15 +114,18 @@ actor SyncService {
         return (try? context.fetchCount(descriptor)) ?? 0
     }
 
-    // MARK: - Cache Sync
+    // MARK: - Cache Writes
 
+    /// Replaces the cached task list with `tasks`: rows that still exist are
+    /// updated in place, new ones inserted, and rows the server no longer
+    /// returns deleted. Takes an already-fetched list rather than fetching its
+    /// own so `AppState.refreshAll()` can persist exactly what it just put on
+    /// screen without a second round trip (issue #144).
     @MainActor
-    func syncTasks() async throws -> [VTask] {
-        let tasks = try await taskService.fetchAllTasks(perPage: 200)
-
+    func cacheTasks(_ tasks: [VTask]) throws {
         let context = modelContainer.mainContext
-        let existingTasks = try context.fetch(FetchDescriptor<CachedTask>())
-        let existingById = Dictionary(uniqueKeysWithValues: existingTasks.map { ($0.id, $0) })
+        let existing = try context.fetch(FetchDescriptor<CachedTask>())
+        let existingById = Dictionary(existing.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
 
         for task in tasks {
             if let cached = existingById[task.id] {
@@ -133,21 +136,18 @@ actor SyncService {
         }
 
         let fetchedIds = Set(tasks.map(\.id))
-        for existing in existingTasks where !fetchedIds.contains(existing.id) {
-            context.delete(existing)
+        for row in existing where !fetchedIds.contains(row.id) {
+            context.delete(row)
         }
 
         try context.save()
-        return tasks
     }
 
     @MainActor
-    func syncProjects() async throws -> [Project] {
-        let projects = try await projectService.fetchProjects()
-
+    func cacheProjects(_ projects: [Project]) throws {
         let context = modelContainer.mainContext
-        let existingProjects = try context.fetch(FetchDescriptor<CachedProject>())
-        let existingById = Dictionary(uniqueKeysWithValues: existingProjects.map { ($0.id, $0) })
+        let existing = try context.fetch(FetchDescriptor<CachedProject>())
+        let existingById = Dictionary(existing.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
 
         for project in projects {
             if let cached = existingById[project.id] {
@@ -158,13 +158,64 @@ actor SyncService {
         }
 
         let fetchedIds = Set(projects.map(\.id))
-        for existing in existingProjects where !fetchedIds.contains(existing.id) {
-            context.delete(existing)
+        for row in existing where !fetchedIds.contains(row.id) {
+            context.delete(row)
         }
 
         try context.save()
+    }
+
+    /// `CachedLabel` has no `update(from:)` because labels are small and
+    /// immutable in practice, so the whole set is replaced.
+    @MainActor
+    func cacheLabels(_ labels: [VLabel]) throws {
+        let context = modelContainer.mainContext
+        for row in try context.fetch(FetchDescriptor<CachedLabel>()) {
+            context.delete(row)
+        }
+        for label in labels {
+            context.insert(CachedLabel(from: label))
+        }
+        try context.save()
+    }
+
+    /// Drops every cached record. Called on an explicit logout so one account's
+    /// tasks can't surface under the next.
+    @MainActor
+    func clearCache() {
+        let context = modelContainer.mainContext
+        for row in (try? context.fetch(FetchDescriptor<CachedTask>())) ?? [] {
+            context.delete(row)
+        }
+        for row in (try? context.fetch(FetchDescriptor<CachedProject>())) ?? [] {
+            context.delete(row)
+        }
+        for row in (try? context.fetch(FetchDescriptor<CachedLabel>())) ?? [] {
+            context.delete(row)
+        }
+        for row in (try? context.fetch(FetchDescriptor<PendingOperation>())) ?? [] {
+            context.delete(row)
+        }
+        try? context.save()
+    }
+
+    // MARK: - Cache Sync
+
+    @MainActor
+    func syncTasks() async throws -> [VTask] {
+        let tasks = try await taskService.fetchAllTasks(perPage: 200)
+        try cacheTasks(tasks)
+        return tasks
+    }
+
+    @MainActor
+    func syncProjects() async throws -> [Project] {
+        let projects = try await projectService.fetchProjects()
+        try cacheProjects(projects)
         return projects
     }
+
+    // MARK: - Cache Reads
 
     @MainActor
     func loadCachedTasks() throws -> [VTask] {
@@ -178,6 +229,13 @@ actor SyncService {
         let context = modelContainer.mainContext
         let cached = try context.fetch(FetchDescriptor<CachedProject>())
         return cached.map { $0.toProject() }
+    }
+
+    @MainActor
+    func loadCachedLabels() throws -> [VLabel] {
+        let context = modelContainer.mainContext
+        let cached = try context.fetch(FetchDescriptor<CachedLabel>())
+        return cached.map { $0.toLabel() }
     }
 
     // MARK: - Local Cache Updates

--- a/mDone/Views/Tasks/TaskListScreen.swift
+++ b/mDone/Views/Tasks/TaskListScreen.swift
@@ -99,7 +99,7 @@ struct TaskListScreen: View {
                     }
                     #endif
 
-                    if !networkMonitor.isConnected {
+                    if isOffline {
                         offlineBanner
                     }
 
@@ -354,11 +354,22 @@ struct TaskListScreen: View {
 
         if appState.activeTasks.isEmpty, !appState.isLoading {
             Section {
-                EmptyStateView(
-                    icon: "checkmark.circle",
-                    title: "All done!",
-                    subtitle: "No pending tasks"
-                )
+                // An empty list while offline usually means "nothing cached
+                // yet", not "nothing to do". Claiming "All done!" there is
+                // actively misleading (issue #144).
+                if isOffline {
+                    EmptyStateView(
+                        icon: "wifi.slash",
+                        title: "No cached tasks",
+                        subtitle: "Connect to your server to load your tasks"
+                    )
+                } else {
+                    EmptyStateView(
+                        icon: "checkmark.circle",
+                        title: "All done!",
+                        subtitle: "No pending tasks"
+                    )
+                }
             }
         }
     }
@@ -413,11 +424,19 @@ struct TaskListScreen: View {
         }
     }
 
+    /// True when the device has no link, or when the last refresh couldn't
+    /// reach the server on an otherwise-working connection (a self-hosted
+    /// Vikunja behind a VPN that's down, say). The second case looks identical
+    /// to the user, so it gets the same banner.
+    private var isOffline: Bool {
+        !networkMonitor.isConnected || appState.isShowingCachedData
+    }
+
     private var offlineBanner: some View {
         HStack {
             Image(systemName: "wifi.slash")
                 .accessibilityHidden(true)
-            Text("You're offline. Changes will sync when connected.")
+            Text("You're offline. Showing your last synced tasks.")
                 .font(.caption)
         }
         .foregroundStyle(.orange)

--- a/mDoneTests/OfflineCacheTests.swift
+++ b/mDoneTests/OfflineCacheTests.swift
@@ -1,0 +1,269 @@
+import SwiftData
+import XCTest
+@testable import mDone
+
+/// Covers the offline path reported in issue #144: the app advertised offline
+/// caching but never wrote to or read from the cache, so launching without a
+/// reachable server sat on a blocking loading overlay and then showed an empty
+/// list.
+@MainActor
+final class OfflineCacheTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    // MARK: - Fixtures
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([
+            CachedTask.self,
+            CachedProject.self,
+            CachedLabel.self,
+            PendingOperation.self,
+            FocusRecord.self,
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    private func makeSyncService(container: ModelContainer) async -> SyncService {
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        return SyncService(
+            taskService: TaskService(apiClient: client),
+            projectService: ProjectService(apiClient: client),
+            modelContainer: container
+        )
+    }
+
+    /// An `AppState` whose task/project/label services all talk to
+    /// `MockURLProtocol`, wired to `sync` and a monitor pinned to `connected`.
+    private func makeAppState(sync: SyncService, connected: Bool) async -> AppState {
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        let state = AppState(
+            taskService: TaskService(apiClient: client),
+            projectService: ProjectService(apiClient: client),
+            labelService: LabelService(apiClient: client)
+        )
+        state.configureSyncService(sync, networkMonitor: NetworkMonitor(stubbedConnection: connected))
+        return state
+    }
+
+    private func json(_ object: Any) -> Data {
+        (try? JSONSerialization.data(withJSONObject: object)) ?? Data()
+    }
+
+    /// Serves one page of tasks, projects and labels, keyed off the request path.
+    private func serveFullSync() {
+        MockURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            let body: Any = if path.contains("/labels") {
+                [["id": 7, "title": "Current"]]
+            } else if path.contains("/projects") {
+                [["id": 3, "title": "Work"]]
+            } else {
+                [["id": 1, "title": "Cached task", "done": false, "priority": 0, "project_id": 3]]
+            }
+            let response = MockURLProtocol.makeResponse(
+                statusCode: 200,
+                url: request.url,
+                headers: ["x-pagination-total-pages": "1"]
+            )
+            return (response, self.json(body))
+        }
+    }
+
+    // MARK: - Cache is written on a successful refresh
+
+    /// Before the fix `refreshAll()` wrote straight to memory: after a fully
+    /// successful sync every cache table was still empty, so there was nothing
+    /// to fall back to offline.
+    func testSuccessfulRefreshPersistsTasksProjectsAndLabels() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: true)
+        serveFullSync()
+
+        await state.refreshAll()
+
+        XCTAssertEqual(state.tasks.map(\.id), [1])
+        XCTAssertEqual(try sync.loadCachedTasks().map(\.id), [1])
+        XCTAssertEqual(try sync.loadCachedProjects().map(\.id), [3])
+        XCTAssertEqual(try sync.loadCachedLabels().map(\.id), [7])
+        XCTAssertFalse(state.isShowingCachedData)
+    }
+
+    // MARK: - Cache is read when offline
+
+    /// The core repro: a synced cache plus no connectivity must still produce a
+    /// populated task list.
+    func testOfflineRefreshServesCachedData() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        try sync.cacheTasks([VTask(id: 1, title: "Cached task", done: false, priority: 0, projectId: 3)])
+        try sync.cacheProjects([Project(id: 3, title: "Work")])
+        try sync.cacheLabels([VLabel(id: 7, title: "Current")])
+
+        let state = await makeAppState(sync: sync, connected: false)
+        MockURLProtocol.requestHandler = { _ in throw URLError(.notConnectedToInternet) }
+
+        await state.refreshAll()
+
+        XCTAssertEqual(state.tasks.map(\.title), ["Cached task"])
+        XCTAssertEqual(state.projects.map(\.id), [3])
+        XCTAssertEqual(state.labels.map(\.id), [7])
+        XCTAssertTrue(state.isShowingCachedData)
+    }
+
+    /// The infinite-spinner half of the report: offline, the refresh must not
+    /// issue requests it can only lose, and must not leave `isLoading` set,
+    /// which is what pins `LoadingOverlay` over the whole screen.
+    func testOfflineRefreshSkipsNetworkAndLeavesNoSpinner() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+        MockURLProtocol.requestHandler = { _ in throw URLError(.notConnectedToInternet) }
+
+        await state.refreshAll()
+
+        XCTAssertTrue(MockURLProtocol.capturedRequests.isEmpty)
+        XCTAssertFalse(state.isLoading)
+    }
+
+    /// An empty cache offline is a legitimate state (never synced). It must not
+    /// crash or spin, just come back empty.
+    func testOfflineRefreshWithEmptyCacheIsEmptyNotStuck() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+
+        await state.refreshAll()
+
+        XCTAssertTrue(state.tasks.isEmpty)
+        XCTAssertFalse(state.isLoading)
+        XCTAssertTrue(state.isShowingCachedData)
+    }
+
+    // MARK: - Unreachable server on a working connection
+
+    /// `NetworkMonitor` reports the device's own link, so a self-hosted server
+    /// that can't be reached leaves `isOffline` false. The cached list must
+    /// survive the failed refresh rather than being replaced by an empty one.
+    func testUnreachableServerKeepsCachedTasksAndFlagsCachedData() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        try sync.cacheTasks([VTask(id: 1, title: "Cached task", done: false, priority: 0, projectId: 3)])
+
+        let state = await makeAppState(sync: sync, connected: true)
+        MockURLProtocol.requestHandler = { _ in throw URLError(.cannotConnectToHost) }
+
+        await state.refreshAll()
+
+        XCTAssertEqual(state.tasks.map(\.title), ["Cached task"])
+        XCTAssertTrue(state.isShowingCachedData)
+        XCTAssertFalse(state.isLoading)
+    }
+
+    /// A later successful refresh has to clear the cached-data flag so the
+    /// offline banner goes away.
+    func testSuccessfulRefreshClearsCachedDataFlag() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: true)
+
+        MockURLProtocol.requestHandler = { _ in throw URLError(.cannotConnectToHost) }
+        await state.refreshAll()
+        XCTAssertTrue(state.isShowingCachedData)
+
+        serveFullSync()
+        await state.refreshAll()
+        XCTAssertFalse(state.isShowingCachedData)
+        XCTAssertEqual(state.tasks.map(\.id), [1])
+    }
+
+    // MARK: - Hydration precedence
+
+    /// Hydration must never overwrite data already fetched from the server.
+    func testHydrationDoesNotClobberFresherTasks() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        try sync.cacheTasks([VTask(id: 99, title: "Stale", done: false, priority: 0, projectId: 3)])
+
+        let state = await makeAppState(sync: sync, connected: true)
+        serveFullSync()
+        await state.refreshAll()
+
+        XCTAssertEqual(state.tasks.map(\.title), ["Cached task"])
+        // The refresh reconciled the cache too, so the stale row is gone.
+        XCTAssertEqual(try sync.loadCachedTasks().map(\.id), [1])
+    }
+
+    // MARK: - Cache reconciliation
+
+    func testCacheTasksRemovesRowsTheServerNoLongerReturns() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+
+        try sync.cacheTasks([
+            VTask(id: 1, title: "Keep", done: false, priority: 0, projectId: 1),
+            VTask(id: 2, title: "Drop", done: false, priority: 0, projectId: 1),
+        ])
+        XCTAssertEqual(try sync.loadCachedTasks().count, 2)
+
+        try sync.cacheTasks([VTask(id: 1, title: "Keep (renamed)", done: true, priority: 0, projectId: 1)])
+        let cached = try sync.loadCachedTasks()
+        XCTAssertEqual(cached.map(\.id), [1])
+        XCTAssertEqual(cached.first?.title, "Keep (renamed)")
+        XCTAssertEqual(cached.first?.done, true)
+    }
+
+    func testCacheLabelsReplacesTheWholeSet() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+
+        try sync.cacheLabels([VLabel(id: 1, title: "One"), VLabel(id: 2, title: "Two")])
+        XCTAssertEqual(try sync.loadCachedLabels().count, 2)
+
+        try sync.cacheLabels([VLabel(id: 2, title: "Two")])
+        XCTAssertEqual(try sync.loadCachedLabels().map(\.id), [2])
+    }
+
+    // MARK: - Logout
+
+    /// A deliberate logout must not leave one account's tasks readable by the
+    /// next person to sign in.
+    func testLogoutClearsTheCache() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        try sync.cacheTasks([VTask(id: 1, title: "Private", done: false, priority: 0, projectId: 1)])
+        try sync.cacheProjects([Project(id: 1, title: "Private project")])
+        try sync.cacheLabels([VLabel(id: 1, title: "Private label")])
+
+        let state = await makeAppState(sync: sync, connected: true)
+        await state.logout()
+
+        XCTAssertTrue(try sync.loadCachedTasks().isEmpty)
+        XCTAssertTrue(try sync.loadCachedProjects().isEmpty)
+        XCTAssertTrue(try sync.loadCachedLabels().isEmpty)
+    }
+
+    /// An expired session is the same account re-authenticating, so the cache
+    /// stays put and the user keeps reading their tasks in the meantime.
+    func testExpiredSessionKeepsTheCache() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        try sync.cacheTasks([VTask(id: 1, title: "Keep me", done: false, priority: 0, projectId: 1)])
+
+        let state = await makeAppState(sync: sync, connected: true)
+        await state.expireSession()
+
+        XCTAssertEqual(try sync.loadCachedTasks().map(\.title), ["Keep me"])
+    }
+}


### PR DESCRIPTION
## Summary

mDone advertised offline caching, but the cache was never written to or read from. This makes it work.

## Related Issues

Fixes #144

## The bug

mDone advertised offline caching, but the cache was inert in both directions.

Reproduced on an iPhone 17 simulator against a dev Vikunja: launch online and let everything sync, make the server unreachable, relaunch. The app showed a full screen blocking "Loading..." overlay with no content, then a misleading "All done! No pending tasks" empty state once the retries gave up.

Dumping the SwiftData store after a completely successful online sync showed why:

```
ZCACHEDTASK: 0
ZCACHEDPROJECT: 0
ZCACHEDLABEL: 0
```

- `SyncService.syncTasks()` / `syncProjects()`, the only code that fills the cache from a full fetch, had no callers. `AppState.refreshAll()` wrote straight to memory and never touched SwiftData, so only tasks the user individually edited were persisted, and labels never were.
- `SyncService.loadCachedTasks()` / `loadCachedProjects()` had no callers either, so nothing read the cache back.
- With nothing cached, `refreshAll()` always ran with an empty task list, which is exactly the condition `TaskListScreen`'s blocking `LoadingOverlay` keys on. Offline it stayed up for the whole retry backoff, and longer on a network that drops packets rather than refusing the connection, where each of the four attempts burned the full 60s `URLSession` timeout.
- The offline banner only keyed on `NetworkMonitor.isConnected`, so an unreachable server on working Wi-Fi gave the user no indication at all.

## The fix

- **Write the cache.** New `SyncService.cacheTasks/cacheProjects/cacheLabels` take an already-fetched list and reconcile it (update in place, insert new, delete rows the server dropped), so `refreshAll()` persists exactly what it just put on screen without a second round trip. `syncTasks()`/`syncProjects()` are now expressed in terms of them.
- **Read the cache.** `AppState.hydrateFromCache()` fills the lists on the first refresh, before any network call. It only fills lists that are still empty, so it can never clobber fresher server data.
- **Skip the network when offline.** `refreshAll()` returns after hydrating rather than firing requests it can only lose. This is what stops the loading overlay sitting over an empty screen.
- **No race on startup.** The sync service is wired in `mDoneApp.init()` instead of `.onAppear`, which raced the child views' `.task` blocks: whichever refresh ran first found no sync service and so no cache.
- **Honest error mapping.** `performRequest` now maps every connectivity `URLError` through `NetworkError.from(_:)`, not just `.notConnectedToInternet`. An unreachable server used to surface as `.unknown`, which hid it from connectivity checks and gave the user a generic banner. Verified: the log now reads `NetworkError: serverUnreachable` where it previously read `unknown(...)`.
- **Honest UI.** The offline banner and a new "No cached tasks" empty state show whenever the last refresh failed for connectivity reasons, not only when the device has no link. The banner text is now "You're offline. Showing your last synced tasks."
- **Request timeout.** 20s per request instead of `URLSession`'s 60s default, so a blackholed route cannot hold the UI for minutes across four attempts.
- **Cache lifecycle.** Cleared on an explicit logout so one account's tasks cannot surface under the next; kept on session expiry, which is the same account re-authenticating.

## Testing

**Unit tests**: new `mDoneTests/OfflineCacheTests.swift`, 11 tests. Confirmed they catch the bug: with the hydration and persistence neutralized, 6 of the 11 fail. Full suite is green at 513 tests, and both the iOS and macOS targets build.

**End to end on the simulator**, same steps as the repro:

| | Before | After |
|---|---|---|
| Cache after an online sync | 0 tasks, 0 projects, 0 labels | 8 tasks, 5 projects, 3 labels |
| Offline launch | blocking spinner, then "All done!" | cached tasks visible immediately, no spinner |
| Offline indication | none | "You're offline. Showing your last synced tasks." |
| Recovery | n/a | banner clears and the list refreshes once the server is back |

Also confirmed cached task detail (description, dates, priority) is readable offline, the Projects tab renders cached projects with their task counts, and the cache survives a session expiry.

## Checklist

- [x] Builds on iOS and macOS
- [x] Tests pass (513 unit tests)
- [x] Ran `swiftlint lint --quiet` and `swiftformat .` (SwiftFormat reformats many files unrelated to this change, since the repo is not currently format-clean; only the changed files are included here)
- [x] No breaking changes

## Not included

Editing offline still fails rather than queueing. `SyncService.queueOperation` and `processPendingOperations` exist but have no callers, so the pending-operation queue is always empty on reconnect. Wiring that up touches every mutation path in `AppState` and needs a story for offline creates, which have no server id to replay against, so it is worth its own change: filed as #146. The issue's primary complaint, the spinner and the missing cached data, is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
