### PR TITLE
feat: queue task edits made offline and replay them on reconnect (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- You can now edit tasks while offline. Completing a task, rescheduling it, changing its progress, editing its details or deleting it all take effect straight away and sync when you reconnect. Rows with changes still waiting show a "Not synced" marker, and the offline banner tells you how many are queued. Previously these actions did nothing for several seconds, then failed with an error that faded away (#146).
+- Queued changes are merged rather than replayed blindly. When your change reaches the server, only the fields you actually edited are applied, so an edit made offline no longer overwrites something you or someone else changed elsewhere in the meantime (#146).
+- If a queued change can never be delivered, for example because the task was deleted elsewhere, the app now tells you which change it was and why, instead of dropping it silently (#146).
+
 ### Fixed
+- Actions that genuinely need a connection, such as creating a task or a project, now say so immediately instead of spending several seconds retrying first (#146).
 - Completing a task no longer wipes its description, priority, progress, color or favorite status. Vikunja replaces a task wholesale on every update, so ticking a task off, postponing it, rescheduling it or dragging its progress bar silently cleared the fields the app did not resend. Those fields are now carried through on every task update (#147).
 - Offline mode now actually works. Opening the app without a reachable server used to sit on a loading spinner and then show an empty list claiming "All done!", because your tasks were never being saved to the offline cache and the cache was never read back. Your tasks, projects and labels are now saved on every successful sync and appear instantly on launch, before any network call, so the app is usable offline (#144).
 - When the device is offline the app no longer fires requests it can only lose, so there is no wait before your cached tasks appear (#144).

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -203,13 +203,11 @@ final class AppState {
     @MainActor
     func onNetworkRestored() async {
         await syncService?.processPendingOperations()
-        updatePendingCount()
+        // Read the queue's leftovers before refreshing: a refresh overwrites the
+        // local tasks, and the failure messages name tasks by title.
+        collectFailedOperations()
+        refreshPendingState()
         await refreshAll()
-    }
-
-    @MainActor
-    private func updatePendingCount() {
-        pendingOperationsCount = (try? syncService?.pendingOperationCount()) ?? 0
     }
 
     var overdueTasks: [VTask] {
@@ -485,7 +483,7 @@ final class AppState {
         if labels.isEmpty, let cached = try? syncService.loadCachedLabels(), !cached.isEmpty {
             labels = cached
         }
-        updatePendingCount()
+        refreshPendingState()
     }
 
     /// Persists the freshly-fetched lists so the next launch has something to
@@ -524,6 +522,16 @@ final class AppState {
             print("[mDone] refreshAll: offline, serving \(tasks.count) cached tasks")
             #endif
             return
+        }
+
+        // Anything queued offline goes out before we read, so the state we
+        // fetch already includes it. This is also what drains the queue when the
+        // server simply became reachable again without the device's own link
+        // ever dropping, which `onNetworkRestored` would never see.
+        if pendingOperationsCount > 0, let syncService {
+            await syncService.processPendingOperations()
+            collectFailedOperations()
+            refreshPendingState()
         }
 
         isLoading = true
@@ -769,6 +777,88 @@ final class AppState {
         return result
     }
 
+    // MARK: - Offline edits (issue #146)
+
+    /// Ids of tasks with an edit still waiting to reach the server.
+    private(set) var pendingTaskIds: Set<Int64> = []
+
+    /// Changes abandoned after repeated failures, surfaced once and then cleared.
+    var failedSyncMessages: [String] = []
+
+    func hasPendingChanges(_ taskId: Int64) -> Bool {
+        pendingTaskIds.contains(taskId)
+    }
+
+    /// Applies an edit locally and queues it for replay when the device is
+    /// offline, returning the updated task. Returns nil when online, so callers
+    /// fall through to their normal network path.
+    ///
+    /// `request` must be the raw intent, i.e. only the fields the user actually
+    /// changed. The queue deliberately stores it un-expanded so replay can merge
+    /// it onto a freshly-read task instead of overwriting everything with values
+    /// that were current when the device went offline (issue #146).
+    @MainActor
+    private func queueOfflineEdit(_ request: TaskUpdateRequest, for current: VTask) -> VTask? {
+        // `isShowingCachedData` covers the other way to be offline: the link is
+        // up but the server isn't reachable (VPN down, server off the LAN). The
+        // last refresh already proved that, so queue rather than spend the retry
+        // budget rediscovering it.
+        guard isOffline || isShowingCachedData, let syncService else { return nil }
+
+        let edit = QueuedTaskEdit(from: request)
+        let updated = edit.applied(to: current)
+        if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
+            tasks[index] = updated
+        } else {
+            tasks.append(updated)
+        }
+        syncEmbeddedRelations(with: updated)
+        syncService.updateCachedTask(updated)
+        syncService.queueTaskEdit(taskId: updated.id, edit: edit)
+        refreshPendingState()
+        WidgetCenter.shared.reloadAllTimelines()
+        return updated
+    }
+
+    /// Reports an action that genuinely can't be done offline, without the
+    /// pointless 7 seconds of connection retries it used to take to find out.
+    @MainActor
+    private var isEffectivelyOffline: Bool {
+        isOffline || isShowingCachedData
+    }
+
+    @MainActor
+    private func rejectOffline(_ action: String) {
+        errorMessage = "\(action) needs a connection."
+        activeError = .networkUnavailable
+    }
+
+    @MainActor
+    func refreshPendingState() {
+        pendingTaskIds = syncService?.pendingTaskIds() ?? []
+        pendingOperationsCount = pendingTaskIds.count
+    }
+
+    /// Collects changes the queue gave up on so the user finds out rather than
+    /// assuming an edit synced.
+    @MainActor
+    private func collectFailedOperations() {
+        guard let syncService else { return }
+        let failed = syncService.failedOperations()
+        guard !failed.isEmpty else { return }
+
+        failedSyncMessages = failed.map { operation in
+            let title = operation.taskId.flatMap { id in
+                tasks.first(where: { $0.id == id })?.title
+            }
+            let reason = operation.failureReason ?? "the server rejected it"
+            return title.map { "\"\($0)\" could not be synced: \(reason)" }
+                ?? "A queued change could not be synced: \(reason)"
+        }
+        syncService.discardFailedOperations()
+        refreshPendingState()
+    }
+
     @MainActor
     func toggleTaskDone(_ task: VTask) async {
         guard await acquireTaskUpdateSlot(id: task.id) else { return }
@@ -777,7 +867,22 @@ final class AppState {
         // One request drives both the network call and the response merge, so
         // the merge can never disagree with what was actually sent.
         let current = taskSnapshot(id: task.id) ?? task
-        let request = TaskUpdateRequest(done: !current.done).preservingExistingValues(from: current)
+        let intent = TaskUpdateRequest(done: !current.done)
+
+        if let updated = queueOfflineEdit(intent, for: current) {
+            if updated.done {
+                recordCompletionForUndo(current)
+                onTaskCompleted?(updated.id)
+            } else {
+                clearUndoIfMatches(id: updated.id)
+            }
+            #if os(iOS)
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            #endif
+            return
+        }
+
+        let request = intent.preservingExistingValues(from: current)
         do {
             let response = try await taskService.updateTask(id: task.id, request: request)
             let existing = taskSnapshot(id: response.id) ?? current
@@ -824,8 +929,17 @@ final class AppState {
         }
         defer { releaseTaskUpdateSlot(id: target.id) }
         let current = taskSnapshot(id: target.id) ?? target
+        let intent = TaskUpdateRequest(done: false)
+
+        if queueOfflineEdit(intent, for: current) != nil {
+            #if os(iOS)
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            #endif
+            return
+        }
+
         do {
-            let request = TaskUpdateRequest(done: false).preservingExistingValues(from: current)
+            let request = intent.preservingExistingValues(from: current)
             _ = try await taskService.updateTask(id: target.id, request: request)
             // Restore from the freshest local snapshot rather than the update
             // response because Vikunja can omit fields such as the due date.
@@ -877,6 +991,15 @@ final class AppState {
         dueDate: Date? = nil,
         priority: Int64 = 0
     ) async -> VTask? {
+        // Creating offline isn't queueable yet: a queued create has no server id,
+        // so any later edit or completion of that task would have nothing to
+        // address. Say so immediately rather than spending the retry budget
+        // discovering it (issue #146).
+        if isEffectivelyOffline {
+            rejectOffline("Creating a task")
+            return nil
+        }
+
         let request = TaskCreateRequest(title: title, description: description, dueDate: dueDate, priority: priority)
         do {
             let newTask = try await taskService.createTask(projectId: projectId, request: request)
@@ -901,7 +1024,13 @@ final class AppState {
         let current = taskSnapshot(id: task.id) ?? task
         let baseDate = current.effectiveDueDate ?? Date()
         let newDate = Calendar.current.date(byAdding: .hour, value: hours, to: baseDate) ?? baseDate
-        let request = TaskUpdateRequest(dueDate: newDate).preservingExistingValues(from: current)
+        let intent = TaskUpdateRequest(dueDate: newDate)
+
+        if queueOfflineEdit(intent, for: current) != nil {
+            return
+        }
+
+        let request = intent.preservingExistingValues(from: current)
 
         let originalDueDate: Date?
         if let index = tasks.firstIndex(where: { $0.id == task.id }) {
@@ -940,7 +1069,13 @@ final class AppState {
         defer { releaseTaskUpdateSlot(id: task.id) }
 
         let current = taskSnapshot(id: task.id) ?? task
-        let request = TaskUpdateRequest(dueDate: newDate).preservingExistingValues(from: current)
+        let intent = TaskUpdateRequest(dueDate: newDate)
+
+        if queueOfflineEdit(intent, for: current) != nil {
+            return
+        }
+
+        let request = intent.preservingExistingValues(from: current)
         let originalDueDate: Date?
         if let index = tasks.firstIndex(where: { $0.id == task.id }) {
             originalDueDate = tasks[index].dueDate
@@ -976,6 +1111,11 @@ final class AppState {
         defer { releaseTaskUpdateSlot(id: id) }
 
         let existing = taskSnapshot(id: id)
+
+        if let existing, queueOfflineEdit(request, for: existing) != nil {
+            return
+        }
+
         let safeRequest = existing.map { request.preservingExistingValues(from: $0) } ?? request
         do {
             let response = try await taskService.updateTask(id: id, request: safeRequest)
@@ -1005,6 +1145,10 @@ final class AppState {
     @MainActor
     @discardableResult
     func addSubtaskRelation(parentId: Int64, childId: Int64) async -> Bool {
+        if isEffectivelyOffline {
+            rejectOffline("Linking subtasks")
+            return false
+        }
         do {
             try await taskService.createRelation(taskId: parentId, otherTaskId: childId, kind: .subtask)
             await refreshTasksAfterRelationChange(ids: [parentId, childId])
@@ -1034,6 +1178,10 @@ final class AppState {
     /// `subtask` relation only unlinks the tasks; neither is deleted.
     @MainActor
     func removeRelation(taskId: Int64, otherTaskId: Int64, kind: RelationKind) async {
+        if isEffectivelyOffline {
+            rejectOffline("Changing task relations")
+            return
+        }
         do {
             try await taskService.deleteRelation(taskId: taskId, otherTaskId: otherTaskId, kind: kind)
             await refreshTasksAfterRelationChange(ids: [taskId, otherTaskId])
@@ -1187,7 +1335,13 @@ final class AppState {
 
         let current = taskSnapshot(id: task.id) ?? task
         let clamped = min(max(percent, 0), 1)
-        let request = TaskUpdateRequest(percentDone: clamped).preservingExistingValues(from: current)
+        let intent = TaskUpdateRequest(percentDone: clamped)
+
+        if queueOfflineEdit(intent, for: current) != nil {
+            return
+        }
+
+        let request = intent.preservingExistingValues(from: current)
         let original = current.percentDone
         if let index = tasks.firstIndex(where: { $0.id == task.id }) {
             tasks[index].percentDone = clamped
@@ -1207,8 +1361,25 @@ final class AppState {
 
     @MainActor
     func deleteTask(_ task: VTask) async {
+        let taskId = task.id
+
+        // Deleting offline is safe to queue: the id is stable, and a queued
+        // delete supersedes any edits of the same task still waiting.
+        if isEffectivelyOffline, let syncService {
+            tasks.removeAll { $0.id == taskId }
+            removeEmbeddedRelations(taskId: taskId)
+            syncService.deleteCachedTask(id: taskId)
+            syncService.queueTaskDelete(taskId: taskId)
+            refreshPendingState()
+            onTaskDeleted?(taskId)
+            #if os(iOS)
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+            #endif
+            WidgetCenter.shared.reloadAllTimelines()
+            return
+        }
+
         do {
-            let taskId = task.id
             try await taskService.deleteTask(id: taskId)
             tasks.removeAll { $0.id == taskId }
             removeEmbeddedRelations(taskId: taskId)
@@ -1345,6 +1516,12 @@ final class AppState {
     ) async -> Project? {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
+        // Project mutations aren't queued yet (issue #146 covers task edits only),
+        // so fail fast instead of retrying a connection that isn't there.
+        if isEffectivelyOffline {
+            rejectOffline("Creating a project")
+            return nil
+        }
         let request = ProjectCreateRequest(
             title: trimmed,
             description: description.flatMap { $0.isEmpty ? nil : $0 },

--- a/mDone/Models/QueuedTaskEdit.swift
+++ b/mDone/Models/QueuedTaskEdit.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+/// A task edit made while offline, stored as the user's **intent** (only the
+/// fields they actually changed) rather than a ready-to-send request body.
+///
+/// Storing intent is what makes replay safe. Vikunja's task update is a full
+/// replace, so a body built offline and replayed an hour later would overwrite
+/// every field with the values the task had when the device went offline,
+/// destroying anything changed elsewhere in the meantime. On replay the intent
+/// is merged onto a freshly-read copy of the task instead (issue #146).
+///
+/// Labels are deliberately absent: they're managed through their own endpoints,
+/// not the task update, so marking a task Current offline isn't queueable here.
+struct QueuedTaskEdit: Codable, Equatable {
+    var done: Bool?
+    var title: String?
+    var taskDescription: String?
+    var priority: Int64?
+    var percentDone: Double?
+    var projectId: Int64?
+    var dueDate: Date?
+    var startDate: Date?
+    var endDate: Date?
+    var repeatAfter: Int64?
+    var repeatMode: Int64?
+    var reminders: [TaskReminder]?
+    var clearDueDate: Bool?
+    var clearStartDate: Bool?
+    var clearEndDate: Bool?
+
+    /// Captures a request the app was about to send. Only the fields the caller
+    /// set are recorded; everything nil stays nil so replay knows not to touch it.
+    init(from request: TaskUpdateRequest) {
+        done = request.done
+        title = request.title
+        taskDescription = request.description
+        priority = request.priority
+        percentDone = request.percentDone
+        projectId = request.projectId
+        dueDate = request.dueDate
+        startDate = request.startDate
+        endDate = request.endDate
+        repeatAfter = request.repeatAfter
+        repeatMode = request.repeatMode
+        reminders = request.reminders
+        clearDueDate = request.clearDueDate
+        clearStartDate = request.clearStartDate
+        clearEndDate = request.clearEndDate
+    }
+
+    /// Rebuilds the request. Still needs `preservingExistingValues(from:)`
+    /// applied against a fresh task before it goes on the wire (issue #147).
+    var request: TaskUpdateRequest {
+        var result = TaskUpdateRequest()
+        result.done = done
+        result.title = title
+        result.description = taskDescription
+        result.priority = priority
+        result.percentDone = percentDone
+        result.projectId = projectId
+        result.dueDate = dueDate
+        result.startDate = startDate
+        result.endDate = endDate
+        result.repeatAfter = repeatAfter
+        result.repeatMode = repeatMode
+        result.reminders = reminders
+        result.clearDueDate = clearDueDate
+        result.clearStartDate = clearStartDate
+        result.clearEndDate = clearEndDate
+        return result
+    }
+
+    /// Folds a later edit of the same task into this one, newer values winning
+    /// field by field. Without this, ticking a task on and off five times while
+    /// offline would replay five requests instead of settling on the final state.
+    ///
+    /// A clear flag and its date are mutually exclusive, so setting either side
+    /// in the newer edit drops the other.
+    func coalesced(with newer: QueuedTaskEdit) -> QueuedTaskEdit {
+        var result = self
+        if let value = newer.done {
+            result.done = value
+        }
+        if let value = newer.title {
+            result.title = value
+        }
+        if let value = newer.taskDescription {
+            result.taskDescription = value
+        }
+        if let value = newer.priority {
+            result.priority = value
+        }
+        if let value = newer.percentDone {
+            result.percentDone = value
+        }
+        if let value = newer.projectId {
+            result.projectId = value
+        }
+        if let value = newer.repeatAfter {
+            result.repeatAfter = value
+        }
+        if let value = newer.repeatMode {
+            result.repeatMode = value
+        }
+        if let value = newer.reminders {
+            result.reminders = value
+        }
+
+        if newer.clearDueDate == true {
+            result.clearDueDate = true
+            result.dueDate = nil
+        } else if let value = newer.dueDate {
+            result.dueDate = value
+            result.clearDueDate = nil
+        }
+
+        if newer.clearStartDate == true {
+            result.clearStartDate = true
+            result.startDate = nil
+        } else if let value = newer.startDate {
+            result.startDate = value
+            result.clearStartDate = nil
+        }
+
+        if newer.clearEndDate == true {
+            result.clearEndDate = true
+            result.endDate = nil
+        } else if let value = newer.endDate {
+            result.endDate = value
+            result.clearEndDate = nil
+        }
+
+        return result
+    }
+
+    /// Applies the edit to a local copy so the UI and cache reflect it straight
+    /// away, before the server has seen it.
+    func applied(to task: VTask) -> VTask {
+        var result = task
+        if let done {
+            result.done = done
+        }
+        if let title {
+            result.title = title
+        }
+        if let taskDescription {
+            result.description = taskDescription
+        }
+        if let priority {
+            result.priority = priority
+        }
+        if let percentDone {
+            result.percentDone = percentDone
+        }
+        if let projectId {
+            result.projectId = projectId
+        }
+        if let repeatAfter {
+            result.repeatAfter = repeatAfter
+        }
+        if let repeatMode {
+            result.repeatMode = repeatMode
+        }
+        if let reminders {
+            result.reminders = reminders
+        }
+        if clearDueDate == true {
+            result.dueDate = nil
+        } else if let dueDate {
+            result.dueDate = dueDate
+        }
+        if clearStartDate == true {
+            result.startDate = nil
+        } else if let startDate {
+            result.startDate = startDate
+        }
+        if clearEndDate == true {
+            result.endDate = nil
+        } else if let endDate {
+            result.endDate = endDate
+        }
+        return result
+    }
+}

--- a/mDone/Models/QueuedTaskEdit.swift
+++ b/mDone/Models/QueuedTaskEdit.swift
@@ -24,6 +24,12 @@ struct QueuedTaskEdit: Codable, Equatable {
     var repeatAfter: Int64?
     var repeatMode: Int64?
     var reminders: [TaskReminder]?
+    /// Captured for completeness: the app doesn't set these itself today, so an
+    /// offline edit leaves them nil and the replay merge fills them from the
+    /// fresh server copy. Recorded anyway so a future editor of colour or
+    /// favourite status doesn't silently lose it offline.
+    var hexColor: String?
+    var isFavorite: Bool?
     var clearDueDate: Bool?
     var clearStartDate: Bool?
     var clearEndDate: Bool?
@@ -43,6 +49,8 @@ struct QueuedTaskEdit: Codable, Equatable {
         repeatAfter = request.repeatAfter
         repeatMode = request.repeatMode
         reminders = request.reminders
+        hexColor = request.hexColor
+        isFavorite = request.isFavorite
         clearDueDate = request.clearDueDate
         clearStartDate = request.clearStartDate
         clearEndDate = request.clearEndDate
@@ -64,6 +72,8 @@ struct QueuedTaskEdit: Codable, Equatable {
         result.repeatAfter = repeatAfter
         result.repeatMode = repeatMode
         result.reminders = reminders
+        result.hexColor = hexColor
+        result.isFavorite = isFavorite
         result.clearDueDate = clearDueDate
         result.clearStartDate = clearStartDate
         result.clearEndDate = clearEndDate
@@ -104,6 +114,12 @@ struct QueuedTaskEdit: Codable, Equatable {
         }
         if let value = newer.reminders {
             result.reminders = value
+        }
+        if let value = newer.hexColor {
+            result.hexColor = value
+        }
+        if let value = newer.isFavorite {
+            result.isFavorite = value
         }
 
         if newer.clearDueDate == true {
@@ -163,6 +179,12 @@ struct QueuedTaskEdit: Codable, Equatable {
         }
         if let reminders {
             result.reminders = reminders
+        }
+        if let hexColor {
+            result.hexColor = hexColor
+        }
+        if let isFavorite {
+            result.isFavorite = isFavorite
         }
         if clearDueDate == true {
             result.dueDate = nil

--- a/mDone/Services/CacheService.swift
+++ b/mDone/Services/CacheService.swift
@@ -229,11 +229,43 @@ final class PendingOperation {
     var retryCount: Int
     var failed: Bool
 
-    init(endpointPath: String, method: String, bodyData: Data? = nil) {
+    /// How `SyncService` should replay this operation. Optional so the store
+    /// migrates without a custom plan; a nil kind means the pre-#146 behaviour
+    /// of sending `bodyData` verbatim.
+    var kind: String?
+
+    /// The task a `.taskEdit` / `.taskDelete` operation targets. Lets the queue
+    /// coalesce repeat edits of one task and drop edits superseded by a delete.
+    var taskId: Int64?
+
+    /// Why the operation was abandoned after exhausting its retries, kept so the
+    /// UI can tell the user which change didn't make it and why.
+    var failureReason: String?
+
+    enum Kind: String {
+        /// `bodyData` holds a `QueuedTaskEdit`: re-read the task, merge, then send.
+        case taskEdit
+        /// No body; delete `taskId`.
+        case taskDelete
+    }
+
+    var operationKind: Kind? {
+        kind.flatMap(Kind.init(rawValue:))
+    }
+
+    init(
+        endpointPath: String,
+        method: String,
+        bodyData: Data? = nil,
+        kind: Kind? = nil,
+        taskId: Int64? = nil
+    ) {
         id = UUID()
         self.endpointPath = endpointPath
         self.method = method
         self.bodyData = bodyData
+        self.kind = kind?.rawValue
+        self.taskId = taskId
         timestamp = Date()
         retryCount = 0
         failed = false

--- a/mDone/Services/SyncService.swift
+++ b/mDone/Services/SyncService.swift
@@ -39,6 +39,122 @@ actor SyncService {
         insertPendingOperation(endpoint: endpoint, bodyData: nil)
     }
 
+    // MARK: - Offline task edits (issue #146)
+
+    private static func editEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private static func editDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    /// Queues an edit to an existing task for replay when the connection comes
+    /// back. Repeat edits of the same task are folded into the one pending
+    /// operation, so ticking a task on and off while offline settles on its
+    /// final state rather than replaying every intermediate step.
+    @MainActor
+    func queueTaskEdit(taskId: Int64, edit: QueuedTaskEdit) {
+        let context = modelContainer.mainContext
+
+        if let existing = pendingEdit(for: taskId, in: context) {
+            let stored = existing.bodyData
+                .flatMap { try? SyncService.editDecoder().decode(QueuedTaskEdit.self, from: $0) }
+            let combined = stored?.coalesced(with: edit) ?? edit
+            existing.bodyData = try? SyncService.editEncoder().encode(combined)
+            // A coalesced edit is a fresh attempt, not a continuation of a
+            // failed one, so give it its retries back.
+            existing.retryCount = 0
+            existing.failed = false
+            existing.failureReason = nil
+            try? context.save()
+            logger.info("Coalesced offline edit for task \(taskId)")
+            return
+        }
+
+        let operation = PendingOperation(
+            endpointPath: Endpoint.updateTask(id: taskId).path,
+            method: HTTPMethod.POST.rawValue,
+            bodyData: try? SyncService.editEncoder().encode(edit),
+            kind: .taskEdit,
+            taskId: taskId
+        )
+        context.insert(operation)
+        try? context.save()
+        logger.info("Queued offline edit for task \(taskId)")
+    }
+
+    /// Queues a delete. Any pending edits for the same task are dropped: editing
+    /// then deleting offline should not replay an update against a task that is
+    /// about to stop existing.
+    @MainActor
+    func queueTaskDelete(taskId: Int64) {
+        let context = modelContainer.mainContext
+
+        for operation in pendingOperations(for: taskId, in: context) {
+            context.delete(operation)
+        }
+
+        let operation = PendingOperation(
+            endpointPath: Endpoint.deleteTask(id: taskId).path,
+            method: HTTPMethod.DELETE.rawValue,
+            kind: .taskDelete,
+            taskId: taskId
+        )
+        context.insert(operation)
+        try? context.save()
+        logger.info("Queued offline delete for task \(taskId)")
+    }
+
+    @MainActor
+    private func pendingOperations(for taskId: Int64, in context: ModelContext) -> [PendingOperation] {
+        let descriptor = FetchDescriptor<PendingOperation>(
+            predicate: #Predicate { $0.taskId == taskId }
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    @MainActor
+    private func pendingEdit(for taskId: Int64, in context: ModelContext) -> PendingOperation? {
+        pendingOperations(for: taskId, in: context)
+            .first { $0.operationKind == .taskEdit }
+    }
+
+    /// Ids of tasks with changes still waiting to sync, so the UI can mark those
+    /// rows rather than leaving the user guessing which edits landed.
+    @MainActor
+    func pendingTaskIds() -> Set<Int64> {
+        let descriptor = FetchDescriptor<PendingOperation>(
+            predicate: #Predicate { !$0.failed }
+        )
+        let operations = (try? modelContainer.mainContext.fetch(descriptor)) ?? []
+        return Set(operations.compactMap(\.taskId))
+    }
+
+    /// Changes that exhausted their retries and were abandoned, for reporting.
+    @MainActor
+    func failedOperations() -> [PendingOperation] {
+        let descriptor = FetchDescriptor<PendingOperation>(
+            predicate: #Predicate { $0.failed },
+            sortBy: [SortDescriptor(\.timestamp, order: .forward)]
+        )
+        return (try? modelContainer.mainContext.fetch(descriptor)) ?? []
+    }
+
+    /// Clears abandoned operations once the user has been told about them.
+    @MainActor
+    func discardFailedOperations() {
+        let context = modelContainer.mainContext
+        for operation in failedOperations() {
+            context.delete(operation)
+        }
+        try? context.save()
+    }
+
     @MainActor
     private func insertPendingOperation(endpoint: Endpoint, bodyData: Data?) {
         let context = modelContainer.mainContext
@@ -71,20 +187,40 @@ actor SyncService {
 
         for operation in operations {
             do {
-                let endpoint = Endpoint(
-                    path: operation.endpointPath,
-                    method: HTTPMethod(rawValue: operation.method) ?? .GET
-                )
-
-                if endpoint.method == .DELETE {
-                    try await apiClient.delete(endpoint)
-                } else {
-                    try await apiClient.sendRawData(endpoint, bodyData: operation.bodyData)
+                switch operation.operationKind {
+                case .taskEdit:
+                    try await replayTaskEdit(operation)
+                case .taskDelete, .none:
+                    let endpoint = Endpoint(
+                        path: operation.endpointPath,
+                        method: HTTPMethod(rawValue: operation.method) ?? .GET
+                    )
+                    if endpoint.method == .DELETE {
+                        try await apiClient.delete(endpoint)
+                    } else {
+                        try await apiClient.sendRawData(endpoint, bodyData: operation.bodyData)
+                    }
                 }
 
                 context.delete(operation)
                 try? context.save()
                 logger.info("Successfully processed: \(operation.method) \(operation.endpointPath)")
+            } catch NetworkError.unauthorized {
+                // Not this operation's fault, and every remaining one will hit
+                // the same wall. Leave the queue untouched, without spending a
+                // retry, so the changes still go out after the user signs back
+                // in rather than being discarded for an expired session.
+                logger.error("Sync paused: session expired with \(operations.count) operations still queued")
+                return
+            } catch let error as NetworkError where Self.isPermanentFailure(error) {
+                // Retrying a 404 or a 400 will never succeed: the task was
+                // deleted elsewhere, or the server rejected the payload. Abandon
+                // it now rather than burning three attempts to reach the same
+                // conclusion, and record why so the user can be told.
+                operation.failed = true
+                operation.failureReason = error.errorDescription
+                logger.error("Abandoning \(operation.endpointPath): \(error.localizedDescription)")
+                try? context.save()
             } catch {
                 operation.retryCount += 1
                 logger
@@ -94,6 +230,7 @@ actor SyncService {
 
                 if operation.retryCount >= SyncService.maxRetries {
                     operation.failed = true
+                    operation.failureReason = NetworkError.friendly(from: error).errorDescription
                     logger
                         .error(
                             "Operation marked as failed after \(SyncService.maxRetries) retries: \(operation.method) \(operation.endpointPath)"
@@ -102,6 +239,47 @@ actor SyncService {
 
                 try? context.save()
             }
+        }
+    }
+
+    /// Replays an offline edit against the task as it stands on the server *now*.
+    ///
+    /// The queued body is the user's intent, not a finished request: it holds
+    /// only the fields they changed. Reading the task first and merging onto it
+    /// means an edit made offline no longer clobbers whatever else changed while
+    /// the device was away (issue #146).
+    @MainActor
+    private func replayTaskEdit(_ operation: PendingOperation) async throws {
+        guard let taskId = operation.taskId,
+              let bodyData = operation.bodyData,
+              let edit = try? SyncService.editDecoder().decode(QueuedTaskEdit.self, from: bodyData)
+        else {
+            throw NetworkError.decodingError(
+                NSError(domain: "SyncService", code: 0, userInfo: [
+                    NSLocalizedDescriptionKey: "Queued edit could not be read back",
+                ])
+            )
+        }
+
+        let fresh = try await taskService.fetchTask(id: taskId)
+        let request = edit.request.preservingExistingValues(from: fresh)
+        _ = try await taskService.updateTask(id: taskId, request: request)
+    }
+
+    /// Failures that no amount of retrying will fix.
+    ///
+    /// 401 is deliberately excluded and handled separately: an expired session
+    /// is a property of the app, not of the queued change, and the change should
+    /// survive until the user signs back in.
+    private static func isPermanentFailure(_ error: NetworkError) -> Bool {
+        switch error {
+        case let .serverError(statusCode, _):
+            // 404: gone from the server. 4xx generally: the server won't take it.
+            (400 ... 499).contains(statusCode) && statusCode != 401
+        case .decodingError:
+            true
+        default:
+            false
         }
     }
 

--- a/mDone/Views/Mac/MacContentView.swift
+++ b/mDone/Views/Mac/MacContentView.swift
@@ -65,5 +65,22 @@ struct MacContentView: View {
         .errorBanner(Bindable(appState).activeError) {
             Task { await appState.refreshAll() }
         }
+        // Changes the sync queue gave up on must not disappear quietly: the
+        // user thinks they made that edit (issue #146).
+        .alert(
+            "Some changes could not be synced",
+            isPresented: Binding(
+                get: { !appState.failedSyncMessages.isEmpty },
+                set: {
+                    if !$0 {
+                        appState.failedSyncMessages = []
+                    }
+                }
+            )
+        ) {
+            Button("OK", role: .cancel) { appState.failedSyncMessages = [] }
+        } message: {
+            Text(appState.failedSyncMessages.joined(separator: "\n\n"))
+        }
     }
 }

--- a/mDone/Views/MainTabView.swift
+++ b/mDone/Views/MainTabView.swift
@@ -66,6 +66,23 @@ struct MainTabView: View {
         .errorBanner(Bindable(appState).activeError) {
             Task { await appState.refreshAll() }
         }
+        // Changes the sync queue gave up on must not disappear quietly: the
+        // user thinks they made that edit (issue #146).
+        .alert(
+            "Some changes could not be synced",
+            isPresented: Binding(
+                get: { !appState.failedSyncMessages.isEmpty },
+                set: {
+                    if !$0 {
+                        appState.failedSyncMessages = []
+                    }
+                }
+            )
+        ) {
+            Button("OK", role: .cancel) { appState.failedSyncMessages = [] }
+        } message: {
+            Text(appState.failedSyncMessages.joined(separator: "\n\n"))
+        }
         .onShake {
             if appState.canUndoLastCompletion {
                 showUndoCompletionPrompt = true

--- a/mDone/Views/Tasks/TaskListScreen.swift
+++ b/mDone/Views/Tasks/TaskListScreen.swift
@@ -436,11 +436,23 @@ struct TaskListScreen: View {
         HStack {
             Image(systemName: "wifi.slash")
                 .accessibilityHidden(true)
-            Text("You're offline. Showing your last synced tasks.")
+            Text(offlineBannerText)
                 .font(.caption)
         }
         .foregroundStyle(.orange)
         .listRowBackground(Color.orange.opacity(0.1))
         .accessibilityElement(children: .combine)
+    }
+
+    /// Says what's actually happening: whether the user is just reading cached
+    /// data, or has edits sitting in the queue waiting to go out.
+    private var offlineBannerText: String {
+        let pending = appState.pendingOperationsCount
+        guard pending > 0 else {
+            return "You're offline. Showing your last synced tasks."
+        }
+        return pending == 1
+            ? "You're offline. 1 change will sync when you reconnect."
+            : "You're offline. \(pending) changes will sync when you reconnect."
     }
 }

--- a/mDone/Views/Tasks/TaskRow.swift
+++ b/mDone/Views/Tasks/TaskRow.swift
@@ -201,6 +201,19 @@ struct TaskRow: View {
                 }
 
                 HStack(spacing: 8) {
+                    // Changes made offline live only on this device until they
+                    // replay, so say which rows are in that state rather than
+                    // letting the user assume everything reached the server.
+                    if appState.hasPendingChanges(task.id) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                            Text("Not synced")
+                        }
+                        .font(density.metadataFont)
+                        .foregroundStyle(.orange)
+                        .accessibilityLabel("Change not yet synced")
+                    }
+
                     if let dueDate = task.effectiveDueDate {
                         HStack(spacing: 4) {
                             Image(systemName: "calendar")

--- a/mDoneTests/OfflineEditQueueTests.swift
+++ b/mDoneTests/OfflineEditQueueTests.swift
@@ -1,0 +1,349 @@
+import SwiftData
+import XCTest
+@testable import mDone
+
+/// Issue #146: edits made offline used to go straight to the network, fail after
+/// ~7s of retries, and vanish. They're now applied locally, queued as the user's
+/// intent, and merged onto a freshly-read task when the connection returns.
+@MainActor
+final class OfflineEditQueueTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    // MARK: - Fixtures
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([
+            CachedTask.self,
+            CachedProject.self,
+            CachedLabel.self,
+            PendingOperation.self,
+            FocusRecord.self,
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    private func makeSyncService(container: ModelContainer) async -> SyncService {
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        return SyncService(
+            taskService: TaskService(apiClient: client),
+            projectService: ProjectService(apiClient: client),
+            modelContainer: container,
+            apiClient: client
+        )
+    }
+
+    private func makeAppState(sync: SyncService, connected: Bool) async -> AppState {
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        let state = AppState(
+            taskService: TaskService(apiClient: client),
+            projectService: ProjectService(apiClient: client),
+            labelService: LabelService(apiClient: client)
+        )
+        state.configureSyncService(sync, networkMonitor: NetworkMonitor(stubbedConnection: connected))
+        return state
+    }
+
+    private func sampleTask() -> VTask {
+        VTask(
+            id: 1,
+            title: "Write quarterly report",
+            description: "Focus on Q1 wins",
+            done: false,
+            priority: 5,
+            projectId: 3,
+            percentDone: 0.5
+        )
+    }
+
+    // MARK: - Queueing
+
+    func testTogglingDoneOfflineAppliesLocallyAndQueues() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+        state.tasks = [sampleTask()]
+        MockURLProtocol.requestHandler = { _ in throw URLError(.notConnectedToInternet) }
+
+        await state.toggleTaskDone(state.tasks[0])
+
+        XCTAssertTrue(state.tasks[0].done, "the checkbox must tick immediately")
+        XCTAssertEqual(sync.pendingOperationCount(), 1)
+        XCTAssertTrue(state.hasPendingChanges(1))
+        XCTAssertTrue(MockURLProtocol.capturedRequests.isEmpty, "offline must not hit the network")
+    }
+
+    /// The old behaviour: nothing visible for ~7s, then a vanishing error.
+    func testOfflineEditSurvivesInTheCache() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+        state.tasks = [sampleTask()]
+        MockURLProtocol.requestHandler = { _ in throw URLError(.notConnectedToInternet) }
+
+        await state.toggleTaskDone(state.tasks[0])
+
+        let cached = try sync.loadCachedTasks()
+        XCTAssertEqual(cached.first?.done, true)
+    }
+
+    func testReschedulingOfflineQueuesAndAppliesTheDate() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+        state.tasks = [sampleTask()]
+        let newDate = Date(timeIntervalSince1970: 1_900_000_000)
+
+        await state.rescheduleTask(state.tasks[0], to: newDate)
+
+        XCTAssertEqual(state.tasks[0].dueDate, newDate)
+        XCTAssertEqual(sync.pendingOperationCount(), 1)
+    }
+
+    func testSettingProgressOfflineQueues() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+        state.tasks = [sampleTask()]
+
+        await state.setProgress(state.tasks[0], percent: 0.9)
+
+        XCTAssertEqual(state.tasks[0].percentDone, 0.9)
+        XCTAssertEqual(sync.pendingOperationCount(), 1)
+    }
+
+    /// Repeated edits of one task collapse into a single queued operation, so
+    /// ticking on and off five times replays once, at the final state.
+    func testRepeatedOfflineEditsCoalesceIntoOneOperation() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+        state.tasks = [sampleTask()]
+
+        await state.toggleTaskDone(state.tasks[0])
+        await state.toggleTaskDone(state.tasks[0])
+        await state.toggleTaskDone(state.tasks[0])
+
+        XCTAssertEqual(sync.pendingOperationCount(), 1)
+        XCTAssertTrue(state.tasks[0].done)
+    }
+
+    func testDeletingOfflineQueuesAndDropsPendingEditsForThatTask() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+        state.tasks = [sampleTask()]
+
+        await state.setProgress(state.tasks[0], percent: 0.9)
+        XCTAssertEqual(sync.pendingOperationCount(), 1)
+
+        await state.deleteTask(VTask(id: 1, title: "Write quarterly report", done: false, priority: 5, projectId: 3))
+
+        XCTAssertTrue(state.tasks.isEmpty)
+        // The edit was superseded by the delete, leaving one operation, not two.
+        XCTAssertEqual(sync.pendingOperationCount(), 1)
+    }
+
+    // MARK: - Replay merges rather than clobbers
+
+    /// The whole point of storing intent: an edit made offline must not undo a
+    /// change someone else made server-side while the device was away.
+    func testReplayMergesOntoTheFreshServerCopy() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+        state.tasks = [sampleTask()]
+
+        // Offline, the user only changes priority.
+        var edit = TaskUpdateRequest()
+        edit.priority = 1
+        await state.updateTask(id: 1, request: edit)
+        XCTAssertEqual(sync.pendingOperationCount(), 1)
+
+        // Meanwhile the title and due date changed on the server.
+        let serverDue = "2026-09-01T10:00:00Z"
+        var sentBody: [String: Any]?
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 200, url: request.url)
+            if request.httpMethod == "GET" {
+                let task: [String: Any] = [
+                    "id": 1,
+                    "title": "Renamed on the web",
+                    "description": "Edited elsewhere",
+                    "done": false,
+                    "priority": 5,
+                    "project_id": 3,
+                    "due_date": serverDue,
+                    "percent_done": 0.5,
+                ]
+                return try (response, JSONSerialization.data(withJSONObject: task))
+            }
+            sentBody = request.decodedJSONBody
+            let task: [String: Any] = [
+                "id": 1,
+                "title": "Renamed on the web",
+                "done": false,
+                "priority": 1,
+                "project_id": 3,
+            ]
+            return try (response, JSONSerialization.data(withJSONObject: task))
+        }
+
+        await sync.processPendingOperations()
+
+        let body = try XCTUnwrap(sentBody)
+        XCTAssertEqual(body["priority"] as? Int, 1, "the user's offline edit must win")
+        XCTAssertEqual(
+            body["description"] as? String,
+            "Edited elsewhere",
+            "the description changed on the server must survive"
+        )
+        XCTAssertNotNil(body["due_date"], "the due date set on the server must survive")
+        XCTAssertNil(body["title"], "title is never sent, so the server keeps its own")
+        XCTAssertEqual(sync.pendingOperationCount(), 0)
+    }
+
+    func testSuccessfulReplayClearsTheQueue() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+        state.tasks = [sampleTask()]
+        await state.toggleTaskDone(state.tasks[0])
+
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 200, url: request.url)
+            let task: [String: Any] = [
+                "id": 1,
+                "title": "Write quarterly report",
+                "done": true,
+                "priority": 5,
+                "project_id": 3,
+            ]
+            return try (response, JSONSerialization.data(withJSONObject: task))
+        }
+
+        await sync.processPendingOperations()
+
+        XCTAssertEqual(sync.pendingOperationCount(), 0)
+        XCTAssertTrue(sync.failedOperations().isEmpty)
+    }
+
+    // MARK: - Failures are reported, not swallowed
+
+    /// A task deleted elsewhere can never accept the edit. Abandon it at once
+    /// and keep the reason, rather than retrying three times into the same wall.
+    func testReplayAgainstADeletedTaskFailsImmediatelyWithAReason() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+        state.tasks = [sampleTask()]
+        await state.toggleTaskDone(state.tasks[0])
+
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 404, url: request.url)
+            return (response, Data("{\"message\":\"task does not exist\"}".utf8))
+        }
+
+        await sync.processPendingOperations()
+
+        let failed = sync.failedOperations()
+        XCTAssertEqual(failed.count, 1)
+        XCTAssertNotNil(failed.first?.failureReason)
+        XCTAssertEqual(failed.first?.retryCount, 0, "a 404 should not burn retries")
+    }
+
+    func testTransientFailureKeepsTheOperationForAnotherAttempt() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+        state.tasks = [sampleTask()]
+        await state.toggleTaskDone(state.tasks[0])
+
+        MockURLProtocol.requestHandler = { _ in throw URLError(.notConnectedToInternet) }
+        await sync.processPendingOperations()
+
+        XCTAssertEqual(sync.pendingOperationCount(), 1, "still queued for a later attempt")
+        XCTAssertTrue(sync.failedOperations().isEmpty)
+    }
+
+    /// An expired session is the app's problem, not the queued change's. The
+    /// change must survive until the user signs back in rather than being
+    /// abandoned, and the rest of the queue shouldn't be marched into the same
+    /// 401 one at a time.
+    func testExpiredSessionPausesTheQueueWithoutLosingAnything() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+        state.tasks = [sampleTask(), VTask(id: 2, title: "Second", done: false, priority: 1, projectId: 3)]
+        await state.toggleTaskDone(state.tasks[0])
+        await state.toggleTaskDone(state.tasks[1])
+        XCTAssertEqual(sync.pendingOperationCount(), 2)
+
+        var requestCount = 0
+        MockURLProtocol.requestHandler = { request in
+            requestCount += 1
+            return (MockURLProtocol.makeResponse(statusCode: 401, url: request.url), Data())
+        }
+
+        await sync.processPendingOperations()
+
+        XCTAssertEqual(sync.pendingOperationCount(), 2, "nothing may be dropped for an expired session")
+        XCTAssertTrue(sync.failedOperations().isEmpty)
+        XCTAssertEqual(requestCount, 1, "should stop after the first 401, not retry every operation")
+    }
+
+    // MARK: - Things that genuinely can't be done offline
+
+    /// Creating offline isn't queueable (no server id to replay against), so it
+    /// must say so at once instead of spending the retry budget finding out.
+    func testCreatingATaskOfflineFailsFast() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: false)
+        MockURLProtocol.requestHandler = { _ in throw URLError(.notConnectedToInternet) }
+
+        let created = await state.createTask(title: "New", projectId: 1)
+
+        XCTAssertNil(created)
+        if case .networkUnavailable = try XCTUnwrap(state.activeError) {} else {
+            XCTFail("expected a networkUnavailable error, got \(String(describing: state.activeError))")
+        }
+        XCTAssertTrue(MockURLProtocol.capturedRequests.isEmpty)
+    }
+
+    // MARK: - Online is unaffected
+
+    func testOnlineEditsStillGoStraightToTheNetwork() async throws {
+        let container = try makeContainer()
+        let sync = await makeSyncService(container: container)
+        let state = await makeAppState(sync: sync, connected: true)
+        state.tasks = [sampleTask()]
+
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 200, url: request.url)
+            let task: [String: Any] = [
+                "id": 1,
+                "title": "Write quarterly report",
+                "done": true,
+                "priority": 5,
+                "project_id": 3,
+            ]
+            return try (response, JSONSerialization.data(withJSONObject: task))
+        }
+
+        await state.toggleTaskDone(state.tasks[0])
+
+        XCTAssertFalse(MockURLProtocol.capturedRequests.isEmpty)
+        XCTAssertEqual(sync.pendingOperationCount(), 0, "online edits are never queued")
+    }
+}


### PR DESCRIPTION
## Summary

Editing while offline now works: changes apply immediately, queue, and sync when you reconnect.

You reported that nothing worked offline, then that a bunch of things updated on reconnect. Both were right, and the explanation is worse than either: **there was no queue at all.** Every mutation went straight to the network, where URLSession retried it for up to ~87 seconds (four attempts at the 20s timeout plus 1s/2s/4s backoff). Reconnect inside that window and the request landed, which is the "bunch of stuff updated". Reconnect after it and the change was gone. Meanwhile the tap itself did nothing visible for seven seconds, then flashed an error banner that auto-dismissed after six.

`SyncService.queueOperation` and `processPendingOperations` already existed, but nothing ever called `queueOperation`, so the replay on reconnect always found an empty queue.

## Related Issues

Fixes #146

## What changed

Edits to tasks that **already exist on the server** are applied locally, written to the cache, and queued: complete/uncomplete, undo, postpone, reschedule, progress, detail-sheet edits, and delete.

**Intent, not a request body.** `QueuedTaskEdit` stores only the fields you actually changed. On replay the task is re-read from the server and your intent merged onto it. This is the difference between "sync my change" and "overwrite the task with what it looked like when my phone went offline", and it's why the queue can sit for a day without being destructive.

**Coalescing.** Repeated edits of one task fold into one operation, so ticking on and off settles on the final state rather than replaying every step. A queued delete supersedes pending edits for that task.

**Draining.** The queue goes out on reconnect *and* at the start of any successful refresh. The second path matters: if your server became reachable again without the phone's own link ever dropping, the connectivity callback never fires, and the old code would have left the queue sitting there.

**Failure handling.**
- `401` pauses the queue without consuming a retry. An expired session is the app's problem, not your change's, so nothing is discarded; it goes out after you sign back in.
- Other `4xx` are permanent, abandoned immediately with the reason kept rather than retried three times into the same wall.
- Anything abandoned is reported by task title, instead of vanishing.

**Actions that genuinely can't work offline** (creating a task or project, relation changes) now say so instantly instead of spending the retry budget finding out. Creating offline is not queueable yet because a queued create has no server id for later edits to address; that stays open as follow-up.

**UI.** Rows with unsent changes show "Not synced". The offline banner says how many changes are waiting.

## Testing

**New tests**: `mDoneTests/OfflineEditQueueTests.swift`, 13 tests covering queueing, coalescing, delete supersession, merge-on-replay, the 401 pause, permanent failures, fail-fast, and that online behaviour is unchanged. Full suite green at **536**; iOS and macOS both build.

**End to end on the simulator**, the case that actually matters:

1. App synced online. Task: `description "original", priority 4, progress 0.25`.
2. Task edited **on the server** to `description "CHANGED ON THE WEB", priority 1, progress 0.9`. The phone never saw this.
3. Server stopped. Ticked the task off in the app. It ticked instantly; SwiftData held exactly `{"done":true}` for that task id; the app's cached copy still said `"original"`.
4. Server restarted, app reopened.

Result on the server:

```
done: True | desc: 'CHANGED ON THE WEB' | prio: 1 | pct: 0.9
```

The offline completion applied, and every server-side change survived. With a naive replay this would have read `desc: 'original', prio: 4, pct: 0.25`. Queue drained to zero, no failures.

## Checklist

- [x] Builds on iOS and macOS
- [x] Tests pass (536 unit tests)
- [x] Ran `swiftlint lint --quiet` and `swiftformat .` (SwiftFormat rewrites many unrelated files since the repo isn't format-clean; only the changed files are included here)
- [x] No breaking changes. `PendingOperation` gains three optional properties, which SwiftData migrates lightweight; operations queued by an older build still replay on the old path.

Builds on #148, which is where the merge helper (`preservingExistingValues`) comes from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
