### PR TITLE
Add task label assignment UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Assign, remove, search, and create Vikunja labels directly from task detail on iPhone and Mac (#4).
 - You can now edit tasks while offline. Completing a task, rescheduling it, changing its progress, editing its details or deleting it all take effect straight away and sync when you reconnect. Rows with changes still waiting show a "Not synced" marker, and the offline banner tells you how many are queued. Previously these actions did nothing for several seconds, then failed with an error that faded away (#146).
 - Queued changes are merged rather than replayed blindly. When your change reaches the server, only the fields you actually edited are applied, so an edit made offline no longer overwrites something you or someone else changed elsewhere in the meantime (#146).
 - If a queued change can never be delivered, for example because the task was deleted elsewhere, the app now tells you which change it was and why, instead of dropping it silently (#146).

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -1254,7 +1254,25 @@ final class AppState {
         }
     }
 
-    // MARK: - Current task mutations
+    // MARK: - Label mutations
+
+    private static let newLabelColors = [
+        "e74c3c",
+        "e67e22",
+        "f1c40f",
+        "2ecc71",
+        "1abc9c",
+        "3498db",
+        "9b59b6",
+        "e84393",
+    ]
+
+    @MainActor
+    private func cacheLabelIfNeeded(_ label: VLabel) {
+        guard !labels.contains(where: { $0.id == label.id }) else { return }
+        labels.append(label)
+        try? syncService?.cacheLabels(labels)
+    }
 
     /// Resolves the "Current" label, creating it on the server if it doesn't
     /// exist yet. Persists the id so it survives a later rename.
@@ -1266,11 +1284,107 @@ final class AppState {
         let created = try await labelService.createLabel(
             LabelCreateRequest(title: Self.currentLabelTitle, hexColor: "1a8cff")
         )
-        if !labels.contains(where: { $0.id == created.id }) {
-            labels.append(created)
-        }
+        cacheLabelIfNeeded(created)
         storedCurrentLabelId = created.id
         return created
+    }
+
+    /// Creates a label and immediately assigns it to `task`. An existing label
+    /// with the same title is reused so a case difference does not create an
+    /// obvious duplicate.
+    @MainActor
+    func createAndAssignLabel(title: String, to task: VTask) async -> VLabel? {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else { return nil }
+        guard !isEffectivelyOffline else {
+            rejectOffline("Creating a label")
+            return nil
+        }
+
+        if let existing = labels.first(where: {
+            $0.title.caseInsensitiveCompare(trimmedTitle) == .orderedSame
+        }) {
+            return await setLabel(existing, on: task, present: true) ? existing : nil
+        }
+
+        do {
+            let color = Self.newLabelColors.randomElement() ?? "3498db"
+            let created = try await labelService.createLabel(
+                LabelCreateRequest(title: trimmedTitle, hexColor: color)
+            )
+            cacheLabelIfNeeded(created)
+            return await setLabel(created, on: task, present: true) ? created : nil
+        } catch {
+            handleError(error)
+            return nil
+        }
+    }
+
+    /// Assigns or removes one label through Vikunja's individual label-task
+    /// endpoint. The local task changes immediately and rolls back if the
+    /// request fails.
+    @MainActor
+    @discardableResult
+    func setLabel(_ label: VLabel, on task: VTask, present: Bool) async -> Bool {
+        guard !isEffectivelyOffline else {
+            rejectOffline(present ? "Adding a label" : "Removing a label")
+            return false
+        }
+
+        let liveTask = taskSnapshot(id: task.id) ?? task
+        let previousLabels = liveTask.labels
+        let previousUpdated = liveTask.updated
+        let matchingLabelCount = previousLabels?.filter { $0.id == label.id }.count ?? 0
+        let wasPresent = matchingLabelCount > 0
+
+        guard wasPresent != present else {
+            if present, matchingLabelCount > 1 {
+                setLabelLocally(taskId: task.id, label: label, present: true, fallback: task)
+            }
+            return true
+        }
+
+        let optimisticTask = setLabelLocally(
+            taskId: task.id,
+            label: label,
+            present: present,
+            fallback: task
+        )
+
+        do {
+            if present {
+                try await labelService.addLabel(taskId: task.id, labelId: label.id)
+            } else {
+                try await labelService.removeLabel(taskId: task.id, labelId: label.id)
+            }
+            #if os(iOS)
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            #endif
+            WidgetCenter.shared.reloadAllTimelines()
+            return true
+        } catch {
+            let currentTask = taskSnapshot(id: task.id)
+            let stillAtOptimisticState = currentTask?.labels?.map(\.id) == optimisticTask?.labels?.map(\.id)
+                && currentTask?.updated == optimisticTask?.updated
+            if stillAtOptimisticState {
+                replaceLabelsLocally(
+                    taskId: task.id,
+                    labels: previousLabels,
+                    updated: previousUpdated,
+                    fallback: task
+                )
+            } else {
+                setLabelLocally(
+                    taskId: task.id,
+                    label: label,
+                    present: wasPresent,
+                    fallback: task,
+                    bumpUpdated: false
+                )
+            }
+            handleError(error)
+            return false
+        }
     }
 
     /// Toggles the "Current" label on `task`, surfacing it in (or removing it
@@ -1278,6 +1392,11 @@ final class AppState {
     /// local copy updates immediately and reverts if the network call fails.
     @MainActor
     func toggleCurrent(_ task: VTask) async {
+        guard !isEffectivelyOffline else {
+            rejectOffline("Changing Current")
+            return
+        }
+
         let label: VLabel
         do {
             label = try await ensureCurrentLabel()
@@ -1286,42 +1405,53 @@ final class AppState {
             return
         }
 
-        let wasCurrent = isCurrent(task)
-        setCurrentLabelLocally(taskId: task.id, label: label, present: !wasCurrent)
-
-        do {
-            if wasCurrent {
-                try await labelService.removeLabel(taskId: task.id, labelId: label.id)
-            } else {
-                try await labelService.addLabel(taskId: task.id, labelId: label.id)
-            }
-            #if os(iOS)
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            #endif
-            WidgetCenter.shared.reloadAllTimelines()
-        } catch {
-            setCurrentLabelLocally(taskId: task.id, label: label, present: wasCurrent)
-            handleError(error)
-        }
+        let liveTask = taskSnapshot(id: task.id) ?? task
+        await setLabel(label, on: liveTask, present: !isCurrent(liveTask))
     }
 
-    /// Adds or removes `label` from the locally cached copy of a task, and
-    /// bumps its `updated` timestamp so the stall indicator resets. The
-    /// `tasks` array is the source of truth.
+    /// Adds or removes `label` from the local task and mirrors that change into
+    /// embedded relation snapshots and the on-device cache.
     @MainActor
-    private func setCurrentLabelLocally(taskId: Int64, label: VLabel, present: Bool) {
-        guard let index = tasks.firstIndex(where: { $0.id == taskId }) else { return }
-        var labelList = tasks[index].labels ?? []
+    @discardableResult
+    private func setLabelLocally(
+        taskId: Int64,
+        label: VLabel,
+        present: Bool,
+        fallback: VTask? = nil,
+        bumpUpdated: Bool = true
+    ) -> VTask? {
+        guard let current = taskSnapshot(id: taskId) ?? fallback else { return nil }
+        var labelList = (current.labels ?? []).filter { $0.id != label.id }
         if present {
-            if !labelList.contains(where: { $0.id == label.id }) {
-                labelList.append(label)
-            }
-        } else {
-            labelList.removeAll { $0.id == label.id }
+            labelList.append(label)
         }
-        tasks[index].labels = labelList
-        tasks[index].updated = Date()
-        syncService?.updateCachedTask(tasks[index])
+        return replaceLabelsLocally(
+            taskId: taskId,
+            labels: labelList,
+            updated: bumpUpdated ? Date() : current.updated,
+            fallback: current
+        )
+    }
+
+    @MainActor
+    @discardableResult
+    private func replaceLabelsLocally(
+        taskId: Int64,
+        labels: [VLabel]?,
+        updated: Date?,
+        fallback: VTask? = nil
+    ) -> VTask? {
+        guard var updatedTask = taskSnapshot(id: taskId) ?? fallback else { return nil }
+        updatedTask.labels = labels
+        updatedTask.updated = updated
+        if let index = tasks.firstIndex(where: { $0.id == taskId }) {
+            tasks[index] = updatedTask
+        } else {
+            tasks.append(updatedTask)
+        }
+        syncEmbeddedRelations(with: updatedTask)
+        syncService?.updateCachedTask(updatedTask)
+        return updatedTask
     }
 
     /// Sets a task's completion progress (clamped to 0...1) and persists it.

--- a/mDone/Views/Components/TaskLabelsSection.swift
+++ b/mDone/Views/Components/TaskLabelsSection.swift
@@ -1,0 +1,220 @@
+import SwiftUI
+
+/// Shared label display and picker entry point for iOS and macOS task detail.
+/// It always reads the live task from `AppState` so optimistic changes remain
+/// visible while a detail editor is open.
+struct TaskLabelsSection: View {
+    @Environment(AppState.self) private var appState
+    let task: VTask
+
+    @State private var isShowingPicker = false
+
+    private var liveTask: VTask {
+        appState.tasks.first(where: { $0.id == task.id }) ?? task
+    }
+
+    private var assignedLabels: [VLabel] {
+        var seenIds: Set<Int64> = []
+        return (liveTask.labels ?? []).filter { seenIds.insert($0.id).inserted }
+    }
+
+    var body: some View {
+        Section("Labels") {
+            if assignedLabels.isEmpty {
+                Text("No labels assigned")
+                    .foregroundStyle(.secondary)
+            } else {
+                FlowLayout(spacing: 8) {
+                    ForEach(assignedLabels) { label in
+                        LabelChip(label: label)
+                    }
+                }
+            }
+
+            Button {
+                isShowingPicker = true
+            } label: {
+                Label(assignedLabels.isEmpty ? "Add Labels" : "Manage Labels", systemImage: "tag")
+            }
+        }
+        .sheet(isPresented: $isShowingPicker) {
+            TaskLabelPicker(task: liveTask)
+        }
+    }
+}
+
+private struct TaskLabelPicker: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+    let task: VTask
+
+    @State private var searchText = ""
+    @State private var pendingLabelIds: Set<Int64> = []
+    @State private var isCreating = false
+
+    private var liveTask: VTask {
+        appState.tasks.first(where: { $0.id == task.id }) ?? task
+    }
+
+    private var assignedLabelIds: Set<Int64> {
+        Set((liveTask.labels ?? []).map(\.id))
+    }
+
+    private var trimmedSearchText: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var visibleLabels: [VLabel] {
+        let sorted = appState.labels.sorted {
+            $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending
+        }
+        guard !trimmedSearchText.isEmpty else { return sorted }
+        return sorted.filter { $0.title.localizedCaseInsensitiveContains(trimmedSearchText) }
+    }
+
+    private var canCreateLabel: Bool {
+        guard !trimmedSearchText.isEmpty else { return false }
+        return !appState.labels.contains {
+            $0.title.caseInsensitiveCompare(trimmedSearchText) == .orderedSame
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Available Labels") {
+                    if visibleLabels.isEmpty {
+                        Text(trimmedSearchText.isEmpty ? "No labels available" : "No matching labels")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(visibleLabels) { label in
+                            labelRow(label)
+                        }
+                    }
+                }
+
+                if canCreateLabel {
+                    Section {
+                        Button(action: createLabel) {
+                            HStack {
+                                Label("Create \"\(trimmedSearchText)\"", systemImage: "plus.circle")
+                                Spacer()
+                                if isCreating {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                }
+                            }
+                        }
+                        .disabled(isCreating)
+                    }
+                }
+            }
+            .searchable(text: $searchText, prompt: "Search or create labels")
+            .navigationTitle("Labels")
+            #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+            #endif
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+        }
+        #if os(iOS)
+        .presentationDetents([.medium, .large])
+        #elseif os(macOS)
+        .frame(minWidth: 400, minHeight: 440)
+        #endif
+    }
+
+    private func labelRow(_ label: VLabel) -> some View {
+        let isAssigned = assignedLabelIds.contains(label.id)
+        let isPending = pendingLabelIds.contains(label.id)
+
+        return Button {
+            guard pendingLabelIds.insert(label.id).inserted else { return }
+            Task {
+                await appState.setLabel(label, on: liveTask, present: !isAssigned)
+                pendingLabelIds.remove(label.id)
+            }
+        } label: {
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(label.color)
+                    .frame(width: 12, height: 12)
+                    .accessibilityHidden(true)
+                Text(label.title)
+                    .foregroundStyle(.primary)
+                Spacer()
+                if isPending {
+                    ProgressView()
+                        .controlSize(.small)
+                } else if isAssigned {
+                    Image(systemName: "checkmark")
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.tint)
+                        .accessibilityHidden(true)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isPending)
+        .accessibilityLabel(isAssigned ? "Remove \(label.title)" : "Assign \(label.title)")
+    }
+
+    private func createLabel() {
+        guard !trimmedSearchText.isEmpty, !isCreating else { return }
+        let title = trimmedSearchText
+        isCreating = true
+        Task {
+            if await appState.createAndAssignLabel(title: title, to: liveTask) != nil {
+                searchText = ""
+            }
+            isCreating = false
+        }
+    }
+}
+
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+        return layout(sizes: sizes, containerWidth: proposal.width ?? .infinity).size
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+        let positions = layout(sizes: sizes, containerWidth: bounds.width).positions
+
+        for (index, subview) in subviews.enumerated() {
+            subview.place(
+                at: CGPoint(x: bounds.minX + positions[index].x, y: bounds.minY + positions[index].y),
+                proposal: .unspecified
+            )
+        }
+    }
+
+    private func layout(sizes: [CGSize], containerWidth: CGFloat) -> (positions: [CGPoint], size: CGSize) {
+        var positions: [CGPoint] = []
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var maxHeight: CGFloat = 0
+        var maxWidth: CGFloat = 0
+
+        for size in sizes {
+            if x + size.width > containerWidth, x > 0 {
+                x = 0
+                y += maxHeight + spacing
+                maxHeight = 0
+            }
+            positions.append(CGPoint(x: x, y: y))
+            maxHeight = max(maxHeight, size.height)
+            x += size.width + spacing
+            maxWidth = max(maxWidth, x)
+        }
+
+        return (positions, CGSize(width: maxWidth, height: y + maxHeight))
+    }
+}

--- a/mDone/Views/Mac/MacTaskDetailView.swift
+++ b/mDone/Views/Mac/MacTaskDetailView.swift
@@ -168,15 +168,7 @@ struct MacTaskDetailView: View {
                 }
             }
 
