### PR TITLE
chore: stop SwiftLint and SwiftFormat fighting over formatting

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,14 @@ excluded:
   - mDone/Resources
 
 disabled_rules:
+  # SwiftFormat owns formatting. `--commas always` in .swiftformat adds the trailing
+  # commas this rule flags, so leaving it enabled makes the two tools undo each other.
+  # Do not re-enable without switching .swiftformat to `--commas inline` first.
+  #
+  # `modifier_order` is left out of opt_in_rules below for the same reason:
+  # SwiftFormat's modifierOrder rule rewrites `nonisolated private` to
+  # `private nonisolated`, which is the order this rule rejects.
+  - trailing_comma
   - trailing_whitespace
   - line_length
   - type_body_length
@@ -20,7 +28,6 @@ opt_in_rules:
   - closure_spacing
   - contains_over_filter_count
   - empty_string
-  - modifier_order
   - overridden_super_call
   - redundant_nil_coalescing
   - toggle_bool


### PR DESCRIPTION
## Summary

`.swiftformat` sets `--commas always`, so SwiftFormat **adds** trailing commas to multi-line collection literals. SwiftLint's `trailing_comma` rule was left enabled, so it **reported** every one of them. Running `swiftformat .` therefore produced warnings that could not be fixed, because hand-removing a comma was undone by the next format run.

The repo showed this happening in both directions: 69 live `trailing_comma` warnings from commas SwiftFormat had added, plus 16 pending SwiftFormat `trailingCommas` findings wanting to re-add commas that had been hand-stripped to silence SwiftLint.

While verifying the fix I found the same conflict a second time, still latent. SwiftFormat's `modifierOrder` rewrites `nonisolated private` to `private nonisolated`, which is exactly the order SwiftLint's opt-in `modifier_order` rule rejects. It affects 4 sites (3 in `AuthService.swift`, 1 in `AppState.swift`) and was quiet only because those files have not been formatted yet. The next person to run `swiftformat .`, as this template's checklist instructs, would have hit fresh unfixable warnings.

Both rules are now disabled in `.swiftlint.yml`, leaving SwiftFormat as the single source of truth for formatting. No Swift sources are touched.

## Related Issues

None, spotted while working in the repo.

## Testing

Verified by formatting a throwaway copy of the entire repo and re-linting it, which tests the real property at stake: that formatting no longer creates lint warnings.

| | SwiftLint violations | `trailing_comma` | `modifier_order` |
|---|---|---|---|
| Before | 79 | 69 | 0 (latent) |
| After, tree as-is | 10 | 0 | 0 |
| After, all 139 files formatted | 9 | 0 | 0 |

Also confirmed per-file: formatting the 6 previously conflicting files leaves SwiftLint silent on both rules, and the 10 violations remaining on the untouched tree are byte-identical to the pre-existing non-comma ones.

The 9 that survive a full format run are 8 `opening_brace` and 1 `function_parameter_count`. Neither is a tool conflict: SwiftFormat does not touch them, so they stay fixed once fixed.

## Checklist

- [x] Builds on iOS and macOS (no Swift sources changed, so compilation is unaffected; CI builds and tests iOS)
- [x] Tests pass (unaffected by a lint config change; CI confirms)
- [x] Ran `swiftlint lint --quiet` and `swiftformat .`
- [x] No breaking changes

Note: `swiftformat --lint .` still reports 43/139 files needing formatting. That is pre-existing drift, identical before and after this change, caused by `.swiftformat` dating from March against newer SwiftFormat rules (`indent`, `wrapIfStatementBodies`, `redundantSwiftUIGroup`). Nothing enforces it, so it has accumulated invisibly. Clearing it is a separate repo-wide reformat, and it is now safe to do since the post-format lint result is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)