### PR TITLE
fix: recover from SwiftData store failures without losing offline edits (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Actions that genuinely need a connection, such as creating a task or a project, now say so immediately instead of spending several seconds retrying first (#146).
 - Completing a task now preserves its colour and favourite status too. 1.12.2 stopped the description, priority and progress being cleared; Vikunja resets these two the same way, so every task update now carries them as well (#147).
+- A damaged local database no longer crashes the app on every launch. mDone used to stop dead if its offline database could not be opened, for instance after a failed upgrade, and the only fix was deleting and reinstalling the app, which threw away any edits you had made offline. It now rescues your unsynced changes and focus history, rebuilds the cached copy of your tasks from the server, and tells you it has done so (#155).
 
 ## [1.12.2] - 2026-08-12
 

--- a/mDone/App/AppDependencies.swift
+++ b/mDone/App/AppDependencies.swift
@@ -5,22 +5,17 @@ struct AppDependencies {
     let modelContainer: ModelContainer
     let networkMonitor: NetworkMonitor
 
+    /// Whether the store had to be rebuilt at launch, so the UI can say so
+    /// rather than the app quietly coming back empty (issue #155).
+    let storeRecovery: StoreRecovery
+
     init() {
-        let schema = Schema([
-            CachedTask.self,
-            CachedProject.self,
-            CachedLabel.self,
-            PendingOperation.self,
-            FocusRecord.self,
-        ])
-
-        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
-
-        do {
-            modelContainer = try ModelContainer(for: schema, configurations: [config])
-        } catch {
-            fatalError("Failed to create ModelContainer: \(error)")
-        }
+        // A store that fails to open used to be a `fatalError`, which crashed
+        // the app on every launch and left reinstalling as the only fix. That
+        // threw away the offline edit queue with it, so recover instead.
+        let outcome = ModelStoreBootstrap.makeContainer()
+        modelContainer = outcome.container
+        storeRecovery = outcome.recovery
 
         networkMonitor = NetworkMonitor()
     }

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -785,6 +785,10 @@ final class AppState {
     /// Changes abandoned after repeated failures, surfaced once and then cleared.
     var failedSyncMessages: [String] = []
 
+    /// Set at launch when the local store had to be rebuilt or fell back to
+    /// memory, so the rebuild is announced rather than silent (issue #155).
+    var storeRecoveryMessage: String?
+
     func hasPendingChanges(_ taskId: Int64) -> Bool {
         pendingTaskIds.contains(taskId)
     }

--- a/mDone/App/ModelStoreBootstrap.swift
+++ b/mDone/App/ModelStoreBootstrap.swift
@@ -1,0 +1,354 @@
+import Foundation
+import SwiftData
+
+/// Why the app is running on a rebuilt or temporary store, so the launch can
+/// tell the user instead of recovering silently (issue #155).
+enum StoreRecovery: Equatable {
+    /// The store opened normally.
+    case none
+
+    /// The store could not be opened, so the re-fetchable cache was rebuilt.
+    /// The counts are the local-only work that was carried across.
+    case cacheRebuilt(pendingOperations: Int, focusRecords: Int)
+
+    /// No store could be opened at all, so this session runs in memory and
+    /// nothing written during it survives a relaunch.
+    case inMemory(pendingOperations: Int, focusRecords: Int)
+
+    /// Alert body for this outcome, or nil when there is nothing to say.
+    var userMessage: String? {
+        switch self {
+        case .none:
+            return nil
+        case let .cacheRebuilt(pendingOperations, focusRecords):
+            var message = "mDone could not open its offline database, so the cached copy of your tasks was rebuilt. Everything reloads from the server."
+            if let carried = Self
+                .carriedOverSentence(pendingOperations: pendingOperations, focusRecords: focusRecords)
+            {
+                message += "\n\n\(carried)"
+            }
+            return message
+        case let .inMemory(pendingOperations, focusRecords):
+            var message = "mDone could not open or recreate its offline database, so it is running without one. Your tasks still load from the server, but anything you change offline will be lost when you quit the app."
+            if let carried = Self
+                .carriedOverSentence(pendingOperations: pendingOperations, focusRecords: focusRecords)
+            {
+                message += "\n\n\(carried) They will be lost if you quit before they are sent."
+            }
+            return message
+        }
+    }
+
+    private static func carriedOverSentence(pendingOperations: Int, focusRecords: Int) -> String? {
+        var parts: [String] = []
+        if pendingOperations > 0 {
+            parts.append(pendingOperations == 1 ? "1 unsynced change" : "\(pendingOperations) unsynced changes")
+        }
+        if focusRecords > 0 {
+            parts.append(focusRecords == 1 ? "1 focus session" : "\(focusRecords) focus sessions")
+        }
+        guard !parts.isEmpty else { return nil }
+        return "\(parts.joined(separator: " and ")) were recovered."
+    }
+}
+
+/// Opens the SwiftData store, and recovers rather than crashing when it cannot.
+///
+/// The store holds two very different kinds of row. `CachedTask`, `CachedProject`
+/// and `CachedLabel` are copies of server state and cost nothing to rebuild.
+/// `PendingOperation` and `FocusRecord` are local-only: the first is the queue of
+/// edits made offline that have not reached Vikunja yet, the second is focus
+/// history that exists nowhere else. So a failed open salvages the local-only
+/// rows first, and only then rebuilds the store around them (issue #155).
+enum ModelStoreBootstrap {
+    struct Outcome {
+        let container: ModelContainer
+        let recovery: StoreRecovery
+    }
+
+    static var schema: Schema {
+        Schema([
+            CachedTask.self,
+            CachedProject.self,
+            CachedLabel.self,
+            PendingOperation.self,
+            FocusRecord.self,
+        ])
+    }
+
+    /// The local-only entities, opened on their own when the full schema fails.
+    /// A schema mismatch or corruption usually only affects some entities, so
+    /// this often succeeds where the full open did not.
+    private static var salvageSchema: Schema {
+        Schema([PendingOperation.self, FocusRecord.self])
+    }
+
+    static func makeContainer() -> Outcome {
+        makeContainer(at: ModelConfiguration(schema: schema, isStoredInMemoryOnly: false).url)
+    }
+
+    static func makeContainer(at url: URL) -> Outcome {
+        let schema = schema
+
+        do {
+            let container = try ModelContainer(
+                for: schema,
+                configurations: [ModelConfiguration(schema: schema, url: url)]
+            )
+            return Outcome(container: container, recovery: .none)
+        } catch {
+            #if DEBUG
+            print("[store] failed to open \(url.lastPathComponent): \(error)")
+            #endif
+        }
+
+        let salvaged = salvage(at: url)
+        #if DEBUG
+        print(
+            "[store] salvaged \(salvaged.pendingOperations.count) pending operations, \(salvaged.focusRecords.count) focus records"
+        )
+        #endif
+
+        // Move the unreadable store aside rather than deleting it. If the open
+        // failed for an environmental reason (no disk space, data still
+        // protected before first unlock) the rows are still on disk, and the
+        // quarantine is undone below so the next launch finds them again.
+        let quarantined = quarantine(at: url)
+
+        do {
+            let container = try ModelContainer(
+                for: schema,
+                configurations: [ModelConfiguration(schema: schema, url: url)]
+            )
+            restore(salvaged, into: container)
+            return Outcome(
+                container: container,
+                recovery: .cacheRebuilt(
+                    pendingOperations: salvaged.pendingOperations.count,
+                    focusRecords: salvaged.focusRecords.count
+                )
+            )
+        } catch {
+            #if DEBUG
+            print("[store] failed to recreate \(url.lastPathComponent): \(error)")
+            #endif
+        }
+
+        if quarantined {
+            unquarantine(at: url)
+        }
+
+        // Last resort: launch on a throwaway store so the app still opens. The
+        // salvaged work rides along so a reconnect during this session can still
+        // flush it.
+        let memoryConfig = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        guard let container = try? ModelContainer(for: schema, configurations: [memoryConfig]) else {
+            // An in-memory container can only fail on a malformed schema, which
+            // is a programming error rather than anything the user can recover
+            // from.
+            fatalError("Failed to create an in-memory ModelContainer")
+        }
+        restore(salvaged, into: container)
+        return Outcome(
+            container: container,
+            recovery: .inMemory(
+                pendingOperations: salvaged.pendingOperations.count,
+                focusRecords: salvaged.focusRecords.count
+            )
+        )
+    }
+
+    // MARK: - Salvage
+
+    struct SalvagedWork: Equatable {
+        var pendingOperations: [PendingOperationSnapshot] = []
+        var focusRecords: [FocusRecordSnapshot] = []
+
+        var isEmpty: Bool {
+            pendingOperations.isEmpty && focusRecords.isEmpty
+        }
+    }
+
+    struct PendingOperationSnapshot: Equatable {
+        var id: UUID
+        var endpointPath: String
+        var method: String
+        var bodyData: Data?
+        var timestamp: Date
+        var retryCount: Int
+        var failed: Bool
+        var kind: String?
+        var taskId: Int64?
+        var failureReason: String?
+    }
+
+    struct FocusRecordSnapshot: Equatable {
+        var taskId: Int64
+        var taskTitle: String
+        var projectName: String
+        var priorityLevel: Int
+        var startedAt: Date
+        var endedAt: Date
+        var focusedSeconds: Double
+        var device: String
+        var clientId: String?
+        var deliveredAt: Date?
+        var discardedAt: Date?
+    }
+
+    /// Reads the local-only rows out of a store that the full schema rejected.
+    /// Everything is copied into value types so nothing keeps the failing store
+    /// alive once this returns.
+    static func salvage(at url: URL) -> SalvagedWork {
+        guard FileManager.default.fileExists(atPath: url.path) else { return SalvagedWork() }
+
+        let schema = salvageSchema
+        guard let container = try? ModelContainer(
+            for: schema,
+            configurations: [ModelConfiguration(schema: schema, url: url)]
+        ) else {
+            #if DEBUG
+            print("[store] nothing could be salvaged from \(url.lastPathComponent)")
+            #endif
+            return SalvagedWork()
+        }
+
+        let context = ModelContext(container)
+        let operations = (try? context.fetch(FetchDescriptor<PendingOperation>())) ?? []
+        let records = (try? context.fetch(FetchDescriptor<FocusRecord>())) ?? []
+
+        return SalvagedWork(
+            pendingOperations: operations.map {
+                PendingOperationSnapshot(
+                    id: $0.id,
+                    endpointPath: $0.endpointPath,
+                    method: $0.method,
+                    bodyData: $0.bodyData,
+                    timestamp: $0.timestamp,
+                    retryCount: $0.retryCount,
+                    failed: $0.failed,
+                    kind: $0.kind,
+                    taskId: $0.taskId,
+                    failureReason: $0.failureReason
+                )
+            },
+            focusRecords: records.map {
+                FocusRecordSnapshot(
+                    taskId: $0.taskId,
+                    taskTitle: $0.taskTitle,
+                    projectName: $0.projectName,
+                    priorityLevel: $0.priorityLevel,
+                    startedAt: $0.startedAt,
+                    endedAt: $0.endedAt,
+                    focusedSeconds: $0.focusedSeconds,
+                    device: $0.device,
+                    clientId: $0.clientId,
+                    deliveredAt: $0.deliveredAt,
+                    discardedAt: $0.discardedAt
+                )
+            }
+        )
+    }
+
+    /// Writes salvaged rows back into a freshly opened store.
+    @discardableResult
+    static func restore(_ salvaged: SalvagedWork, into container: ModelContainer) -> Bool {
+        guard !salvaged.isEmpty else { return true }
+
+        let context = ModelContext(container)
+
+        for snapshot in salvaged.pendingOperations {
+            let operation = PendingOperation(
+                endpointPath: snapshot.endpointPath,
+                method: snapshot.method,
+                bodyData: snapshot.bodyData,
+                kind: snapshot.kind.flatMap(PendingOperation.Kind.init(rawValue:)),
+                taskId: snapshot.taskId
+            )
+            // The initialiser stamps a fresh id and timestamp; the queue replays
+            // in timestamp order and coalesces by id, so both have to survive.
+            operation.id = snapshot.id
+            operation.timestamp = snapshot.timestamp
+            operation.retryCount = snapshot.retryCount
+            operation.failed = snapshot.failed
+            operation.failureReason = snapshot.failureReason
+            context.insert(operation)
+        }
+
+        for snapshot in salvaged.focusRecords {
+            context.insert(FocusRecord(
+                taskId: snapshot.taskId,
+                taskTitle: snapshot.taskTitle,
+                projectName: snapshot.projectName,
+                priorityLevel: snapshot.priorityLevel,
+                startedAt: snapshot.startedAt,
+                endedAt: snapshot.endedAt,
+                focusedSeconds: snapshot.focusedSeconds,
+                device: snapshot.device,
+                clientId: snapshot.clientId,
+                deliveredAt: snapshot.deliveredAt,
+                discardedAt: snapshot.discardedAt
+            ))
+        }
+
+        do {
+            try context.save()
+            return true
+        } catch {
+            #if DEBUG
+            print("[store] failed to restore salvaged work: \(error)")
+            #endif
+            return false
+        }
+    }
+
+    // MARK: - Store files
+
+    /// SQLite keeps its write-ahead log and shared memory alongside the store,
+    /// and all three have to move together.
+    private static func storeFiles(for url: URL) -> [URL] {
+        [url, URL(fileURLWithPath: url.path + "-wal"), URL(fileURLWithPath: url.path + "-shm")]
+    }
+
+    private static func quarantineURL(for url: URL) -> URL {
+        URL(fileURLWithPath: url.path + ".quarantined")
+    }
+
+    /// Moves the unreadable store to a single fixed backup location, replacing
+    /// any earlier backup so these cannot pile up.
+    @discardableResult
+    private static func quarantine(at url: URL) -> Bool {
+        let manager = FileManager.default
+        guard manager.fileExists(atPath: url.path) else { return false }
+
+        var moved = false
+        for file in storeFiles(for: url) {
+            let destination = quarantineURL(for: file)
+            try? manager.removeItem(at: destination)
+            guard manager.fileExists(atPath: file.path) else { continue }
+            do {
+                try manager.moveItem(at: file, to: destination)
+                moved = true
+            } catch {
+                #if DEBUG
+                print("[store] could not quarantine \(file.lastPathComponent): \(error)")
+                #endif
+                try? manager.removeItem(at: file)
+            }
+        }
+        return moved
+    }
+
+    /// Puts a quarantined store back, for when recreating the store failed too.
+    /// The failure was environmental rather than the store's fault, so the next
+    /// launch should get the original rows.
+    private static func unquarantine(at url: URL) {
+        let manager = FileManager.default
+        for file in storeFiles(for: url) {
+            let source = quarantineURL(for: file)
+            guard manager.fileExists(atPath: source.path) else { continue }
+            try? manager.removeItem(at: file)
+            try? manager.moveItem(at: source, to: file)
+        }
+    }
+}

--- a/mDone/App/mDoneApp.swift
+++ b/mDone/App/mDoneApp.swift
@@ -28,6 +28,7 @@ struct mDoneApp: App {
             ),
             networkMonitor: deps.networkMonitor
         )
+        state.storeRecoveryMessage = deps.storeRecovery.userMessage
         _appState = State(initialValue: state)
 
         #if os(iOS)

--- a/mDone/Views/Mac/MacContentView.swift
+++ b/mDone/Views/Mac/MacContentView.swift
@@ -82,5 +82,22 @@ struct MacContentView: View {
         } message: {
             Text(appState.failedSyncMessages.joined(separator: "\n\n"))
         }
+        // A rebuilt local store must not be silent: the user's cached tasks
+        // are gone until the next refresh (issue #155).
+        .alert(
+            "Offline database rebuilt",
+            isPresented: Binding(
+                get: { appState.storeRecoveryMessage != nil },
+                set: {
+                    if !$0 {
+                        appState.storeRecoveryMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK", role: .cancel) { appState.storeRecoveryMessage = nil }
+        } message: {
+            Text(appState.storeRecoveryMessage ?? "")
+        }
     }
 }

--- a/mDone/Views/MainTabView.swift
+++ b/mDone/Views/MainTabView.swift
@@ -83,6 +83,23 @@ struct MainTabView: View {
         } message: {
             Text(appState.failedSyncMessages.joined(separator: "\n\n"))
         }
+        // A rebuilt local store must not be silent: the user's cached tasks
+        // are gone until the next refresh (issue #155).
+        .alert(
+            "Offline database rebuilt",
+            isPresented: Binding(
+                get: { appState.storeRecoveryMessage != nil },
+                set: {
+                    if !$0 {
+                        appState.storeRecoveryMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK", role: .cancel) { appState.storeRecoveryMessage = nil }
+        } message: {
+            Text(appState.storeRecoveryMessage ?? "")
+        }
         .onShake {
             if appState.canUndoLastCompletion {
                 showUndoCompletionPrompt = true

--- a/mDoneTests/Helpers/LegacyStoreFixtures.swift
+++ b/mDoneTests/Helpers/LegacyStoreFixtures.swift
@@ -1,0 +1,23 @@
+import Foundation
+import SwiftData
+
+/// A store written before `CachedTask` had its current shape: `title` is typed
+/// differently, which SwiftData cannot migrate automatically. Used to prove the
+/// recovery path in issue #155 salvages offline work from a store the app's own
+/// schema rejects.
+///
+/// SwiftData keys entities off the unqualified class name, so nesting this keeps
+/// it out of the way of the app's `CachedTask` in Swift while still colliding
+/// with it in the store.
+enum LegacyStore {
+    @Model
+    final class CachedTask {
+        @Attribute(.unique) var id: Int64
+        var title: Int64
+
+        init(id: Int64, title: Int64) {
+            self.id = id
+            self.title = title
+        }
+    }
+}

--- a/mDoneTests/ModelStoreRecoveryTests.swift
+++ b/mDoneTests/ModelStoreRecoveryTests.swift
@@ -1,0 +1,280 @@
+import Foundation
+import SwiftData
+import XCTest
+@testable import mDone
+
+/// Covers issue #155: a store that will not open used to `fatalError` on every
+/// launch, and the only user-side fix (reinstalling) silently destroyed the
+/// queue of edits made offline.
+final class ModelStoreRecoveryTests: XCTestCase {
+    private var directory: URL!
+    private var storeURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("store-recovery-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        storeURL = directory.appendingPathComponent("default.store")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Fixtures
+
+    private func makeStore(pendingOperations: Int = 0, focusRecords: Int = 0) throws {
+        let schema = ModelStoreBootstrap.schema
+        let container = try ModelContainer(
+            for: schema,
+            configurations: [ModelConfiguration(schema: schema, url: storeURL)]
+        )
+        let context = ModelContext(container)
+
+        for index in 0 ..< pendingOperations {
+            let operation = PendingOperation(
+                endpointPath: "/tasks/\(index)",
+                method: "POST",
+                bodyData: Data("edit-\(index)".utf8),
+                kind: .taskEdit,
+                taskId: Int64(index)
+            )
+            operation.retryCount = index
+            context.insert(operation)
+        }
+
+        for index in 0 ..< focusRecords {
+            context.insert(FocusRecord(
+                taskId: Int64(index),
+                taskTitle: "Focus \(index)",
+                projectName: "Inbox",
+                priorityLevel: 3,
+                startedAt: Date(timeIntervalSince1970: 1000 + Double(index)),
+                endedAt: Date(timeIntervalSince1970: 2000 + Double(index)),
+                focusedSeconds: 1500,
+                device: "iPhone"
+            ))
+        }
+
+        try context.save()
+    }
+
+    private func corruptStore() throws {
+        try Data(repeating: 0xAB, count: 4096).write(to: storeURL)
+    }
+
+    private func counts(in container: ModelContainer) throws -> (operations: Int, records: Int) {
+        let context = ModelContext(container)
+        return try (
+            context.fetchCount(FetchDescriptor<PendingOperation>()),
+            context.fetchCount(FetchDescriptor<FocusRecord>())
+        )
+    }
+
+    // MARK: - Healthy store
+
+    func testHealthyStoreOpensUntouched() throws {
+        try makeStore(pendingOperations: 2, focusRecords: 1)
+
+        let outcome = ModelStoreBootstrap.makeContainer(at: storeURL)
+
+        XCTAssertEqual(outcome.recovery, StoreRecovery.none)
+        let counts = try counts(in: outcome.container)
+        XCTAssertEqual(counts.operations, 2)
+        XCTAssertEqual(counts.records, 1)
+    }
+
+    // MARK: - Corrupted store
+
+    func testCorruptedStoreStillLaunches() throws {
+        try corruptStore()
+
+        let outcome = ModelStoreBootstrap.makeContainer(at: storeURL)
+
+        // The point of the fix: a container comes back rather than a crash.
+        XCTAssertEqual(outcome.recovery, .cacheRebuilt(pendingOperations: 0, focusRecords: 0))
+        let counts = try counts(in: outcome.container)
+        XCTAssertEqual(counts.operations, 0)
+        XCTAssertEqual(counts.records, 0)
+    }
+
+    func testCorruptedStoreIsQuarantinedNotDeleted() throws {
+        try corruptStore()
+
+        _ = ModelStoreBootstrap.makeContainer(at: storeURL)
+
+        let quarantined = URL(fileURLWithPath: storeURL.path + ".quarantined")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: quarantined.path))
+        XCTAssertEqual(try Data(contentsOf: quarantined), Data(repeating: 0xAB, count: 4096))
+    }
+
+    func testSalvageReturnsNothingForAnUnreadableStore() throws {
+        try corruptStore()
+
+        XCTAssertTrue(ModelStoreBootstrap.salvage(at: storeURL).isEmpty)
+    }
+
+    func testSalvageReturnsNothingWhenThereIsNoStore() {
+        XCTAssertTrue(ModelStoreBootstrap.salvage(at: storeURL).isEmpty)
+    }
+
+    // MARK: - Salvaging offline work
+
+    func testSalvageReadsPendingOperationsAndFocusRecords() throws {
+        try makeStore(pendingOperations: 3, focusRecords: 2)
+
+        let salvaged = ModelStoreBootstrap.salvage(at: storeURL)
+
+        XCTAssertEqual(salvaged.pendingOperations.count, 3)
+        XCTAssertEqual(salvaged.focusRecords.count, 2)
+        let paths = Set(salvaged.pendingOperations.map(\.endpointPath))
+        XCTAssertEqual(paths, ["/tasks/0", "/tasks/1", "/tasks/2"])
+    }
+
+    /// The real regression: a rebuilt store has to come back with the offline
+    /// edit queue intact, including the fields the queue replays on.
+    func testRebuildRestoresPendingOperationsIntact() throws {
+        try makeStore(pendingOperations: 2, focusRecords: 1)
+        let salvaged = ModelStoreBootstrap.salvage(at: storeURL)
+        try FileManager.default.removeItem(at: storeURL)
+
+        let outcome = ModelStoreBootstrap.makeContainer(at: storeURL)
+        XCTAssertTrue(ModelStoreBootstrap.restore(salvaged, into: outcome.container))
+
+        let context = ModelContext(outcome.container)
+        let restored = try context.fetch(FetchDescriptor<PendingOperation>())
+            .sorted { $0.endpointPath < $1.endpointPath }
+        XCTAssertEqual(restored.count, 2)
+
+        let expected = salvaged.pendingOperations.sorted { $0.endpointPath < $1.endpointPath }
+        for (operation, snapshot) in zip(restored, expected) {
+            XCTAssertEqual(operation.id, snapshot.id)
+            XCTAssertEqual(operation.endpointPath, snapshot.endpointPath)
+            XCTAssertEqual(operation.method, snapshot.method)
+            XCTAssertEqual(operation.bodyData, snapshot.bodyData)
+            XCTAssertEqual(operation.timestamp, snapshot.timestamp)
+            XCTAssertEqual(operation.retryCount, snapshot.retryCount)
+            XCTAssertEqual(operation.failed, snapshot.failed)
+            XCTAssertEqual(operation.kind, snapshot.kind)
+            XCTAssertEqual(operation.taskId, snapshot.taskId)
+        }
+
+        let records = try context.fetch(FetchDescriptor<FocusRecord>())
+        XCTAssertEqual(records.count, 1)
+        XCTAssertNil(records.first?.deliveredAt, "an undelivered record must stay undelivered so the outbox retries it")
+    }
+
+    func testRestoreIsANoOpForEmptySalvage() throws {
+        let outcome = ModelStoreBootstrap.makeContainer(at: storeURL)
+
+        XCTAssertTrue(ModelStoreBootstrap.restore(ModelStoreBootstrap.SalvagedWork(), into: outcome.container))
+        let counts = try counts(in: outcome.container)
+        XCTAssertEqual(counts.operations, 0)
+        XCTAssertEqual(counts.records, 0)
+    }
+
+    // MARK: - Schema mismatch
+
+    /// A migration the store cannot perform is the other way this fails in the
+    /// wild. The store here holds only the local-only entities, so opening it
+    /// with the full schema has to add the cache entities.
+    func testStoreWrittenWithAnOlderSchemaKeepsPendingWork() throws {
+        let oldSchema = Schema([PendingOperation.self, FocusRecord.self])
+        let container = try ModelContainer(
+            for: oldSchema,
+            configurations: [ModelConfiguration(schema: oldSchema, url: storeURL)]
+        )
+        let context = ModelContext(container)
+        context.insert(PendingOperation(endpointPath: "/tasks/7", method: "POST", kind: .taskEdit, taskId: 7))
+        try context.save()
+
+        let outcome = ModelStoreBootstrap.makeContainer(at: storeURL)
+
+        // Whether SwiftData migrates this in place or the recovery path rebuilds
+        // it, the queued edit has to still be there afterwards.
+        let restored = try ModelContext(outcome.container).fetch(FetchDescriptor<PendingOperation>())
+        XCTAssertEqual(restored.count, 1)
+        XCTAssertEqual(restored.first?.taskId, 7)
+    }
+
+    // MARK: - Messages
+
+    func testNoRecoveryHasNoMessage() {
+        XCTAssertNil(StoreRecovery.none.userMessage)
+    }
+
+    func testRebuiltMessageMentionsRecoveredWork() throws {
+        let message = try XCTUnwrap(StoreRecovery.cacheRebuilt(pendingOperations: 2, focusRecords: 1).userMessage)
+
+        XCTAssertTrue(message.contains("2 unsynced changes"))
+        XCTAssertTrue(message.contains("1 focus session"))
+        XCTAssertFalse(message.contains("\u{2014}"), "repo style: no em-dashes in user-facing copy")
+    }
+
+    func testRebuiltMessageOmitsCountsWhenNothingWasRecovered() throws {
+        let message = try XCTUnwrap(StoreRecovery.cacheRebuilt(pendingOperations: 0, focusRecords: 0).userMessage)
+
+        XCTAssertFalse(message.contains("recovered"))
+    }
+
+    func testInMemoryMessageWarnsChangesWillNotPersist() throws {
+        let message = try XCTUnwrap(StoreRecovery.inMemory(pendingOperations: 0, focusRecords: 0).userMessage)
+
+        XCTAssertTrue(message.lowercased().contains("lost"))
+    }
+}
+
+extension ModelStoreRecoveryTests {
+    /// The case the fix exists for: the store cannot be opened with the current
+    /// schema, but the offline edit queue inside it is still readable and has to
+    /// come back.
+    func testSchemaMismatchRebuildsCacheAndKeepsPendingWork() throws {
+        let legacySchema = Schema([LegacyStore.CachedTask.self, PendingOperation.self, FocusRecord.self])
+        let legacy = try ModelContainer(
+            for: legacySchema,
+            configurations: [ModelConfiguration(schema: legacySchema, url: storeURL)]
+        )
+        let seeding = ModelContext(legacy)
+        seeding.insert(LegacyStore.CachedTask(id: 1, title: 99))
+        let queued = PendingOperation(
+            endpointPath: "/tasks/42",
+            method: "POST",
+            bodyData: Data("offline edit".utf8),
+            kind: .taskEdit,
+            taskId: 42
+        )
+        seeding.insert(queued)
+        seeding.insert(FocusRecord(
+            taskId: 42,
+            taskTitle: "Write the fix",
+            projectName: "mDone",
+            priorityLevel: 3,
+            startedAt: Date(timeIntervalSince1970: 1000),
+            endedAt: Date(timeIntervalSince1970: 2500),
+            focusedSeconds: 1500,
+            device: "iPhone"
+        ))
+        try seeding.save()
+
+        let outcome = ModelStoreBootstrap.makeContainer(at: storeURL)
+
+        XCTAssertEqual(outcome.recovery, .cacheRebuilt(pendingOperations: 1, focusRecords: 1))
+
+        let context = ModelContext(outcome.container)
+        let operations = try context.fetch(FetchDescriptor<PendingOperation>())
+        XCTAssertEqual(operations.count, 1)
+        XCTAssertEqual(operations.first?.id, queued.id)
+        XCTAssertEqual(operations.first?.taskId, 42)
+        XCTAssertEqual(operations.first?.bodyData, Data("offline edit".utf8))
+        XCTAssertEqual(operations.first?.operationKind, .taskEdit)
+
+        let records = try context.fetch(FetchDescriptor<FocusRecord>())
+        XCTAssertEqual(records.count, 1)
+        XCTAssertNil(records.first?.deliveredAt)
+
+        // The cache is the part that is safe to lose: it reloads from the server.
+        XCTAssertEqual(try context.fetchCount(FetchDescriptor<CachedTask>()), 0)
+    }
+}


### PR DESCRIPTION
## Summary

`AppDependencies.init()` called `fatalError` when `ModelContainer` creation failed, so a corrupted store or a failed migration crashed the app on every launch. The only user-side fix, deleting and reinstalling, also destroyed the `PendingOperation` queue holding edits made offline, which is a worse outcome than the crash for anyone who has been working without a connection.

New `ModelStoreBootstrap` (mDone/App/ModelStoreBootstrap.swift) handles a failed open in four steps:

1. **Salvage first.** `PendingOperation` and `FocusRecord` rows are read out into value types, opening the store with a schema containing only those two entities. A schema problem confined to the cache entities does not block the read, which is what makes the recovery worth attempting at all.
2. **Quarantine, do not delete.** The unreadable store (plus its `-wal` and `-shm` sidecars) moves to a single fixed `.quarantined` path, replacing any earlier backup so these cannot pile up. If recreating the store then also fails, the move is undone, so an environmental failure (no disk space, data still protected before first unlock) never destroys a good store.
3. **Rebuild and restore.** The cache entities come back empty, since they are all re-fetchable from the server. Salvaged rows are reinserted with their `id`, `timestamp`, `retryCount` and `failed` preserved: the queue replays in timestamp order and coalesces by id, so a fresh id or timestamp would change replay behaviour. `FocusRecord.deliveredAt` is preserved for the same reason, `FocusOutboxService` uses `nil` as its pending marker.
4. **In-memory last resort.** If no on-disk store can be opened, the app still launches on a throwaway container, with the salvaged work carried across so a reconnect during that session can still flush it.

The outcome is reported through `AppState.storeRecoveryMessage` and surfaced as an alert in both `MainTabView` and `MacContentView`, so a rebuild is never silent. The in-memory case says explicitly that offline changes will not survive quitting. All diagnostic logging is `#if DEBUG`.

## Related Issues

Fixes #155

## Testing

14 new cases in `mDoneTests/ModelStoreRecoveryTests.swift`, covering both scenarios the issue asked for:

- **Schema mismatch** (`testSchemaMismatchRebuildsCacheAndKeepsPendingWork`): a store whose `CachedTask.title` has a type SwiftData cannot migrate. The full open genuinely fails, and the test asserts `.cacheRebuilt(pendingOperations: 1, focusRecords: 1)` with the queued edit's id, `taskId`, body data and kind all intact, the focus record still undelivered, and the cache empty. The legacy fixture lives in `mDoneTests/Helpers/LegacyStoreFixtures.swift`, nested inside an enum so it collides with `CachedTask` in the store without shadowing it in Swift.
- **Corruption**: a store overwritten with garbage still yields a working container rather than a crash, and the corrupt bytes are found intact at the quarantine path afterwards.
- Healthy store opens untouched, salvage handles a missing or unreadable store, restore round-trips every replay-relevant field, and the alert copy is checked for the recovered counts.

Verified locally:

- 554 `mDoneTests` cases pass on the iOS Simulator
- `mDone-macOS` builds
- New files are clean under both `swiftlint lint --quiet` and `swiftformat`

## Checklist

- [x] Builds on iOS and macOS
- [x] Tests pass
- [x] Ran `swiftlint lint --quiet` and `swiftformat .`
- [x] No breaking changes (or described in summary above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