-            if let labels = task.labels, !labels.isEmpty {
-                Section("Labels") {
-                    FlowLayout(spacing: 8) {
-                        ForEach(labels) { label in
-                            LabelChip(label: label)
-                        }
-                    }
-                }
-            }
+            TaskLabelsSection(task: task)
 
             FocusHistoryGate(taskId: task.id) {
                 Section("Focus") {

--- a/mDone/Views/Tasks/TaskDetailSheet.swift
+++ b/mDone/Views/Tasks/TaskDetailSheet.swift
@@ -188,15 +188,7 @@ struct TaskDetailSheet: View {
                     }
                 }
 
-                if let labels = task.labels, !labels.isEmpty {
-                    Section("Labels") {
-                        FlowLayout(spacing: 8) {
-                            ForEach(labels) { label in
-                                LabelChip(label: label)
-                            }
-                        }
-                    }
-                }
+                TaskLabelsSection(task: task)
 
                 Section {
                     Button("Delete Task", role: .destructive) {
@@ -268,48 +260,5 @@ struct TaskDetailSheet: View {
             await appState.updateTask(id: task.id, request: request)
             dismiss()
         }
-    }
-}
-
-struct FlowLayout: Layout {
-    var spacing: CGFloat = 8
-
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
-        return layout(sizes: sizes, containerWidth: proposal.width ?? .infinity).size
-    }
-
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
-        let positions = layout(sizes: sizes, containerWidth: bounds.width).positions
-
-        for (index, subview) in subviews.enumerated() {
-            subview.place(
-                at: CGPoint(x: bounds.minX + positions[index].x, y: bounds.minY + positions[index].y),
-                proposal: .unspecified
-            )
-        }
-    }
-
-    private func layout(sizes: [CGSize], containerWidth: CGFloat) -> (positions: [CGPoint], size: CGSize) {
-        var positions: [CGPoint] = []
-        var x: CGFloat = 0
-        var y: CGFloat = 0
-        var maxHeight: CGFloat = 0
-        var maxWidth: CGFloat = 0
-
-        for size in sizes {
-            if x + size.width > containerWidth, x > 0 {
-                x = 0
-                y += maxHeight + spacing
-                maxHeight = 0
-            }
-            positions.append(CGPoint(x: x, y: y))
-            maxHeight = max(maxHeight, size.height)
-            x += size.width + spacing
-            maxWidth = max(maxWidth, x)
-        }
-
-        return (positions, CGSize(width: maxWidth, height: y + maxHeight))
     }
 }

