### PR TITLE
fix: stop partial task updates wiping description, priority and progress (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- Completing a task no longer wipes its description, priority and progress. Vikunja replaces a task wholesale on every update, so ticking a task off, postponing it, rescheduling it or dragging its progress bar silently cleared the fields the app did not resend. Those fields are now carried through on every task update (#147).
 - Offline mode now actually works. Opening the app without a reachable server used to sit on a loading spinner and then show an empty list claiming "All done!", because your tasks were never being saved to the offline cache and the cache was never read back. Your tasks, projects and labels are now saved on every successful sync and appear instantly on launch, before any network call, so the app is usable offline (#144).
 - When the device is offline the app no longer fires requests it can only lose, so there is no wait before your cached tasks appear (#144).
 - A server that cannot be reached now shows "You're offline. Showing your last synced tasks." and a clear "can't reach the server" message, instead of a generic error and a misleading empty list. This covers the case where Wi-Fi is working but your Vikunja is not reachable, for example over a VPN that is down (#144).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
-- Completing a task no longer wipes its description, priority and progress. Vikunja replaces a task wholesale on every update, so ticking a task off, postponing it, rescheduling it or dragging its progress bar silently cleared the fields the app did not resend. Those fields are now carried through on every task update (#147).
+- Completing a task no longer wipes its description, priority, progress, color or favorite status. Vikunja replaces a task wholesale on every update, so ticking a task off, postponing it, rescheduling it or dragging its progress bar silently cleared the fields the app did not resend. Those fields are now carried through on every task update (#147).
 - Offline mode now actually works. Opening the app without a reachable server used to sit on a loading spinner and then show an empty list claiming "All done!", because your tasks were never being saved to the offline cache and the cache was never read back. Your tasks, projects and labels are now saved on every successful sync and appear instantly on launch, before any network call, so the app is usable offline (#144).
 - When the device is offline the app no longer fires requests it can only lose, so there is no wait before your cached tasks appear (#144).
 - A server that cannot be reached now shows "You're offline. Showing your last synced tasks." and a clear "can't reach the server" message, instead of a generic error and a misleading empty list. This covers the case where Wi-Fi is working but your Vikunja is not reachable, for example over a VPN that is down (#144).

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -777,7 +777,7 @@ final class AppState {
         // One request drives both the network call and the response merge, so
         // the merge can never disagree with what was actually sent.
         let current = taskSnapshot(id: task.id) ?? task
-        let request = TaskUpdateRequest(done: !current.done).preservingSchedule(from: current)
+        let request = TaskUpdateRequest(done: !current.done).preservingExistingValues(from: current)
         do {
             let response = try await taskService.updateTask(id: task.id, request: request)
             let existing = taskSnapshot(id: response.id) ?? current
@@ -825,7 +825,7 @@ final class AppState {
         defer { releaseTaskUpdateSlot(id: target.id) }
         let current = taskSnapshot(id: target.id) ?? target
         do {
-            let request = TaskUpdateRequest(done: false).preservingSchedule(from: current)
+            let request = TaskUpdateRequest(done: false).preservingExistingValues(from: current)
             _ = try await taskService.updateTask(id: target.id, request: request)
             // Restore from the freshest local snapshot rather than the update
             // response because Vikunja can omit fields such as the due date.
@@ -901,7 +901,7 @@ final class AppState {
         let current = taskSnapshot(id: task.id) ?? task
         let baseDate = current.effectiveDueDate ?? Date()
         let newDate = Calendar.current.date(byAdding: .hour, value: hours, to: baseDate) ?? baseDate
-        let request = TaskUpdateRequest(dueDate: newDate).preservingSchedule(from: current)
+        let request = TaskUpdateRequest(dueDate: newDate).preservingExistingValues(from: current)
 
         let originalDueDate: Date?
         if let index = tasks.firstIndex(where: { $0.id == task.id }) {
@@ -940,7 +940,7 @@ final class AppState {
         defer { releaseTaskUpdateSlot(id: task.id) }
 
         let current = taskSnapshot(id: task.id) ?? task
-        let request = TaskUpdateRequest(dueDate: newDate).preservingSchedule(from: current)
+        let request = TaskUpdateRequest(dueDate: newDate).preservingExistingValues(from: current)
         let originalDueDate: Date?
         if let index = tasks.firstIndex(where: { $0.id == task.id }) {
             originalDueDate = tasks[index].dueDate
@@ -976,7 +976,7 @@ final class AppState {
         defer { releaseTaskUpdateSlot(id: id) }
 
         let existing = taskSnapshot(id: id)
-        let safeRequest = existing.map { request.preservingSchedule(from: $0) } ?? request
+        let safeRequest = existing.map { request.preservingExistingValues(from: $0) } ?? request
         do {
             let response = try await taskService.updateTask(id: id, request: safeRequest)
             // Preserve relations from the latest local snapshot when Vikunja
@@ -1187,7 +1187,7 @@ final class AppState {
 
         let current = taskSnapshot(id: task.id) ?? task
         let clamped = min(max(percent, 0), 1)
-        let request = TaskUpdateRequest(percentDone: clamped).preservingSchedule(from: current)
+        let request = TaskUpdateRequest(percentDone: clamped).preservingExistingValues(from: current)
         let original = current.percentDone
         if let index = tasks.firstIndex(where: { $0.id == task.id }) {
             tasks[index].percentDone = clamped

--- a/mDone/Models/VTask.swift
+++ b/mDone/Models/VTask.swift
@@ -299,6 +299,12 @@ struct TaskUpdateRequest: Encodable {
     var reminders: [TaskReminder]?
     /// Completion progress, 0...1. Drives the Current section's progress bar.
     var percentDone: Double?
+    /// The app never sets a color itself; this exists so partial updates can
+    /// carry a color assigned in another client through Vikunja's full replace.
+    var hexColor: String?
+    /// Same as `hexColor`: carried so completing a task in mDone doesn't drop
+    /// it from favorites lists in other clients.
+    var isFavorite: Bool?
     var clearDueDate: Bool?
     var clearStartDate: Bool?
     var clearEndDate: Bool?
@@ -309,7 +315,7 @@ struct TaskUpdateRequest: Encodable {
 
     private enum CodingKeys: String, CodingKey {
         case title, description, done, dueDate, startDate, endDate, priority, projectId, labels
-        case repeatAfter, repeatMode, reminders, percentDone
+        case repeatAfter, repeatMode, reminders, percentDone, hexColor, isFavorite
     }
 
     func encode(to encoder: Encoder) throws {
@@ -339,6 +345,8 @@ struct TaskUpdateRequest: Encodable {
         try container.encodeIfPresent(repeatMode, forKey: .repeatMode)
         try container.encodeIfPresent(reminders, forKey: .reminders)
         try container.encodeIfPresent(percentDone, forKey: .percentDone)
+        try container.encodeIfPresent(hexColor, forKey: .hexColor)
+        try container.encodeIfPresent(isFavorite, forKey: .isFavorite)
     }
 
     /// Carries every field this request doesn't set forward from `task`.
@@ -349,11 +357,14 @@ struct TaskUpdateRequest: Encodable {
     ///
     /// This used to cover the schedule fields only, so completing, postponing
     /// or re-progressing a task silently destroyed that task's description,
-    /// priority and progress on the server (issue #147).
+    /// priority, progress, color and favorite flag on the server (issue #147).
     ///
     /// `title`, `labels` and `projectId` are deliberately **not** carried: the
     /// server keeps those when they're omitted, so leaving them out avoids
     /// overwriting a change made elsewhere with our local snapshot.
+    ///
+    /// Callers that mean "clear the description" must send an explicit empty
+    /// string; a nil description here means "keep what the task has".
     func preservingExistingValues(from task: VTask) -> TaskUpdateRequest {
         var request = self
         if request.description == nil {
@@ -364,6 +375,12 @@ struct TaskUpdateRequest: Encodable {
         }
         if request.percentDone == nil {
             request.percentDone = task.percentDone
+        }
+        if request.hexColor == nil {
+            request.hexColor = task.hexColor
+        }
+        if request.isFavorite == nil {
+            request.isFavorite = task.isFavorite
         }
         if request.dueDate == nil, request.clearDueDate != true {
             request.dueDate = task.effectiveDueDate

--- a/mDone/Models/VTask.swift
+++ b/mDone/Models/VTask.swift
@@ -341,10 +341,30 @@ struct TaskUpdateRequest: Encodable {
         try container.encodeIfPresent(percentDone, forKey: .percentDone)
     }
 
-    /// Carries schedule fields forward for Vikunja task updates, which can
-    /// otherwise clear omitted values on partial mutations such as Done or Progress.
-    func preservingSchedule(from task: VTask) -> TaskUpdateRequest {
+    /// Carries every field this request doesn't set forward from `task`.
+    ///
+    /// Vikunja's `POST /tasks/{id}` is a **full replace**: any field missing
+    /// from the body is reset to its zero value. A partial request such as
+    /// "just mark it done" therefore wipes whatever it doesn't mention.
+    ///
+    /// This used to cover the schedule fields only, so completing, postponing
+    /// or re-progressing a task silently destroyed that task's description,
+    /// priority and progress on the server (issue #147).
+    ///
+    /// `title`, `labels` and `projectId` are deliberately **not** carried: the
+    /// server keeps those when they're omitted, so leaving them out avoids
+    /// overwriting a change made elsewhere with our local snapshot.
+    func preservingExistingValues(from task: VTask) -> TaskUpdateRequest {
         var request = self
+        if request.description == nil {
+            request.description = task.description
+        }
+        if request.priority == nil {
+            request.priority = task.priority
+        }
+        if request.percentDone == nil {
+            request.percentDone = task.percentDone
+        }
         if request.dueDate == nil, request.clearDueDate != true {
             request.dueDate = task.effectiveDueDate
         }

--- a/mDone/Views/Mac/MacTaskDetailView.swift
+++ b/mDone/Views/Mac/MacTaskDetailView.swift
@@ -247,7 +247,9 @@ struct MacTaskDetailView: View {
 
     private func saveTask() {
         let body = descriptionText.isEmpty ? nil : descriptionText
-        let composedDescription = EstimateMarker.apply(estimateSeconds, to: body)
+        // Empty string, not nil: preservingExistingValues treats nil as "keep
+        // the old text", so a cleared description must be sent explicitly.
+        let composedDescription = EstimateMarker.apply(estimateSeconds, to: body) ?? ""
         let request = TaskUpdateRequest(
             title: title,
             description: composedDescription,

--- a/mDone/Views/Tasks/TaskDetailSheet.swift
+++ b/mDone/Views/Tasks/TaskDetailSheet.swift
@@ -245,7 +245,9 @@ struct TaskDetailSheet: View {
         // round-trips through Vikunja and is visible to any agent that reads
         // the task via the API. `apply` strips any prior marker first.
         let body = description.isEmpty ? nil : description
-        let composedDescription = EstimateMarker.apply(estimateSeconds, to: body)
+        // Empty string, not nil: preservingExistingValues treats nil as "keep
+        // the old text", so a cleared description must be sent explicitly.
+        let composedDescription = EstimateMarker.apply(estimateSeconds, to: body) ?? ""
         let request = TaskUpdateRequest(
             title: title,
             description: composedDescription,

--- a/mDoneTests/TaskServiceTests.swift
+++ b/mDoneTests/TaskServiceTests.swift
@@ -677,7 +677,7 @@ final class TaskServiceTests: XCTestCase {
             return (response, responseJSON)
         }
 
-        let request = TaskUpdateRequest(done: !originalTask.done).preservingSchedule(from: originalTask)
+        let request = TaskUpdateRequest(done: !originalTask.done).preservingExistingValues(from: originalTask)
         let toggled = try await service.updateTask(id: originalTask.id, request: request)
         XCTAssertTrue(toggled.done)
     }
@@ -703,7 +703,7 @@ final class TaskServiceTests: XCTestCase {
             return (response, responseJSON)
         }
 
-        let request = TaskUpdateRequest(done: !originalTask.done).preservingSchedule(from: originalTask)
+        let request = TaskUpdateRequest(done: !originalTask.done).preservingExistingValues(from: originalTask)
         let toggled = try await service.updateTask(id: originalTask.id, request: request)
         XCTAssertFalse(toggled.done)
     }
@@ -867,7 +867,7 @@ final class TaskServiceTests: XCTestCase {
             reminders: [reminder]
         )
 
-        let request = TaskUpdateRequest(done: true).preservingSchedule(from: task)
+        let request = TaskUpdateRequest(done: true).preservingExistingValues(from: task)
 
         XCTAssertEqual(request.dueDate, due)
         XCTAssertEqual(request.startDate, start)

--- a/mDoneTests/TaskUpdateRequestMergeTests.swift
+++ b/mDoneTests/TaskUpdateRequestMergeTests.swift
@@ -23,7 +23,9 @@ final class TaskUpdateRequestMergeTests: XCTestCase {
             dueDate: Date(timeIntervalSince1970: 1_800_000_000),
             priority: 5,
             projectId: 3,
-            percentDone: 0.75
+            hexColor: "e8283c",
+            percentDone: 0.75,
+            isFavorite: true
         )
     }
 
@@ -67,6 +69,18 @@ final class TaskUpdateRequestMergeTests: XCTestCase {
         XCTAssertEqual(body["priority"] as? Int, 5)
     }
 
+    /// The color and favorite flag are set from other Vikunja clients, but the
+    /// server wipes them on partial updates just like the fields above, so every
+    /// update must carry them too (verified against Vikunja v2.4.0: a bare
+    /// `{done: true}` resets `hex_color` to "" and `is_favorite` to false).
+    func testCompletingATaskCarriesColorAndFavorite() throws {
+        let task = richTask()
+        let body = try encodedBody(TaskUpdateRequest(done: true).preservingExistingValues(from: task))
+
+        XCTAssertEqual(body["hex_color"] as? String, "e8283c")
+        XCTAssertEqual(body["is_favorite"] as? Bool, true)
+    }
+
     // MARK: - The caller's own values still win
 
     func testExplicitValuesAreNotOverwrittenByTheSnapshot() throws {
@@ -80,6 +94,17 @@ final class TaskUpdateRequestMergeTests: XCTestCase {
         XCTAssertEqual(body["description"] as? String, "Rewritten")
         XCTAssertEqual(body["priority"] as? Int, 1)
         XCTAssertEqual(body["percent_done"] as? Double, 0.1)
+    }
+
+    func testExplicitColorAndFavoriteAreNotOverwrittenByTheSnapshot() throws {
+        let task = richTask()
+        var request = TaskUpdateRequest(done: true)
+        request.hexColor = "00ff00"
+        request.isFavorite = false
+        let body = try encodedBody(request.preservingExistingValues(from: task))
+
+        XCTAssertEqual(body["hex_color"] as? String, "00ff00")
+        XCTAssertEqual(body["is_favorite"] as? Bool, false)
     }
 
     /// Clearing a description to empty is a real edit, not "unset", so it must
@@ -159,5 +184,35 @@ final class TaskUpdateRequestMergeTests: XCTestCase {
         XCTAssertEqual(body["priority"] as? Int, 0)
         XCTAssertNil(body["description"])
         XCTAssertNil(body["percent_done"])
+        XCTAssertNil(body["hex_color"])
+        XCTAssertNil(body["is_favorite"])
+    }
+
+    // MARK: - What the task editors send
+
+    /// The edit sheets compose their description through `EstimateMarker.apply`
+    /// and must fall back to "" (an explicit clear), never nil: under
+    /// `preservingExistingValues` a nil description means "keep the old text",
+    /// which would silently undo the user deleting a description.
+    func testEditorStyleClearedDescriptionReachesTheWire() throws {
+        let task = richTask()
+        var request = TaskUpdateRequest(done: false)
+        // What TaskDetailSheet/MacTaskDetailView build for an emptied editor
+        // with no estimate set.
+        request.description = EstimateMarker.apply(nil, to: nil) ?? ""
+        let body = try encodedBody(request.preservingExistingValues(from: task))
+
+        XCTAssertEqual(body["description"] as? String, "")
+    }
+
+    /// The converse pin: removing the body but keeping an estimate must still
+    /// send the marker-only description, not resurrect the old body.
+    func testEditorStyleMarkerOnlyDescriptionReachesTheWire() throws {
+        let task = richTask()
+        var request = TaskUpdateRequest(done: false)
+        request.description = EstimateMarker.apply(1500, to: nil) ?? ""
+        let body = try encodedBody(request.preservingExistingValues(from: task))
+
+        XCTAssertEqual(body["description"] as? String, "<!-- mdone:estimate=1500 -->")
     }
 }

--- a/mDoneTests/TaskUpdateRequestMergeTests.swift
+++ b/mDoneTests/TaskUpdateRequestMergeTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import mDone
+
+/// Issue #147: Vikunja's `POST /tasks/{id}` is a full replace, so any field left
+/// out of the body is reset to its zero value. These tests assert on the encoded
+/// wire body rather than the struct, because it's the omission that causes the
+/// data loss, not the property being nil.
+final class TaskUpdateRequestMergeTests: XCTestCase {
+    private func encodedBody(_ request: TaskUpdateRequest) throws -> [String: Any] {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(request)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func richTask() -> VTask {
+        VTask(
+            id: 1,
+            title: "Write quarterly report",
+            description: "Focus on Q1 wins",
+            done: false,
+            dueDate: Date(timeIntervalSince1970: 1_800_000_000),
+            priority: 5,
+            projectId: 3,
+            percentDone: 0.75
+        )
+    }
+
+    // MARK: - The reported bug
+
+    /// Ticking a task off sent `{done: true}` plus the schedule fields, which
+    /// wiped the task's description, priority and progress server-side.
+    func testCompletingATaskCarriesDescriptionPriorityAndProgress() throws {
+        let task = richTask()
+        let request = TaskUpdateRequest(done: true).preservingExistingValues(from: task)
+        let body = try encodedBody(request)
+
+        XCTAssertEqual(body["done"] as? Bool, true)
+        XCTAssertEqual(body["description"] as? String, "Focus on Q1 wins")
+        XCTAssertEqual(body["priority"] as? Int, 5)
+        XCTAssertEqual(body["percent_done"] as? Double, 0.75)
+    }
+
+    func testReschedulingCarriesDescriptionPriorityAndProgress() throws {
+        let task = richTask()
+        let newDate = Date(timeIntervalSince1970: 1_900_000_000)
+        let request = TaskUpdateRequest(dueDate: newDate).preservingExistingValues(from: task)
+        let body = try encodedBody(request)
+
+        XCTAssertNotNil(body["due_date"])
+        XCTAssertEqual(body["description"] as? String, "Focus on Q1 wins")
+        XCTAssertEqual(body["priority"] as? Int, 5)
+        XCTAssertEqual(body["percent_done"] as? Double, 0.75)
+    }
+
+    /// `setProgress` was the sharpest case: it sets the progress of a task whose
+    /// progress bar is the point of the Current section, and wiped that task's
+    /// priority and description doing it.
+    func testSettingProgressCarriesDescriptionAndPriority() throws {
+        let task = richTask()
+        let request = TaskUpdateRequest(percentDone: 0.25).preservingExistingValues(from: task)
+        let body = try encodedBody(request)
+
+        XCTAssertEqual(body["percent_done"] as? Double, 0.25)
+        XCTAssertEqual(body["description"] as? String, "Focus on Q1 wins")
+        XCTAssertEqual(body["priority"] as? Int, 5)
+    }
+
+    // MARK: - The caller's own values still win
+
+    func testExplicitValuesAreNotOverwrittenByTheSnapshot() throws {
+        let task = richTask()
+        var request = TaskUpdateRequest(done: true)
+        request.description = "Rewritten"
+        request.priority = 1
+        request.percentDone = 0.1
+        let body = try encodedBody(request.preservingExistingValues(from: task))
+
+        XCTAssertEqual(body["description"] as? String, "Rewritten")
+        XCTAssertEqual(body["priority"] as? Int, 1)
+        XCTAssertEqual(body["percent_done"] as? Double, 0.1)
+    }
+
+    /// Clearing a description to empty is a real edit, not "unset", so it must
+    /// not be replaced by the old text.
+    func testClearingDescriptionToEmptyIsPreserved() throws {
+        let task = richTask()
+        var request = TaskUpdateRequest(done: false)
+        request.description = ""
+        let body = try encodedBody(request.preservingExistingValues(from: task))
+
+        XCTAssertEqual(body["description"] as? String, "")
+    }
+
+    /// Priority zero means "none" and is a legitimate value to send.
+    func testExplicitZeroPriorityIsPreserved() throws {
+        let task = richTask()
+        var request = TaskUpdateRequest(done: false)
+        request.priority = 0
+        let body = try encodedBody(request.preservingExistingValues(from: task))
+
+        XCTAssertEqual(body["priority"] as? Int, 0)
+    }
+
+    // MARK: - Fields the server keeps on its own
+
+    /// The server preserves these when they're omitted, so we deliberately don't
+    /// send our local snapshot back and risk clobbering an edit made elsewhere.
+    func testTitleProjectAndLabelsAreNotCarried() throws {
+        let task = richTask()
+        let body = try encodedBody(TaskUpdateRequest(done: true).preservingExistingValues(from: task))
+
+        XCTAssertNil(body["title"])
+        XCTAssertNil(body["project_id"])
+        XCTAssertNil(body["labels"])
+    }
+
+    // MARK: - Existing schedule behaviour still holds
+
+    func testScheduleFieldsAreStillCarried() throws {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let end = Date(timeIntervalSince1970: 1_800_086_400)
+        let task = VTask(
+            id: 1,
+            title: "Ranged",
+            done: false,
+            dueDate: end,
+            startDate: start,
+            endDate: end,
+            priority: 2,
+            projectId: 1
+        )
+        let body = try encodedBody(TaskUpdateRequest(done: true).preservingExistingValues(from: task))
+
+        XCTAssertNotNil(body["due_date"])
+        XCTAssertNotNil(body["start_date"])
+        XCTAssertNotNil(body["end_date"])
+    }
+
+    func testClearFlagsStillWinOverCarriedValues() throws {
+        let task = richTask()
+        var request = TaskUpdateRequest(done: true)
+        request.clearDueDate = true
+        let body = try encodedBody(request.preservingExistingValues(from: task))
+
+        // Vikunja's zero-date sentinel, i.e. explicitly cleared rather than kept.
+        XCTAssertEqual(body["due_date"] as? String, "0001-01-01T00:00:00Z")
+    }
+
+    // MARK: - Tasks with nothing to carry
+
+    /// A bare task has no description or progress to preserve; carrying "nothing"
+    /// must not invent values or crash.
+    func testMinimalTaskCarriesOnlyWhatItHas() throws {
+        let task = VTask(id: 1, title: "Bare", done: false, priority: 0, projectId: 1)
+        let body = try encodedBody(TaskUpdateRequest(done: true).preservingExistingValues(from: task))
+
+        XCTAssertEqual(body["priority"] as? Int, 0)
+        XCTAssertNil(body["description"])
+        XCTAssertNil(body["percent_done"])
+    }
+}


### PR DESCRIPTION
## Summary

Ticking a task off in mDone silently destroyed its description, priority and progress on the server. Same for postponing, rescheduling and changing progress. This is in the shipped 1.12.0, so it is data loss users have already suffered.

Found while designing the replay merge for #146, which is why this is a separate, small PR: it should be able to ship as a patch release without waiting for the offline work.

## Related Issues

Fixes #147

## Cause

Vikunja's `POST /api/v1/tasks/{id}` is a **full replace**: any field missing from the body is reset to its zero value. Confirmed directly against v2.5.0:

```
POST /api/v1/tasks/9  {"done":true}
-> priority 4->0, percent_done 0.5->0, description "keep me"->"", due_date -> 0001-01-01
```

`TaskUpdateRequest.encode` uses `encodeIfPresent`, so every nil property is omitted, and the old `preservingSchedule(from:)` carried forward only `dueDate`, `startDate`, `endDate`, `repeatAfter`, `repeatMode` and `reminders`. `description`, `priority` and `percentDone` were carried by nothing.

This is the same class of bug that `preservingSchedule` was added to fix for dates during the #17 / #136 work. The remaining scalar fields were simply never covered.

## Fix

Renamed the helper to `preservingExistingValues(from:)`, since it is no longer only about the schedule, and it now also carries `description`, `priority` and `percentDone`.

`title`, `labels` and `projectId` are deliberately **not** carried. I probed each field individually and the server keeps those when they are omitted, so leaving them out is strictly safer: sending our local snapshot back could overwrite a change made elsewhere while we were looking at a stale copy.

| Field | Survived a partial update before this PR? |
|---|---|
| `title`, `labels`, `project_id` | yes, server keeps them |
| dates, repeat, reminders | yes, already carried |
| **`description`, `priority`, `percent_done`** | **no, wiped** |

## Testing

**New tests**: `mDoneTests/TaskUpdateRequestMergeTests.swift`, 10 tests. They assert on the **encoded JSON body**, not the struct, because the data loss comes from the key being absent from the request rather than the property being nil. Confirmed they catch the bug: with the three carry-forward lines removed, 4 of the 10 fail. They also pin the deliberate omissions and the existing behaviour, so `clearDueDate` still beats a carried value, an explicit `description = ""` is still an edit rather than "unset", and an explicit `priority = 0` is still sent.

Full suite green at 523 tests; iOS and macOS both build.

**End to end in the simulator** against a local Vikunja, tapping a real checkbox in the app:

| | Before | After |
|---|---|---|
| priority | 5 -> **0** | 5 -> 5 |
| percent done | 0.75 -> **0** | 0.75 -> 0.75 |
| description | "do not lose me" -> **""** | preserved |
| done | false -> true | false -> true |

## Checklist

- [x] Builds on iOS and macOS
- [x] Tests pass (523 unit tests)
- [x] Ran `swiftlint lint --quiet` and `swiftformat .` (SwiftFormat reformats many unrelated files since the repo is not format-clean; only the changed files are included here)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review follow-up (second commit)

A deep review probed every remaining `VTask` field against a live Vikunja (v2.4.0) with a bare `POST {"done": true}` and found two gaps, both fixed in the follow-up commit:

| Field | Partial update result |
|---|---|
| **`hex_color`** | **wiped to ""** (a color set in the web UI vanished on tick-off) |
| **`is_favorite`** | **wiped to false** (task dropped out of other clients' favorites) |
| `position`, `bucket_id`, `index`, `cover_image_attachment_id` | kept by the server |

`TaskUpdateRequest` can now encode `hexColor` and `isFavorite`, and `preservingExistingValues` carries both.

The review also caught a regression in the first commit: the edit sheets sent `description: nil` when the user deleted a description, which the merge now reads as "keep the old text", so the deletion was silently undone. (It previously "worked" only by riding the wipe bug this PR fixes.) Both editors now send an explicit `""`.

Four new tests cover the carried color/favorite, the editor clear path, and the marker-only estimate description. Full suite green at 527 tests; iOS and macOS both build.
