### PR TITLE
feat: adaptive sidebar and hardware keyboard shortcuts on iPad (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- On iPad the tab bar can now expand into a sidebar, making better use of the larger screen (#34).
+- Hardware keyboard shortcuts on iPhone and iPad: Cmd-N new task, Cmd-R refresh, and Cmd-1 to Cmd-4 to switch sections. Hold Cmd to see them listed (#34).
 - You can now edit tasks while offline. Completing a task, rescheduling it, changing its progress, editing its details or deleting it all take effect straight away and sync when you reconnect. Rows with changes still waiting show a "Not synced" marker, and the offline banner tells you how many are queued. Previously these actions did nothing for several seconds, then failed with an error that faded away (#146).
 - Queued changes are merged rather than replayed blindly. When your change reaches the server, only the fields you actually edited are applied, so an edit made offline no longer overwrites something you or someone else changed elsewhere in the meantime (#146).
 - If a queued change can never be delivered, for example because the task was deleted elsewhere, the app now tells you which change it was and why, instead of dropping it silently (#146).

--- a/mDone/Views/MainTabView.swift
+++ b/mDone/Views/MainTabView.swift
@@ -47,6 +47,10 @@ struct MainTabView: View {
                 }
             }
         }
+        // On iPad this turns the tab bar into a proper sidebar (the user can
+        // collapse it back to a tab bar); on iPhone it stays a plain tab bar.
+        .tabViewStyle(.sidebarAdaptable)
+        .background { keyboardShortcuts }
         .tint(Color.accentColor)
         .task {
             await appState.refreshAll()
@@ -104,6 +108,37 @@ struct MainTabView: View {
     }
 
     #if os(iOS)
+    /// Hardware-keyboard shortcuts (iPad with a keyboard, mainly). The buttons
+    /// are invisible: they exist only to carry the key equivalents, and their
+    /// titles are what the hold-Command discoverability overlay displays.
+    private var keyboardShortcuts: some View {
+        Group {
+            Button("New Task") {
+                // Same pipeline as the widget and the Shortcuts action: the
+                // onChange above switches to Inbox, QuickAddBar grabs focus.
+                appState.quickAddTrigger = UUID()
+            }
+            .keyboardShortcut("n", modifiers: .command)
+
+            Button("Refresh") {
+                Task { await appState.refreshAll() }
+            }
+            .keyboardShortcut("r", modifiers: .command)
+
+            Button("Inbox") { selectedTab = .inbox }
+                .keyboardShortcut("1", modifiers: .command)
+            Button("Projects") { selectedTab = .projects }
+                .keyboardShortcut("2", modifiers: .command)
+            Button("Calendar") { selectedTab = .calendar }
+                .keyboardShortcut("3", modifiers: .command)
+            Button("Settings") { selectedTab = .settings }
+                .keyboardShortcut("4", modifiers: .command)
+        }
+        .opacity(0)
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
     private var undoPromptTitle: String {
         if let title = appState.undoableCompletionTitle {
             return "Undo completing \u{201C}\(title)\u{201D}?"


### PR DESCRIPTION
First slice of #34: the cheap wins that make the iPad app feel intentional without touching the navigation architecture.

## What changed

- `MainTabView` adopts `.tabViewStyle(.sidebarAdaptable)`. On iPad the tab bar becomes a floating top bar with a real sidebar the user can toggle; on iPhone nothing changes.
- Hardware keyboard shortcuts on iOS, carried by invisible buttons whose titles feed the hold-Command discoverability overlay:
  - Cmd-N: quick add. Reuses the existing `quickAddTrigger` pipeline (same path as the widget shortcut and the Shortcuts action), so it switches to Inbox and focuses the quick-add bar.
  - Cmd-R: refresh all.
  - Cmd-1 to Cmd-4: switch between Inbox, Projects, Calendar, Settings.

Also confirmed as already fine, so no changes needed: the app icon is a single universal 1024pt asset (covers iPad), and the widget extension already builds for iPad.

## What was tried and dropped

Cmd-F to open search. iOS consumes Cmd-F ahead of app-level key equivalents (system find interaction), and even SwiftUI's own `searchable` field ignores it in this layout; verified on the iPad simulator that neither a custom binding nor the native one presents the search field, while the identical Cmd-N binding works. Shipping a dead shortcut is worse than omitting it; search stays reachable via the toolbar magnifier. Worth revisiting in the bigger iPad layout PR.

## Verification

- Built for iPad Pro 11-inch (M4) and iPhone; `mDoneTests` pass locally (iPhone 17 simulator, iOS 26).
- Verified on the iPad simulator against a throwaway dev Vikunja: adaptive top tab bar renders, the sidebar opens with all four sections and collapses back, and Cmd-N from a hardware keyboard focuses the quick-add bar.
- Cmd-R and Cmd-1 to Cmd-4 cannot be exercised in the iOS Simulator because Simulator.app claims those exact keys for its own menus (Record Screen, window scaling, Fit Screen). They use the identical mechanism as the verified Cmd-N; a once-over on a physical iPad with a keyboard is the remaining manual check.

Closes nothing yet; #34's layout, multitasking and detail-panel work remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)