--- a/mDoneTests/LabelAssignmentTests.swift
+++ b/mDoneTests/LabelAssignmentTests.swift
@@ -1,0 +1,262 @@
+import XCTest
+@testable import mDone
+
+@MainActor
+final class LabelAssignmentTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+        UserDefaults.standard.removeObject(forKey: "currentLabelId")
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        UserDefaults.standard.removeObject(forKey: "currentLabelId")
+        super.tearDown()
+    }
+
+    private func makeAppState() async -> AppState {
+        let client = APIClient(session: MockURLProtocol.mockSession())
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        return AppState(
+            taskService: TaskService(apiClient: client),
+            labelService: LabelService(apiClient: client)
+        )
+    }
+
+    private func task(labels: [VLabel]? = nil) -> VTask {
+        var task = VTask(id: 1, title: "Task", done: false, priority: 0, projectId: 2)
+        task.labels = labels
+        return task
+    }
+
+    func testAssignExistingLabelIsOptimisticAndPersistsOnSuccess() async throws {
+        let appState = await makeAppState()
+        let label = VLabel(id: 7, title: "Home")
+        let originalTask = task()
+        appState.labels = [label]
+        appState.tasks = [originalTask]
+
+        let requestStarted = expectation(description: "Add request started")
+        var pendingProtocol: MockURLProtocol?
+        MockURLProtocol.asynchronousRequestHandler = { _, protocolInstance in
+            pendingProtocol = protocolInstance
+            requestStarted.fulfill()
+        }
+
+        let mutation = Task {
+            await appState.setLabel(label, on: originalTask, present: true)
+        }
+        await fulfillment(of: [requestStarted], timeout: 1)
+
+        XCTAssertEqual(appState.tasks[0].labels?.map(\.id), [7], "The label is visible before the request finishes")
+        let request = try XCTUnwrap(MockURLProtocol.capturedRequests.last)
+        XCTAssertEqual(request.url?.path, "/api/v1/tasks/1/labels")
+        XCTAssertEqual(request.httpMethod, "PUT")
+
+        let response = MockURLProtocol.makeResponse(statusCode: 201, url: request.url)
+        let protocolInstance = try XCTUnwrap(pendingProtocol)
+        try protocolInstance.complete(response: response, data: XCTUnwrap(#"{"label_id":7}"#.data(using: .utf8)))
+        let succeeded = await mutation.value
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(appState.tasks[0].labels?.map(\.id), [7])
+    }
+
+    func testRemoveExistingLabelPersistsOnSuccess() async {
+        let appState = await makeAppState()
+        let label = VLabel(id: 7, title: "Home")
+        let originalTask = task(labels: [label])
+        appState.tasks = [originalTask]
+        MockURLProtocol.requestHandler = { request in
+            (
+                MockURLProtocol.makeResponse(statusCode: 200, url: request.url),
+                #"{"message":"ok"}"#.data(using: .utf8)!
+            )
+        }
+
+        let succeeded = await appState.setLabel(label, on: originalTask, present: false)
+
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(appState.tasks[0].labels, [])
+        XCTAssertEqual(MockURLProtocol.capturedRequests.last?.url?.path, "/api/v1/tasks/1/labels/7")
+        XCTAssertEqual(MockURLProtocol.capturedRequests.last?.httpMethod, "DELETE")
+    }
+
+    func testFailedAddRollsBack() async {
+        let appState = await makeAppState()
+        let label = VLabel(id: 7, title: "Home")
+        let originalTask = task()
+        appState.tasks = [originalTask]
+        MockURLProtocol.requestHandler = { request in
+            (
+                MockURLProtocol.makeResponse(statusCode: 400, url: request.url),
+                #"{"message":"bad"}"#.data(using: .utf8)!
+            )
+        }
+
+        let succeeded = await appState.setLabel(label, on: originalTask, present: true)
+
+        XCTAssertFalse(succeeded)
+        XCTAssertNil(appState.tasks[0].labels)
+    }
+
+    func testFailedRemoveRollsBack() async {
+        let appState = await makeAppState()
+        let label = VLabel(id: 7, title: "Home")
+        let originalTask = task(labels: [label])
+        appState.tasks = [originalTask]
+        MockURLProtocol.requestHandler = { request in
+            (
+                MockURLProtocol.makeResponse(statusCode: 400, url: request.url),
+                #"{"message":"bad"}"#.data(using: .utf8)!
+            )
+        }
+
+        let succeeded = await appState.setLabel(label, on: originalTask, present: false)
+
+        XCTAssertFalse(succeeded)
+        XCTAssertEqual(appState.tasks[0].labels?.map(\.id), [7])
+    }
+
+    func testFailedAddPreservesNewerUpdatedTimestamp() async throws {
+        let appState = await makeAppState()
+        let label = VLabel(id: 7, title: "Home")
+        var originalTask = task()
+        originalTask.updated = Date(timeIntervalSince1970: 100)
+        appState.tasks = [originalTask]
+
+        let requestStarted = expectation(description: "Add request started")
+        var pendingProtocol: MockURLProtocol?
+        MockURLProtocol.asynchronousRequestHandler = { _, protocolInstance in
+            pendingProtocol = protocolInstance
+            requestStarted.fulfill()
+        }
+
+        let mutation = Task {
+            await appState.setLabel(label, on: originalTask, present: true)
+        }
+        await fulfillment(of: [requestStarted], timeout: 1)
+
+        XCTAssertEqual(appState.tasks[0].labels?.map(\.id), [7], "The label is applied optimistically")
+        let optimisticUpdated = try XCTUnwrap(appState.tasks[0].updated)
+        let newerUpdated = optimisticUpdated.addingTimeInterval(60)
+        appState.tasks[0].updated = newerUpdated
+
+        let request = try XCTUnwrap(MockURLProtocol.capturedRequests.last)
+        let response = MockURLProtocol.makeResponse(statusCode: 400, url: request.url)
+        let protocolInstance = try XCTUnwrap(pendingProtocol)
+        try protocolInstance.complete(response: response, data: XCTUnwrap(#"{"message":"bad"}"#.data(using: .utf8)))
+
+        let succeeded = await mutation.value
+        XCTAssertFalse(succeeded)
+        XCTAssertNil(appState.tasks[0].labels, "The failed optimistic label is removed")
+        XCTAssertEqual(appState.tasks[0].updated, newerUpdated, "Rollback keeps the newer task timestamp")
+    }
+
+    func testAssigningPresentLabelRemovesLocalDuplicatesWithoutAnotherRequest() async {
+        let appState = await makeAppState()
+        let label = VLabel(id: 7, title: "Home")
+        let originalTask = task(labels: [label, label])
+        appState.tasks = [originalTask]
+
+        let succeeded = await appState.setLabel(label, on: originalTask, present: true)
+
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(appState.tasks[0].labels?.map(\.id), [7])
+        XCTAssertTrue(MockURLProtocol.capturedRequests.isEmpty)
+    }
+
+    func testCreateLabelCachesItAndAssignsItToTask() async {
+        let appState = await makeAppState()
+        let originalTask = task()
+        appState.tasks = [originalTask]
+        MockURLProtocol.requestHandler = { request in
+            if request.url?.path == "/api/v1/labels" {
+                let body = try XCTUnwrap(request.decodedJSONBody)
+                XCTAssertEqual(body["title"] as? String, "Errands")
+                XCTAssertFalse((body["hex_color"] as? String ?? "").isEmpty)
+                return (
+                    MockURLProtocol.makeResponse(statusCode: 201, url: request.url),
+                    #"{"id":12,"title":"Errands","hex_color":"3498db"}"#.data(using: .utf8)!
+                )
+            }
+            return (
+                MockURLProtocol.makeResponse(statusCode: 201, url: request.url),
+                #"{"label_id":12}"#.data(using: .utf8)!
+            )
+        }
+
+        let created = await appState.createAndAssignLabel(title: "  Errands  ", to: originalTask)
+
+        XCTAssertEqual(created?.id, 12)
+        XCTAssertEqual(appState.labels.map(\.id), [12])
+        XCTAssertEqual(appState.tasks[0].labels?.map(\.id), [12])
+        XCTAssertEqual(MockURLProtocol.capturedRequests.map { $0.url?.path }, [
+            "/api/v1/labels",
+            "/api/v1/tasks/1/labels",
+        ])
+    }
+
+    func testCreateAndAssignReusesExistingLabelCaseInsensitively() async {
+        let appState = await makeAppState()
+        let existing = VLabel(id: 12, title: "Errands")
+        let originalTask = task()
+        appState.labels = [existing]
+        appState.tasks = [originalTask]
+        MockURLProtocol.requestHandler = { request in
+            (
+                MockURLProtocol.makeResponse(statusCode: 201, url: request.url),
+                #"{"label_id":12}"#.data(using: .utf8)!
+            )
+        }
+
+        let resolved = await appState.createAndAssignLabel(title: "errands", to: originalTask)
+
+        XCTAssertEqual(resolved?.id, existing.id)
+        XCTAssertEqual(appState.labels.map(\.id), [existing.id])
+        XCTAssertEqual(appState.tasks[0].labels?.map(\.id), [existing.id])
+        XCTAssertEqual(MockURLProtocol.capturedRequests.map { $0.url?.path }, ["/api/v1/tasks/1/labels"])
+    }
+
+    func testGeneralLabelMutationPreservesCurrentBehavior() async {
+        let appState = await makeAppState()
+        let current = VLabel(id: 3, title: "Current")
+        let other = VLabel(id: 7, title: "Home")
+        let originalTask = task(labels: [current])
+        appState.labels = [current, other]
+        appState.tasks = [originalTask]
+        MockURLProtocol.requestHandler = { request in
+            (
+                MockURLProtocol.makeResponse(statusCode: 201, url: request.url),
+                #"{"label_id":7}"#.data(using: .utf8)!
+            )
+        }
+
+        let succeeded = await appState.setLabel(other, on: originalTask, present: true)
+
+        XCTAssertTrue(succeeded)
+        XCTAssertTrue(appState.isCurrent(appState.tasks[0]))
+        XCTAssertEqual(appState.currentTasks.map(\.id), [1])
+        XCTAssertEqual(Set(appState.tasks[0].labels?.map(\.id) ?? []), Set([3, 7]))
+    }
+
+    func testLabelMutationUpdatesEmbeddedTaskSnapshots() async {
+        let appState = await makeAppState()
+        let label = VLabel(id: 7, title: "Home")
+        let child = task()
+        var parent = VTask(id: 2, title: "Parent", done: false, priority: 0, projectId: 2)
+        parent.relatedTasks = [RelationKind.subtask.rawValue: [child]]
+        appState.tasks = [child, parent]
+        MockURLProtocol.requestHandler = { request in
+            (
+                MockURLProtocol.makeResponse(statusCode: 201, url: request.url),
+                #"{"label_id":7}"#.data(using: .utf8)!
+            )
+        }
+
+        let succeeded = await appState.setLabel(label, on: child, present: true)
+
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(appState.tasks[1].subtasks.first?.labels?.map(\.id), [7])
+    }
+}


### PR DESCRIPTION
## Summary

- Adds label assignment and removal from task detail on iOS and macOS.
- Adds a shared searchable label picker.
- Allows creating a label directly from the picker and immediately assigning it.
- Reuses existing labels for case-insensitive exact title matches.
- Uses Vikunja's individual v1 task-label endpoints rather than bulk replacement.
- Generalizes AppState's existing optimistic Current-label behavior for arbitrary labels.
- Keeps live task state, cached tasks, and embedded task snapshots synchronized.
- Rolls failed optimistic mutations back without clobbering newer task state.
- Keeps the PR scoped to label assignment. No offline label queueing or global label administration is included.

## Related Issues

Fixes #4

## Testing

Completed on Windows:

- SwiftFormat 0.62.1
- Swift 5.9 syntax parse
- SwiftLint: 0 errors; the existing repository warning baseline remains
- `git diff --check`
- Throwaway Vikunja v2.5.0 integration checks:
  - label creation
  - individual assignment
  - individual removal

New unit coverage includes:

- optimistic label assignment
- label removal
- add and remove failure rollback
- rollback preserving a newer task `updated` timestamp
- local label deduplication
- create and assign
- case-insensitive existing-label reuse
- Current-label compatibility
- embedded related-task synchronization

Xcode unit tests and iOS and macOS builds have not been run locally because development was performed on Windows. GitHub PR CI should run the iOS unit-test suite on macOS.

## Checklist

- [ ] Builds on iOS and macOS
- [ ] Tests pass
- [x] Ran `swiftlint lint --quiet` and `swiftformat .`
- [x] No breaking changes (or described in summary above)
