### PR TITLE
docs: stamp 1.12.2 in the changelog and add its App Store What's New

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Actions that genuinely need a connection, such as creating a task or a project, now say so immediately instead of spending several seconds retrying first (#146).
-- Completing a task no longer wipes its description, priority, progress, color or favorite status. Vikunja replaces a task wholesale on every update, so ticking a task off, postponing it, rescheduling it or dragging its progress bar silently cleared the fields the app did not resend. Those fields are now carried through on every task update (#147).
+- Completing a task now preserves its colour and favourite status too. 1.12.2 stopped the description, priority and progress being cleared; Vikunja resets these two the same way, so every task update now carries them as well (#147).
+
+## [1.12.2] - 2026-08-12
+
+### Fixed
+- Completing a task no longer wipes its description, priority and progress. Vikunja replaces a task wholesale on every update, so ticking a task off, postponing it, rescheduling it or dragging its progress bar silently cleared the fields the app did not resend. Those fields are now carried through on every task update (#147).
 - Offline mode now actually works. Opening the app without a reachable server used to sit on a loading spinner and then show an empty list claiming "All done!", because your tasks were never being saved to the offline cache and the cache was never read back. Your tasks, projects and labels are now saved on every successful sync and appear instantly on launch, before any network call, so the app is usable offline (#144).
 - When the device is offline the app no longer fires requests it can only lose, so there is no wait before your cached tasks appear (#144).
 - A server that cannot be reached now shows "You're offline. Showing your last synced tasks." and a clear "can't reach the server" message, instead of a generic error and a misleading empty list. This covers the case where Wi-Fi is working but your Vikunja is not reachable, for example over a VPN that is down (#144).

--- a/docs/appstore-metadata.md
+++ b/docs/appstore-metadata.md
@@ -83,6 +83,15 @@ Steps to test:
 
 This is a private test server maintained by the developer for App Store review purposes.
 
+## What's New (v1.12.2)
+
+Offline mode that actually works, plus an important data-loss fix.
+
+- Your tasks, projects and labels are saved as you sync and appear the moment you open the app, even with no connection. mDone previously showed a loading spinner and then an empty list.
+- When your server cannot be reached, mDone now says so clearly and shows your last synced tasks, instead of a generic error and a misleading empty list.
+- Fixed a bug where completing, postponing or rescheduling a task, or changing its progress, could clear that task's description, priority and progress on your server.
+- Available on both iPhone and Mac.
+
 ## What's New (v1.12.0)
 
 Task date ranges, plus fixes for busy accounts.


### PR DESCRIPTION
## Summary

Docs only, no code. 1.12.2 (build 59) is in App Store review on both platforms, so this splits it out of `[Unreleased]` and adds the matching App Store metadata.

## Related Issues

Follows #144, #146, #147.

## The one judgement call worth reviewing

The split follows **what each build actually contains**, not what `main` contains now, because those differ:

| | description / priority / progress | colour / favourite |
|---|---|---|
| Build 59 (1.12.2, in review) | yes | **no** |
| Build 60 (1.13.0, TestFlight) | yes | **no** |
| `main` today | yes | yes |

Build 59 was cut from `32e599e`, before #148 was merged as `1d7dfa7` with the carry-forward widened to `hexColor` and `isFavorite`. That widening is on `main` but in no build yet.

So:

- **`[1.12.2]`** gets the #144 offline-cache entries plus the #147 entry as it shipped, wording limited to description, priority and progress.
- **`[Unreleased]`** keeps the #146 offline edit queue, and gains a separate #147 entry for colour and favourite status.

Crediting 1.12.2 with the colour and favourite fix would have told users it was in a build that does not have it.

## Metadata

`docs/appstore-metadata.md` gains a `What's New (v1.12.2)` section mirroring the text already submitted to App Store Connect for this version, so the repo and ASC agree rather than drifting.

## Testing

No code changed, so nothing to run. Verified by diffing `32e599e`, `262f0e6` and `1d7dfa7` to confirm which fields each build carries.

Date stamped `2026-08-12`, the submission date, matching how 1.12.0 was stamped in #143. Worth nudging if approval slips into another day.

## Checklist

- [x] Builds on iOS and macOS (no code changed)
- [x] Tests pass (no code changed)
- [x] Ran `swiftlint lint --quiet` and `swiftformat .` (not applicable, markdown only)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
