### PR TITLE
feat: sign in with single sign-on via OIDC (#153)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ vikunja-dev-data/
 
 # Claude Code
 .claude/
+
+# Dev OIDC stack (docker-compose.oidc.yml)
+dev/vikunja/config.yml
+.env.oidc
+dev/certs/
+dev/authelia/oidc.key

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ dev/vikunja/config.yml
 .env.oidc
 dev/certs/
 dev/authelia/oidc.key
+
+# Isolated macOS OIDC test build (scripts/dev-macos-oidc.sh)
+.build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - On iPad the tab bar can now expand into a sidebar, making better use of the larger screen (#34).
 - Hardware keyboard shortcuts on iPhone and iPad: Cmd-N new task, Cmd-R refresh, and Cmd-1 to Cmd-4 to switch sections. Hold Cmd to see them listed (#34).
+- You can now sign in with single sign-on. If your Vikunja is set up with an OIDC provider such as Authelia, Keycloak or Authentik, the login screen offers a "Continue with ..." button for it. Sign-in happens in the system browser, so you can see the real address of the page you are typing your password into, and the app never sees it (#153).
+- The login screen now adapts to your server. If your server has username and password login turned off, those fields are hidden rather than shown and then failing with "Not Found" (#153).
 - You can now edit tasks while offline. Completing a task, rescheduling it, changing its progress, editing its details or deleting it all take effect straight away and sync when you reconnect. Rows with changes still waiting show a "Not synced" marker, and the offline banner tells you how many are queued. Previously these actions did nothing for several seconds, then failed with an error that faded away (#146).
 - Queued changes are merged rather than replayed blindly. When your change reaches the server, only the fields you actually edited are applied, so an edit made offline no longer overwrites something you or someone else changed elsewhere in the meantime (#146).
 - If a queued change can never be delivered, for example because the task was deleted elsewhere, the app now tells you which change it was and why, instead of dropping it silently (#146).

--- a/dev/authelia/configuration.yml
+++ b/dev/authelia/configuration.yml
@@ -1,0 +1,82 @@
+###############################################################################
+# Dev-only Authelia, acting as an OIDC provider for the throwaway Vikunja in
+# docker-compose.dev.yml. See docs/dev-setup.md.
+#
+# Every secret in here is a literal, committed, dev-only string. Nothing in
+# this file is safe to reuse anywhere real.
+#
+# DEV_BASE is injected by scripts/dev-oidc-up.sh as <lan-ip>.nip.io, so the
+# same hostname resolves from the Mac, the iOS Simulator and from inside the
+# other containers. See the note in docker-compose.dev.yml for why.
+###############################################################################
+
+theme: 'light'
+
+log:
+  level: 'info'
+
+server:
+  address: 'tcp://0.0.0.0:9091'
+
+identity_validation:
+  reset_password:
+    jwt_secret: 'dev-only-authelia-reset-jwt-secret-not-real'
+
+authentication_backend:
+  password_reset:
+    disable: true
+  file:
+    path: '/config/users_database.yml'
+
+access_control:
+  default_policy: 'one_factor'
+
+session:
+  secret: 'dev-only-authelia-session-secret-not-real'
+  cookies:
+    - name: 'authelia_session'
+      # Parent of both vikunja.* and auth.*, so the session cookie covers both.
+      domain: '{{ env "DEV_BASE" }}'
+      authelia_url: 'https://auth.{{ env "DEV_BASE" }}:8443'
+      default_redirection_url: 'https://vikunja.{{ env "DEV_BASE" }}:8443'
+
+storage:
+  encryption_key: 'dev-only-authelia-storage-encryption-key-not-real'
+  local:
+    path: '/config/db.sqlite3'
+
+notifier:
+  # Writes "emails" to a file instead of sending them.
+  filesystem:
+    filename: '/config/notification.txt'
+
+identity_providers:
+  oidc:
+    hmac_secret: 'dev-only-authelia-oidc-hmac-secret-not-real'
+    jwks:
+      - key_id: 'dev'
+        algorithm: 'RS256'
+        use: 'sig'
+        key: {{ secret "/config/oidc.key" | mindent 10 "|" | msquote }}
+    clients:
+      - client_id: 'vikunja'
+        client_name: 'Vikunja (dev)'
+        # $plaintext$ prefix keeps the dev secret readable. Real deployments
+        # store a PBKDF2 hash here instead.
+        client_secret: '$plaintext$vikunja-dev-client-secret'
+        public: false
+        authorization_policy: 'one_factor'
+        require_pkce: false
+        consent_mode: 'implicit'
+        redirect_uris:
+          # The web frontend's URI, and the custom scheme a native app would
+          # use. Registering both is what a self-hoster running web + app would
+          # have to do. See the callback-shape investigation for issue #153.
+          - 'https://vikunja.{{ env "DEV_BASE" }}:8443/auth/openid/authelia'
+          - 'mdone://oidc-callback'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_post'

--- a/dev/authelia/users_database.yml
+++ b/dev/authelia/users_database.yml
@@ -1,0 +1,12 @@
+# Dev-only user database for the throwaway Authelia in docker-compose.dev.yml.
+# Password is "devpassword" (argon2id hash below).
+# Never reuse these anywhere that matters.
+users:
+  devuser:
+    disabled: false
+    displayname: 'Dev User'
+    # devpassword
+    password: '$argon2id$v=19$m=65536,t=3,p=4$gMo5BYE1lJbT+5605phJXg$cE5TbOoBq5MWrSS9qBUWWZmeSZt1nyyQ3C4QmadvGmg'
+    email: 'devuser@example.com'
+    groups:
+      - 'admins'

--- a/dev/caddy/Caddyfile
+++ b/dev/caddy/Caddyfile
@@ -1,0 +1,21 @@
+# Dev-only TLS terminator for the OIDC stack. Gives Vikunja and Authelia two
+# real hostnames on one mkcert-issued wildcard certificate, which is what lets
+# the whole flow run over https.
+#
+# https is not optional here: Authelia refuses a plaintext `authelia_url`, and
+# iOS App Transport Security would block a cleartext identity provider, so
+# testing over http would need an ATS exception we do not want to ship.
+{
+	auto_https off
+	admin off
+}
+
+https://vikunja.{$DEV_BASE}:8443 {
+	tls /certs/cert.pem /certs/key.pem
+	reverse_proxy vikunja:3456
+}
+
+https://auth.{$DEV_BASE}:8443 {
+	tls /certs/cert.pem /certs/key.pem
+	reverse_proxy authelia:9091
+}

--- a/dev/vikunja/config.yml.template
+++ b/dev/vikunja/config.yml.template
@@ -1,0 +1,30 @@
+# Generated into dev/vikunja/config.yml by scripts/dev-oidc-up.sh.
+# Do not edit the generated file, edit this template.
+#
+# Only the OIDC bits live here. Everything else stays in the environment block
+# of docker-compose.dev.yml, and environment wins over this file in Vikunja.
+auth:
+  local:
+    enabled: ${VIKUNJA_LOCAL_AUTH}
+  openid:
+    enabled: true
+    # Vikunja appends the provider key to this, giving
+    # .../auth/openid/authelia, which is what dev/authelia/configuration.yml
+    # registers as the client's only redirect URI.
+    #
+    # Known limitation carried over from the #103 review: this assumes the API
+    # and the Vikunja frontend share an origin.
+    redirecturl: https://vikunja.${DEV_BASE}:8443/auth/openid/
+    #
+    # `providers` is a MAP keyed by provider key, not a list. Vikunja v2.4.0
+    # rejects the list form that most guides and older docs show, with only
+    # "It looks like your openid configuration is in the wrong format" in the
+    # log and `"providers": null` in /api/v1/info. The key here ("authelia")
+    # becomes the `key` field in that payload and the last path segment of
+    # both the redirect URI and the callback endpoint.
+    providers:
+      authelia:
+        name: Authelia
+        authurl: https://auth.${DEV_BASE}:8443
+        clientid: vikunja
+        clientsecret: vikunja-dev-client-secret

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,7 +15,8 @@ services:
     volumes:
       - ./vikunja-dev-data/files:/app/vikunja/files
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3456/api/v1/info"]
+      # The image has no shell, wget or curl, so probe with the binary itself.
+      test: ["CMD", "/app/vikunja/vikunja", "healthcheck"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/docker-compose.oidc.yml
+++ b/docker-compose.oidc.yml
@@ -1,0 +1,64 @@
+###############################################################################
+# Overlay that puts an Authelia OIDC provider and a TLS terminator in front of
+# the dev Vikunja, for work on issue #153. Never used on its own, always via:
+#
+#   ./scripts/dev-oidc-up.sh
+#
+# Two things drive the shape of this file.
+#
+# 1. One hostname has to resolve to the same place from three vantage points:
+#    the Mac, the iOS Simulator, and the Vikunja container doing the
+#    server-side token exchange. "localhost" cannot, because inside a container
+#    it means that container. DEV_BASE is <lan-ip>.nip.io, public wildcard DNS
+#    that maps the embedded IP straight back, so all three agree. Needs DNS.
+#
+# 2. Everything is https. Authelia rejects a plaintext authelia_url, and iOS
+#    App Transport Security would block a cleartext identity provider, so an
+#    http stack would need an ATS exception we do not want to ship. Caddy
+#    terminates TLS with a mkcert-issued wildcard for *.DEV_BASE.
+###############################################################################
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    container_name: mdone-caddy-dev
+    restart: unless-stopped
+    ports:
+      - "8443:8443"
+    environment:
+      DEV_BASE: "${DEV_BASE:?run scripts/dev-oidc-up.sh, do not invoke compose directly}"
+    volumes:
+      - ./dev/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./dev/certs:/certs:ro
+    depends_on:
+      - vikunja
+      - authelia
+
+  authelia:
+    image: authelia/authelia:4.39
+    container_name: mdone-authelia-dev
+    restart: unless-stopped
+    expose:
+      - "9091"
+    environment:
+      DEV_BASE: "${DEV_BASE}"
+      # Enables Go templating in configuration.yml, which is how DEV_BASE and
+      # the JWKS private key get injected.
+      X_AUTHELIA_CONFIG_FILTERS: "template"
+    volumes:
+      - ./dev/authelia/configuration.yml:/config/configuration.yml:ro
+      - ./dev/authelia/users_database.yml:/config/users_database.yml:ro
+      - ./dev/authelia/oidc.key:/config/oidc.key:ro
+      - ./vikunja-dev-data/authelia:/config/data
+
+  vikunja:
+    environment:
+      VIKUNJA_SERVICE_PUBLICURL: "https://vikunja.${DEV_BASE}:8443"
+      # Vikunja's server-side discovery and token exchange call Authelia over
+      # TLS, so its Go HTTP client has to trust the mkcert CA. Go reads this
+      # env var; the bundle is system roots plus that CA.
+      SSL_CERT_FILE: "/certs/ca-bundle.crt"
+    volumes:
+      - ./vikunja-dev-data/files:/app/vikunja/files
+      - ./dev/vikunja/config.yml:/etc/vikunja/config.yml:ro
+      - ./dev/certs:/certs:ro

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -158,6 +158,32 @@ problem rather than a parse error. The map key becomes the provider `key` in
 that payload and the last path segment of both the redirect URI and the
 callback endpoint.
 
+### Testing SSO on macOS
+
+```bash
+./scripts/dev-macos-oidc.sh            # build and launch
+./scripts/dev-macos-oidc.sh --cleanup  # quit it, remove every trace
+```
+
+**Do not just build and run `mDone-macOS` for this.** It shares the bundle
+identifier `com.mdone.app` with the copy in `/Applications`, so it reads the
+same keychain and the same sandbox container. It will sign you straight into
+whatever server your real app uses and never show the setup screen, and signing
+in to a test server from it overwrites the credentials your real app depends on.
+
+The script overrides `PRODUCT_BUNDLE_IDENTIFIER`, which gives the build its own
+keychain access group and container, so nothing it does can reach the real app.
+
+Two macOS behaviours to expect, neither of which happens on iOS:
+
+- **The sign-in opens in your default browser**, not an in-app Safari sheet,
+  unless Safari *is* your default. `prefersEphemeralWebBrowserSession` is a
+  Safari feature, so in a third-party browser the flow probably uses your normal
+  profile and whatever provider session it already holds.
+- **If it hangs on the spinner** after you sign in, the callback is not getting
+  back to the app. The first thing to check is whether `mdone://oidc-callback`
+  is registered as a redirect URI on that server's identity provider.
+
 ### Proving the flow works
 
 ```bash

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -98,6 +98,122 @@ After `docker compose up -d` and the seed script, run the app and exercise the p
 - **Offline / sync** — Simulator → Settings → Developer → Network Link Conditioner → 100% Loss; make changes; restore network; verify the pending operations in [mDone/Services/SyncService.swift](../mDone/Services/SyncService.swift) flush.
 - **Edge dates** — the seed includes overdue and zero-date cases ([APIClient.swift](../mDone/Services/APIClient.swift) handles Vikunja's `0001-01-01T00:00:00Z` → `Date.distantPast`).
 
+## OIDC / SSO dev stack (issue #153)
+
+The plain dev server has no identity provider. For OIDC work there is a second
+stack that puts **Authelia** in front of the same Vikunja, chosen because it is
+what the maintainer's homelab runs, so dev and production behave the same.
+
+```bash
+./scripts/dev-oidc-up.sh                  # local auth on  + OIDC
+./scripts/dev-oidc-up.sh --no-local-auth  # local auth off + OIDC
+```
+
+The second form is the one that exercises "hide the username and password
+fields when the server has local auth disabled". Log in as `devuser` /
+`devpassword`, same as the plain stack.
+
+Tear down with the command the script prints when it finishes.
+
+### Why it looks more complicated than the plain stack
+
+Three constraints shape it, and all three are easy to rediscover the hard way.
+
+**One hostname, three vantage points.** The same host has to resolve
+identically from the Mac, from the iOS Simulator, and from inside the Vikunja
+container doing the server-side token exchange. `localhost` cannot do that,
+because inside a container it means that container. The script uses
+`<lan-ip>.nip.io`, public wildcard DNS that maps the embedded IP straight back,
+so all three agree without touching `/etc/hosts`. It does need working public
+DNS, and a few resolvers block nip.io as DNS rebinding.
+
+**Everything is HTTPS.** Authelia refuses a plaintext `authelia_url`, and iOS
+App Transport Security would block a cleartext identity provider, so an HTTP
+stack would need an ATS exception we do not want to ship. Caddy terminates TLS
+for both hosts with one mkcert wildcard certificate. Vikunja trusts that CA via
+`SSL_CERT_FILE`; the Simulator gets it from `simctl keychain add-root-cert`,
+which the script runs for you if a Simulator is booted. Nothing needs
+`mkcert -install`, so nothing needs your password.
+
+**Vikunja wants a map of providers, not a list.** This one costs an hour if you
+follow the older docs:
+
+```yaml
+# WRONG on v2.4.0, and fails almost silently
+providers:
+  - name: Authelia
+    authurl: ...
+
+# RIGHT
+providers:
+  authelia:
+    name: Authelia
+    authurl: ...
+```
+
+The list form logs only `It looks like your openid configuration is in the
+wrong format` and leaves `"providers": null` in `/api/v1/info`, with
+`"enabled": true` right next to it, so it looks like a discovery or networking
+problem rather than a parse error. The map key becomes the provider `key` in
+that payload and the last path segment of both the redirect URI and the
+callback endpoint.
+
+### Proving the flow works
+
+```bash
+./scripts/dev-oidc-smoke.sh
+```
+
+Walks the whole leg the app has to perform, against the running dev stack:
+authorization request, Authelia login, authorization code, Vikunja callback,
+JWT, then a real API call with that JWT. It asserts the two security
+properties #153 calls out, that `state` round-trips unchanged and that an
+authorization code cannot be replayed, and it verifies TLS against the mkcert
+root rather than skipping verification, so a broken certificate chain fails the
+run instead of hiding.
+
+Run it after any change to the stack, and against your own server before
+trusting a build there. It does not exercise `ASWebAuthenticationSession`,
+which is system UI and still has to be checked by hand.
+
+One behaviour worth knowing, because it decides how wrong the UI can afford to
+be: with local auth disabled, `POST /api/v1/login` returns **404**, not 401 or
+403. The endpoint is gone rather than refusing. So a build that shows the
+username and password fields on an SSO-only server does not produce a helpful
+"local login is disabled" message, it produces "Not Found".
+
+### What /api/v1/info actually returns
+
+With a provider configured, the block the app decodes looks like this. Note
+that `auth_url` is the fully resolved authorization endpoint, which Vikunja
+gets from the provider's discovery document, so the app never builds it:
+
+```json
+"auth": {
+  "local":          { "enabled": true, "registration_enabled": true },
+  "ldap":           { "enabled": false },
+  "openid_connect": {
+    "enabled": true,
+    "providers": [
+      {
+        "name": "Authelia",
+        "key": "authelia",
+        "auth_url": "https://auth.<host>:8443/api/oidc/authorization",
+        "logout_url": "",
+        "client_id": "vikunja",
+        "scope": "openid profile email",
+        "email_fallback": false,
+        "username_fallback": false,
+        "force_user_info": false
+      }
+    ]
+  }
+}
+```
+
+With no provider configured, `providers` is `null` rather than `[]`, so decode
+it as an optional array.
+
 ## Vikunja version pinning
 
 `docker-compose.dev.yml` currently uses `vikunja/vikunja:latest`. When you start noticing odd behaviour after a `docker compose pull`, check the [Vikunja release notes](https://kolaente.dev/vikunja/vikunja/-/releases) and pin to a known-good tag.

--- a/docs/oidc-callback-decision.md
+++ b/docs/oidc-callback-decision.md
@@ -99,22 +99,52 @@ identity provider's page. Two further reasons found while investigating:
 
 ## Consequences for the implementation
 
-1. **Register the scheme.** `mdone` goes in `CFBundleURLTypes` via `project.yml`.
-   The `.xcodeproj` is generated, so confirm it survives `xcodegen generate`.
-2. **The app builds the authorization URL.** Vikunja supplies only the resolved
+1. **The scheme is already registered, and must stay in the plist.** `mdone` is
+   in `CFBundleURLTypes` in `mDone/Info.plist`, which both app targets share via
+   `INFOPLIST_FILE` (`project.yml:45` and `project.yml:81`). It has been there
+   since the widget deep links `mdone://focus` and `mdone://create` were added,
+   so `mdone://oidc-callback` is a third host on an existing scheme and needs no
+   new registration.
+
+   **Do not move it into `project.yml`.** An earlier draft of this document said
+   to, which was wrong. XcodeGen's `info:` block *generates* a plist rather than
+   merging into one, so adding it for these targets would rewrite
+   `mDone/Info.plist` from scratch and silently drop the hand-written keys,
+   including `NSSupportsLiveActivities`, `NSCalendarsFullAccessUsageDescription`
+   and `NSLocalNetworkUsageDescription`, and would replace the
+   `$(MARKETING_VERSION)` and `$(CURRENT_PROJECT_VERSION)` wiring with literal
+   `1.0` / `1`. That last one ships every build as version 1.0 and gets rejected
+   at upload.
+
+   This is a different case from the `PRODUCT_NAME`, `ENABLE_TESTABILITY` and
+   `SDKROOT` pins that `project.yml` already carries. Those add back settings
+   XcodeGen stopped emitting. An `info:` block instead takes ownership of a
+   git-tracked file that is currently hand-maintained.
+
+   Guard: `xcodegen generate` must leave `mDone/Info.plist` byte-identical, and
+   `plutil -p mDone/Info.plist | grep -c '^  "'` must still report 22 keys.
+
+2. **Leave `mdone://oidc-callback` unhandled in `onOpenURL`.**
+   `mDoneApp.swift:120` switches on `url.host` with `default: break`, so a
+   callback arriving through the system URL dispatcher is already ignored. That
+   is the behaviour we want and it should be made explicit with a comment rather
+   than left incidental: `ASWebAuthenticationSession` delivers the callback to
+   its own completion handler, and a code arriving by any other route did not
+   come from a session this app started.
+3. **The app builds the authorization URL.** Vikunja supplies only the resolved
    `auth_url`; the app appends `client_id`, `redirect_uri`, `response_type`,
    `scope`, `state` and `nonce`.
-3. **`nonce` needs real entropy**, per the evidence table. Done:
+4. **`nonce` needs real entropy**, per the evidence table. Done:
    `OIDCLogin.generateNonce()` sits alongside `generateState()`, both drawing 32
    bytes from the same CSPRNG helper but as independent values. Reusing the
    generator is fine; reusing the same *value* for both is not, and there is a
    test asserting they differ.
-4. **Send `redirect_url` on the callback**, matching the authorize request byte
+5. **Send `redirect_url` on the callback**, matching the authorize request byte
    for byte, or the exchange fails with `invalid_grant`.
-5. **Document the IdP step for self-hosters:** add `mdone://oidc-callback` to the
+6. **Document the IdP step for self-hosters:** add `mdone://oidc-callback` to the
    Vikunja client's redirect URIs. Without it the provider refuses the request,
    correctly and unhelpfully.
-6. **Known limitation to carry forward from the #103 review:** Vikunja derives
+7. **Known limitation to carry forward from the #103 review:** Vikunja derives
    its own default redirect URL from the API server URL, which assumes the API
    and the frontend share an origin. That assumption is now only load-bearing for
    the web frontend, not for us.

--- a/docs/oidc-callback-decision.md
+++ b/docs/oidc-callback-decision.md
@@ -1,0 +1,120 @@
+# OIDC callback shape (issue #153)
+
+**Decision: a custom URL scheme, one fixed callback URI, `mdone://oidc-callback`,
+delivered through `ASWebAuthenticationSession`.**
+
+Issue #153 asks for this to be settled before any UI is written, because it
+decides the rest. This is the write-up behind that choice. Everything in the
+evidence table was measured against a real Vikunja v2.4.0 with Authelia in front
+of it, using the dev stack in [dev-setup.md](dev-setup.md), not inferred from
+documentation.
+
+## What we measured
+
+| Question | Answer | How we know |
+|---|---|---|
+| Does Vikunja force its own configured `redirecturl`? | **No.** It honours the `redirect_url` the client sends to the callback. | Authorized with `mdone://oidc-callback` while the server stayed configured with its https frontend URL, and still got a JWT. |
+| Is the redirect URI binding enforced at token exchange? | **Yes.** | Authorizing with one URI and exchanging with another returns `invalid_grant`. |
+| Will an IdP register a custom scheme for a confidential client? | **Yes**, Authelia does. | Registered `mdone://oidc-callback`, code was issued to it. |
+| Can an unregistered URI be used to leak a code? | **No.** | Authelia returns the error to its own page and never redirects to the supplied URI. |
+| Is there a minimum entropy requirement on `nonce`? | **Yes.** | A short `nonce` is rejected with `insufficient_entropy`. |
+
+The first row is the one that decides everything. Because Vikunja accepts a
+client-supplied `redirect_url`, **the app can use its own callback URI without
+the server's `auth.openid.redirecturl` changing at all**, so adopting a custom
+scheme does not break the Vikunja web frontend for the same instance. Had that
+gone the other way, every option below would have been considerably worse.
+
+## Option A: custom scheme (chosen)
+
+`ASWebAuthenticationSession(url:callback:.customScheme("mdone"))`.
+
+**In favour**
+
+- No entitlement, no hosted files, no developer-controlled infrastructure.
+- Explicitly sanctioned for native apps by RFC 8252.
+- Works for every self-hosted deployment identically, whatever the user's domain.
+- The server needs no reconfiguration, per the evidence above.
+
+**Cost**
+
+The self-hoster must add one redirect URI at their identity provider. That is
+unavoidable for any native app, and it is one line in their IdP config. Using a
+single fixed `mdone://oidc-callback` rather than a per-provider
+`mdone://auth/openid/{key}` keeps that instruction identical no matter how many
+providers they run. The app already knows which provider it started, so it can
+still POST to the right `/auth/openid/{key}/callback`.
+
+**The security caveat, stated plainly**
+
+Custom schemes can in principle be claimed by another app on the device. Two
+things limit that here, and one thing does not help at all:
+
+- `ASWebAuthenticationSession` hands the callback URL straight to its completion
+  handler. It does not route through the system URL dispatcher, so a second app
+  registering the same scheme cannot intercept a callback belonging to a live
+  session.
+- `state` validation, already implemented and tested, rejects any callback the
+  app did not initiate.
+- **PKCE is not available to us.** mDone is not the OAuth client, Vikunja is: it
+  holds the client secret and performs the exchange. So the app cannot bind the
+  code to itself with a verifier. If a code did escape to a hostile app, that app
+  could exchange it at Vikunja's unauthenticated callback endpoint, because it
+  would know both the code and the redirect URI.
+
+The residual risk is therefore real but narrow, and it is bounded by codes being
+single use and short lived, which the smoke test asserts. It is worth revisiting
+if Vikunja ever exposes a public-client OIDC flow with PKCE.
+
+## Option B: https callback via Associated Domains (not viable)
+
+`ASWebAuthenticationSession.Callback.https(host:path:)` exists on our deployment
+target and is the better shape in the abstract, since https URIs cannot be
+claimed by another app.
+
+It cannot work for a self-hosted app. It requires the Associated Domains
+entitlement, which lists domains **compiled into the app at build time**, and an
+`apple-app-site-association` file served from each of those domains. mDone's
+users each run their own server on their own domain. There is no wildcard for
+"whatever host the user typed into the setup screen", and there is no way to
+enumerate them in advance.
+
+The only way to force it would be to route every user's OIDC redirect through a
+domain we control. That would insert us into other people's authentication flow,
+where we would see their authorization codes, and would require us to run and
+secure that infrastructure indefinitely. Both are disqualifying for an app whose
+whole premise is that the user hosts their own data.
+
+## Option C: embedded WKWebView (rejected, as PR #103 had it)
+
+Already rejected in the issue on anti-phishing grounds, since an embedded web
+view shows no URL bar and the host app can read what the user types into the
+identity provider's page. Two further reasons found while investigating:
+
+- Google refuses OAuth in embedded web views outright, returning
+  `disallowed_useragent`. Any user whose Vikunja federates to Google Workspace
+  would simply be unable to log in.
+- `prefersEphemeralWebBrowserSession` gives the cookie isolation that #103 was
+  reaching for with `WKWebsiteDataStore.nonPersistent()`, so nothing is lost.
+
+## Consequences for the implementation
+
+1. **Register the scheme.** `mdone` goes in `CFBundleURLTypes` via `project.yml`.
+   The `.xcodeproj` is generated, so confirm it survives `xcodegen generate`.
+2. **The app builds the authorization URL.** Vikunja supplies only the resolved
+   `auth_url`; the app appends `client_id`, `redirect_uri`, `response_type`,
+   `scope`, `state` and `nonce`.
+3. **`nonce` needs real entropy**, per the evidence table. Done:
+   `OIDCLogin.generateNonce()` sits alongside `generateState()`, both drawing 32
+   bytes from the same CSPRNG helper but as independent values. Reusing the
+   generator is fine; reusing the same *value* for both is not, and there is a
+   test asserting they differ.
+4. **Send `redirect_url` on the callback**, matching the authorize request byte
+   for byte, or the exchange fails with `invalid_grant`.
+5. **Document the IdP step for self-hosters:** add `mdone://oidc-callback` to the
+   Vikunja client's redirect URIs. Without it the provider refuses the request,
+   correctly and unhelpfully.
+6. **Known limitation to carry forward from the #103 review:** Vikunja derives
+   its own default redirect URL from the API server URL, which assumes the API
+   and the frontend share an origin. That assumption is now only load-bearing for
+   the web frontend, not for us.

--- a/docs/oidc-callback-decision.md
+++ b/docs/oidc-callback-decision.md
@@ -66,6 +66,43 @@ The residual risk is therefore real but narrow, and it is bounded by codes being
 single use and short lived, which the smoke test asserts. It is worth revisiting
 if Vikunja ever exposes a public-client OIDC flow with PKCE.
 
+## macOS behaves differently, and it weakens two claims above
+
+Tested on macOS 15 with a sandboxed build against the dev stack. What works:
+the setup screen renders, the `/api/v1/info` probe succeeds (confirmed in the
+server log as `user_agent="mDone-macOS/..."`), the SSO button appears, and
+`ASWebAuthenticationSession` starts without a presentation-anchor error and
+sends a correct authorization request that reaches the provider.
+
+What is different: **macOS hands the session to the default browser when that
+browser is not Safari.** On a machine defaulting to Brave, the authorization
+request opened in Brave, not in an in-app Safari sheet. Two consequences.
+
+**`prefersEphemeralWebBrowserSession` is a Safari guarantee, and probably does
+nothing here.** Cookie isolation is provided by Safari's ephemeral mode. Handed
+to a third-party browser, the flow almost certainly runs in the user's ordinary
+profile, with whatever identity-provider session they already have. So the
+claim that this matches the isolation PR #103 wanted from
+`WKWebsiteDataStore.nonPersistent()` holds on iOS but should not be relied on
+for macOS.
+
+**The "callback never touches the system URL dispatcher" claim is unverified on
+macOS.** With an external browser the redirect leaves that browser and is
+brokered by `AuthenticationServicesAgent`. That is very likely still a direct
+hand-off to the waiting session, but it was not possible to prove here, so it
+should not be stated as fact. Treat the scheme-squatting mitigation as verified
+on iOS and unproven on macOS.
+
+One thing that did check out: `mDoneApp`'s `onOpenURL` is `#if os(iOS)`, so a
+`mdone://` URL arriving on macOS through LaunchServices is inert. A callback
+that escapes the session cannot be consumed by accident.
+
+### Still to verify on macOS
+
+Completing a sign-in in an external default browser and confirming the code
+reaches the app. Everything up to the provider's login page is confirmed; the
+return leg is not.
+
 ## Option B: https callback via Associated Domains (not viable)
 
 `ASWebAuthenticationSession.Callback.https(host:path:)` exists on our deployment

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -102,7 +102,7 @@ final class AppState {
     /// The live instance backing the UI, set on init. App Intents run in the
     /// app process without access to the SwiftUI environment, so this is their
     /// only route to app state. Touch it from the main actor only.
-    static weak var shared: AppState?
+    weak static var shared: AppState?
 
     /// `taskService` is injectable so tests can drive the network paths
     /// (e.g. `undoLastCompletion`) through a mocked `APIClient`.
@@ -342,77 +342,115 @@ final class AppState {
         )
     }
 
+    /// How a session's access token is obtained. The rest of logging in is
+    /// identical whichever of these is used, which is what `completeLogin`
+    /// exists to stop us copying three times (noted in the PR #103 review).
+    private enum LoginMethod {
+        case apiToken(String)
+        case credentials(username: String, password: String)
+        /// `redirectURI` must be byte-identical to the one sent on the
+        /// authorization request, or Vikunja's exchange fails with
+        /// `invalid_grant`. Thread the same constant through, never rebuild it.
+        case oidc(provider: String, code: String, redirectURI: String)
+    }
+
     @MainActor
     func login(serverURL: String, token: String) async throws {
-        #if DEBUG
-        print("[mDone] login() called with serverURL: \(serverURL)")
-        #endif
-        isLoading = true
-        errorMessage = nil
-        defer { isLoading = false }
-
-        await registerAPIClientHandlers()
-        await APIClient.shared.configure(serverURL: serverURL, token: token)
-
-        // Validate by fetching projects: works with both JWT and API tokens.
-        // One page is enough to prove the credentials are good; the full
-        // paginated list is loaded by refreshAll().
-        #if DEBUG
-        print("[mDone] Fetching projects to validate...")
-        #endif
-        let projects: [Project] = try await APIClient.shared.fetch(Endpoint.projects())
-        #if DEBUG
-        print("[mDone] Validation OK - got \(projects.count) projects")
-        #endif
-
-        authService.saveServerURL(serverURL)
-        authService.saveToken(token)
-        #if DEBUG
-        print("[mDone] Credentials saved, setting isAuthenticated = true")
-        #endif
-        isAuthenticated = true
+        try await completeLogin(serverURL: serverURL, using: .apiToken(token))
     }
 
     @MainActor
     func loginWithCredentials(serverURL: String, username: String, password: String) async throws {
-        #if DEBUG
-        print("[mDone] loginWithCredentials() called")
-        #endif
+        try await completeLogin(serverURL: serverURL, using: .credentials(username: username, password: password))
+    }
+
+    /// Finishes an OIDC login with the code the auth session brought back.
+    ///
+    /// The `state` check has already happened in `OIDCLogin.parseCallback`; by
+    /// the time a code reaches here it belongs to a session this app started.
+    @MainActor
+    func loginWithOIDC(serverURL: String, provider: String, code: String, redirectURI: String) async throws {
+        try await completeLogin(
+            serverURL: serverURL,
+            using: .oidc(provider: provider, code: code, redirectURI: redirectURI)
+        )
+    }
+
+    /// The shared spine of every login: obtain a token, prove it works, persist
+    /// it, flip the flag.
+    ///
+    /// `isLoading` is set and cleared here rather than in the callers, so a
+    /// throw from any of them still clears the spinner.
+    @MainActor
+    private func completeLogin(serverURL: String, using method: LoginMethod) async throws {
         isLoading = true
+        // A reset, not a message. The setup screen shows its own error from the
+        // thrown value; assigning here too would show the user the same thing
+        // twice on two different surfaces.
         errorMessage = nil
         defer { isLoading = false }
 
+        // Must happen before any traffic. If a login request 401s with no
+        // handlers installed, notifySessionExpired() fires into a nil handler
+        // and the failure is swallowed. See registerAPIClientHandlers().
         await registerAPIClientHandlers()
+
         let url = serverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        await APIClient.shared.configure(serverURL: url, token: "")
+        let (token, refreshToken) = try await obtainToken(serverURL: url, using: method)
 
-        // Get JWT token via login endpoint. The Vikunja 2.0+ `Set-Cookie:
-        // vikunja_refresh_token=…` header is captured inside APIClient as part
-        // of the response — we read it back after this call to persist it.
-        let loginRequest = LoginRequest(username: username, password: password)
-        let loginResponse: LoginResponse = try await APIClient.shared.send(Endpoint.login, body: loginRequest)
-        let capturedRefreshToken = await APIClient.shared.currentRefreshToken()
+        // Configure with the token plus any refresh cookie, so ordinary
+        // requests and the 401 retry path both have what they need.
+        await APIClient.shared.configure(serverURL: url, token: token, refreshToken: refreshToken)
 
-        // Configure with the JWT token + refresh cookie so subsequent requests
-        // (and the 401 retry path) have everything they need.
-        await APIClient.shared.configure(
-            serverURL: url,
-            token: loginResponse.token,
-            refreshToken: capturedRefreshToken
-        )
-
-        // Validate. One page is enough here too, see login().
+        // Validate by fetching projects: works with both JWT and API tokens.
+        // One page is enough to prove the credentials are good; the full
+        // paginated list is loaded by refreshAll().
         let projects: [Project] = try await APIClient.shared.fetch(Endpoint.projects())
         #if DEBUG
         print("[mDone] Validation OK - got \(projects.count) projects")
         #endif
 
+        // Goes through AuthService, never the keychain directly: saveToken also
+        // mirrors into SharedTokenStore and saveServerURL into the app group,
+        // which is how the widgets stay signed in.
         authService.saveServerURL(url)
-        authService.saveToken(loginResponse.token)
-        if let capturedRefreshToken {
-            authService.saveRefreshToken(capturedRefreshToken)
+        authService.saveToken(token)
+        if let refreshToken {
+            authService.saveRefreshToken(refreshToken)
         }
         isAuthenticated = true
+    }
+
+    /// The only part that differs per login method.
+    @MainActor
+    private func obtainToken(
+        serverURL: String,
+        using method: LoginMethod
+    ) async throws -> (token: String, refreshToken: String?) {
+        switch method {
+        case let .apiToken(token):
+            // Personal API tokens have no refresh cookie. Returning nil keeps
+            // this path identical to before: persisting a stray refresh token
+            // would flip the 401 branch from "expire the session" to "try to
+            // refresh it", which cannot work for an API token.
+            return (token, nil)
+
+        case let .credentials(username, password):
+            await APIClient.shared.configure(serverURL: serverURL, token: "")
+            let response: LoginResponse = try await APIClient.shared.send(
+                Endpoint.login,
+                body: LoginRequest(username: username, password: password)
+            )
+            return await (response.token, APIClient.shared.currentRefreshToken())
+
+        case let .oidc(provider, code, redirectURI):
+            await APIClient.shared.configure(serverURL: serverURL, token: "")
+            let response: LoginResponse = try await APIClient.shared.send(
+                Endpoint.openIDCallback(provider: provider),
+                body: OIDCCallbackRequest(code: code, redirectUrl: redirectURI)
+            )
+            return await (response.token, APIClient.shared.currentRefreshToken())
+        }
     }
 
     @MainActor
@@ -685,8 +723,12 @@ final class AppState {
     /// response drive them.
     static func preservingRelations(existing: VTask, response: VTask) -> VTask {
         var result = response
-        if result.labels == nil { result.labels = existing.labels }
-        if result.relatedTasks == nil { result.relatedTasks = existing.relatedTasks }
+        if result.labels == nil {
+            result.labels = existing.labels
+        }
+        if result.relatedTasks == nil {
+            result.relatedTasks = existing.relatedTasks
+        }
         return result
     }
 
@@ -712,7 +754,9 @@ final class AppState {
     @MainActor
     private func acquireTaskUpdateSlot(id: Int64) async -> Bool {
         guard !Task.isCancelled else { return false }
-        if activeTaskUpdates.insert(id).inserted { return true }
+        if activeTaskUpdates.insert(id).inserted {
+            return true
+        }
         await withCheckedContinuation { continuation in
             taskUpdateWaiters[id, default: []].append(continuation)
         }
@@ -924,7 +968,9 @@ final class AppState {
         guard let target = undoableCompletion else { return }
         undoableCompletion = nil
         guard await acquireTaskUpdateSlot(id: target.id) else {
-            if undoableCompletion == nil { undoableCompletion = target }
+            if undoableCompletion == nil {
+                undoableCompletion = target
+            }
             return
         }
         defer { releaseTaskUpdateSlot(id: target.id) }
@@ -962,7 +1008,9 @@ final class AppState {
             // Only restore the old target if no newer completion was recorded
             // while this request was in flight — otherwise we'd clobber the more
             // recent undo target and break "undo the most recent completion".
-            if undoableCompletion == nil { undoableCompletion = target }
+            if undoableCompletion == nil {
+                undoableCompletion = target
+            }
             handleError(error)
         }
     }

--- a/mDone/Models/APIModels.swift
+++ b/mDone/Models/APIModels.swift
@@ -9,6 +9,18 @@ struct LoginResponse: Codable {
     var token: String
 }
 
+/// Body of `POST /api/v1/auth/openid/{key}/callback`.
+///
+/// `redirectUrl` becomes `redirect_url` through the client's
+/// `convertToSnakeCase` strategy, so do not add `CodingKeys` here without
+/// matching it. Vikunja forwards the value as the `redirect_uri` of the token
+/// exchange, so it must equal the one used on the authorization request or the
+/// provider rejects the grant.
+struct OIDCCallbackRequest: Encodable {
+    var code: String
+    var redirectUrl: String
+}
+
 struct APIError: Codable {
     var code: Int?
     var message: String?

--- a/mDone/Models/AuthOptions.swift
+++ b/mDone/Models/AuthOptions.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// What the setup screen should offer, derived from `GET /api/v1/info`.
+///
+/// Kept as a plain value computed by a pure function so the rules can be tested
+/// without standing up a view. See `AuthOptionsTests`.
+struct AuthOptions: Equatable {
+    /// Whether to show the username and password fields.
+    var showsCredentials: Bool
+    /// Whether to offer the API-token field. Always true: personal API tokens
+    /// are issued in Vikunja's own settings and validate independently of how
+    /// the instance authenticates people.
+    var showsAPIToken: Bool
+    /// SSO buttons to render, in server order. Empty when OIDC is off.
+    var providers: [OIDCProvider]
+
+    /// True when the server offers neither password nor SSO login, leaving an
+    /// API token as the only way in. Worth saying out loud in the UI rather
+    /// than presenting a form that cannot work.
+    var isAPITokenOnly: Bool {
+        !showsCredentials && providers.isEmpty
+    }
+
+    /// Conservative default for before `/api/v1/info` has been fetched, or when
+    /// fetching it failed. Matches how the app behaved before issue #153: show
+    /// the credentials form and no SSO.
+    static let unknownServer = AuthOptions(showsCredentials: true, showsAPIToken: true, providers: [])
+
+    init(showsCredentials: Bool, showsAPIToken: Bool, providers: [OIDCProvider]) {
+        self.showsCredentials = showsCredentials
+        self.showsAPIToken = showsAPIToken
+        self.providers = providers
+    }
+
+    init(info: ServerInfo) {
+        let auth = info.auth
+
+        // Deliberately `||`, not just `local.enabled`. LDAP binds go through
+        // the same POST /api/v1/login with a username and password, so an
+        // LDAP-only server still needs these fields even though mDone has no
+        // LDAP-specific support yet (issue #156). Hiding them there would
+        // leave the user with no way to sign in at all.
+        showsCredentials = auth.local.enabled || auth.ldap.enabled
+
+        showsAPIToken = true
+
+        // `enabled: false` with a populated `providers` array is not something
+        // Vikunja is expected to send, but trust the flag over the list.
+        providers = auth.openidConnect.enabled ? (auth.openidConnect.providers ?? []) : []
+    }
+}

--- a/mDone/Models/ServerInfo.swift
+++ b/mDone/Models/ServerInfo.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// The parts of `GET /api/v1/info` the login screen cares about.
+///
+/// Decoded with `APIClient`'s `convertFromSnakeCase` strategy, so `openid_connect`
+/// arrives as `openidConnect` and `auth_url` as `authUrl`.
+///
+/// Everything here is lenient on purpose. This is the one endpoint the app hits
+/// before it knows anything about the server, including how old it is, and a
+/// decode failure here means the user cannot get to a login screen at all.
+struct ServerInfo: Decodable, Equatable {
+    var version: String?
+    var auth: AuthInfo
+
+    enum CodingKeys: String, CodingKey {
+        case version, auth
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decodeIfPresent(String.self, forKey: .version)
+        // A server old enough to have no `auth` block predates both OIDC and
+        // LDAP, so username and password is the only way in.
+        auth = try container.decodeIfPresent(AuthInfo.self, forKey: .auth) ?? .localOnly
+    }
+
+    init(version: String? = nil, auth: AuthInfo) {
+        self.version = version
+        self.auth = auth
+    }
+
+    struct AuthInfo: Decodable, Equatable {
+        var local: Method
+        var ldap: Method
+        var openidConnect: OpenIDConnect
+
+        static let localOnly = AuthInfo(
+            local: Method(enabled: true),
+            ldap: Method(enabled: false),
+            openidConnect: OpenIDConnect(enabled: false, providers: nil)
+        )
+
+        enum CodingKeys: String, CodingKey {
+            case local, ldap, openidConnect
+        }
+
+        init(local: Method, ldap: Method, openidConnect: OpenIDConnect) {
+            self.local = local
+            self.ldap = ldap
+            self.openidConnect = openidConnect
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            local = try container.decodeIfPresent(Method.self, forKey: .local) ?? Method(enabled: true)
+            ldap = try container.decodeIfPresent(Method.self, forKey: .ldap) ?? Method(enabled: false)
+            openidConnect = try container.decodeIfPresent(OpenIDConnect.self, forKey: .openidConnect)
+                ?? OpenIDConnect(enabled: false, providers: nil)
+        }
+
+        struct Method: Decodable, Equatable {
+            var enabled: Bool
+            var registrationEnabled: Bool?
+        }
+
+        struct OpenIDConnect: Decodable, Equatable {
+            var enabled: Bool
+            /// Vikunja sends `null`, not `[]`, when no provider is configured,
+            /// which is the common case. Verified against v2.4.0.
+            var providers: [OIDCProvider]?
+        }
+    }
+}
+
+/// One configured OIDC provider, as advertised by `/api/v1/info`.
+struct OIDCProvider: Decodable, Equatable, Identifiable {
+    /// Display name, e.g. "Authelia".
+    var name: String
+    /// Provider key, e.g. "authelia". This is the last path segment of both the
+    /// redirect URI and the `/auth/openid/{key}/callback` endpoint.
+    var key: String
+    /// The fully resolved authorization endpoint. Vikunja reads this from the
+    /// provider's discovery document, so the app never builds it.
+    var authUrl: String
+    var logoutUrl: String?
+    var clientId: String?
+    var scope: String?
+
+    var id: String {
+        key
+    }
+
+    var authorizationURL: URL? {
+        URL(string: authUrl)
+    }
+
+    init(
+        name: String,
+        key: String,
+        authUrl: String,
+        logoutUrl: String? = nil,
+        clientId: String? = nil,
+        scope: String? = nil
+    ) {
+        self.name = name
+        self.key = key
+        self.authUrl = authUrl
+        self.logoutUrl = logoutUrl
+        self.clientId = clientId
+        self.scope = scope
+    }
+}

--- a/mDone/Services/APIClient.swift
+++ b/mDone/Services/APIClient.swift
@@ -93,10 +93,14 @@ actor APIClient {
     }
 
     /// Test/inspection hook for the currently stored refresh token.
-    func currentRefreshToken() -> String? { refreshToken }
+    func currentRefreshToken() -> String? {
+        refreshToken
+    }
 
     /// Test/inspection hook for the currently stored access token.
-    func currentToken() -> String? { apiToken }
+    func currentToken() -> String? {
+        apiToken
+    }
 
     private func buildRequest(for endpoint: Endpoint) throws -> URLRequest {
         guard let serverURL else { throw NetworkError.invalidURL }
@@ -117,7 +121,14 @@ actor APIClient {
         request.timeoutInterval = APIClient.requestTimeout
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        if let apiToken {
+        // Pre-login requests configure the client with an empty token so a base
+        // URL exists. Without the isEmpty guard that sends a literal
+        // "Authorization: Bearer " with nothing after it. Vikunja ignores it,
+        // because /info, /login and the OIDC callback sit outside its JWT
+        // middleware, but a forward-auth proxy in front of it (Authelia,
+        // Cloudflare Access, nginx auth_request) can reject the malformed
+        // header, which would look like the server being unreachable.
+        if let apiToken, !apiToken.isEmpty {
             request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
         }
 
@@ -338,7 +349,7 @@ actor APIClient {
         // which would have masked a real bug.
         let task = Task<Void, Error> { [self] in
             defer { self.inFlightRefresh = nil }
-            try await self.performRefresh()
+            try await performRefresh()
         }
         inFlightRefresh = task
         try await task.value

--- a/mDone/Services/Endpoint.swift
+++ b/mDone/Services/Endpoint.swift
@@ -31,8 +31,22 @@ struct Endpoint {
 
     /// Exchanges an OIDC authorization code for a Vikunja JWT. `provider` is
     /// the provider `key` from `/api/v1/info`, not its display name.
+    ///
+    /// The key is percent-encoded because it comes from the server rather than
+    /// from us, and `APIClient.buildRequest` concatenates paths and calls
+    /// `URL(string:)` without escaping. An unescaped key containing `/` or `..`
+    /// would move this POST to a different path, and this is the request that
+    /// carries the authorization code.
     static func openIDCallback(provider: String) -> Endpoint {
-        Endpoint(path: "/api/v1/auth/openid/\(provider)/callback", method: .POST)
+        Endpoint(path: "/api/v1/auth/openid/\(pathSegment(provider))/callback", method: .POST)
+    }
+
+    /// Percent-encodes a single path segment. Deliberately narrower than
+    /// `.urlPathAllowed`, which permits `/`, and narrower than RFC 3986's
+    /// unreserved set, which permits `.` and would leave `..` intact.
+    static func pathSegment(_ raw: String) -> String {
+        let safe = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_~"))
+        return raw.addingPercentEncoding(withAllowedCharacters: safe) ?? ""
     }
 
     // MARK: - User

--- a/mDone/Services/Endpoint.swift
+++ b/mDone/Services/Endpoint.swift
@@ -24,6 +24,17 @@ struct Endpoint {
     /// Set-Cookie that invalidates the previous refresh token.
     static let refreshToken = Endpoint(path: "/api/v1/user/token/refresh", method: .POST)
 
+    /// Instance metadata, including which auth methods the server offers.
+    /// Unauthenticated: this is what the login screen reads before it knows
+    /// anything about the server.
+    static let info = Endpoint(path: "/api/v1/info")
+
+    /// Exchanges an OIDC authorization code for a Vikunja JWT. `provider` is
+    /// the provider `key` from `/api/v1/info`, not its display name.
+    static func openIDCallback(provider: String) -> Endpoint {
+        Endpoint(path: "/api/v1/auth/openid/\(provider)/callback", method: .POST)
+    }
+
     // MARK: - User
 
     static let currentUser = Endpoint(path: "/api/v1/user")

--- a/mDone/Services/OIDCLogin.swift
+++ b/mDone/Services/OIDCLogin.swift
@@ -161,6 +161,20 @@ enum OIDCLogin {
         return url
     }
 
+    /// The URL scheme the app claims, already registered in `mDone/Info.plist`
+    /// for the widget deep links `mdone://focus` and `mdone://create`.
+    static let callbackScheme = "mdone"
+
+    /// The one callback URI, threaded through the authorization request, the
+    /// callback check and Vikunja's token exchange. All three have to agree
+    /// byte for byte or the exchange fails with `invalid_grant`, so this is a
+    /// constant rather than something rebuilt at each call site.
+    ///
+    /// A single fixed URI rather than one per provider keeps the instruction to
+    /// self-hosters the same however many providers they run: add
+    /// `mdone://oidc-callback` to the Vikunja client at your identity provider.
+    static let redirectURI = "mdone://oidc-callback"
+
     /// Used when the server does not advertise a scope. Vikunja normally does.
     static let defaultScope = "openid profile email"
 

--- a/mDone/Services/OIDCLogin.swift
+++ b/mDone/Services/OIDCLogin.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Security
+
+/// The outcome of an OIDC redirect coming back to the app.
+///
+/// `code` is deliberately not part of any description. See `debugDescription`.
+enum OIDCCallbackResult: Equatable {
+    /// A usable authorization code, with a `state` that matched.
+    case success(code: String)
+    /// The provider reported a failure, e.g. `error=access_denied` when the
+    /// user pressed Cancel on the consent screen. PR #103 ignored this case
+    /// entirely, which left the user staring at a stuck web view.
+    case providerError(error: String, description: String?)
+    /// `state` was missing, or did not match the value we generated. Treated as
+    /// hostile: this is the CSRF check, and #103 generated the token and then
+    /// never compared it.
+    case stateMismatch
+    case malformed(Reason)
+
+    enum Reason: Equatable {
+        case notAURL
+        case noQueryParameters
+        case missingCode
+        case duplicateParameter(String)
+        case unexpectedCallbackScheme
+    }
+}
+
+extension OIDCCallbackResult: CustomDebugStringConvertible {
+    /// Never includes the authorization code. A code in a log or a crash report
+    /// is a credential in a log or a crash report, and `print("\(result)")` is
+    /// exactly the kind of line that slips through review.
+    var debugDescription: String {
+        switch self {
+        case .success:
+            "OIDCCallbackResult.success(code: <redacted>)"
+        case let .providerError(error, description):
+            "OIDCCallbackResult.providerError(\(error), \(description ?? "no description"))"
+        case .stateMismatch:
+            "OIDCCallbackResult.stateMismatch"
+        case let .malformed(reason):
+            "OIDCCallbackResult.malformed(\(reason))"
+        }
+    }
+}
+
+enum OIDCLogin {
+    /// Generates a CSRF token for the `state` parameter.
+    ///
+    /// Compared against the value on the callback. This is the check PR #103
+    /// generated a token for and then never performed.
+    static func generateState() -> String {
+        randomToken()
+    }
+
+    /// Generates a `nonce` for the authorization request.
+    ///
+    /// Distinct from `state` and solving a different problem: `state` protects
+    /// the callback against CSRF, `nonce` binds the resulting ID token to this
+    /// one request so a captured token cannot be replayed into a later one.
+    ///
+    /// Providers enforce a floor on this. Authelia rejects a short value with
+    /// `insufficient_entropy`, which surfaces only at the token exchange, well
+    /// after the user has finished logging in and looks like a server fault.
+    /// 32 bytes is far above any provider's threshold.
+    ///
+    /// Never pass the same value for both: reusing one token for two
+    /// independent protections means a leak of either defeats both.
+    static func generateNonce() -> String {
+        randomToken()
+    }
+
+    /// 32 bytes from the system CSPRNG, base64url encoded so it survives a
+    /// round trip through a query string untouched.
+    private static func randomToken(byteCount: Int = 32) -> String {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            // SecRandomCopyBytes does not fail in practice. If it ever does,
+            // falling back to a weaker source would silently downgrade both the
+            // CSRF and replay protections to nothing, so refuse instead.
+            fatalError("SecRandomCopyBytes failed with status \(status)")
+        }
+        return Data(bytes).base64URLEncodedString()
+    }
+
+    /// Parses the redirect the provider sends back to the app.
+    ///
+    /// Order matters. `state` is checked before anything else is trusted, so a
+    /// forged callback cannot get as far as being reported as a provider error
+    /// or having its code read. RFC 6749 requires the provider to echo `state`
+    /// on error responses too, so this is safe for real providers and strict
+    /// for everyone else.
+    ///
+    /// - Parameters:
+    ///   - url: the redirect URL handed back by the auth session.
+    ///   - expectedState: the value from `generateState()` for this attempt.
+    ///   - expectedScheme: the registered callback scheme, when there is one.
+    static func parseCallback(
+        _ url: URL,
+        expectedState: String,
+        expectedScheme: String? = nil
+    ) -> OIDCCallbackResult {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return .malformed(.notAURL)
+        }
+
+        if let expectedScheme, components.scheme?.lowercased() != expectedScheme.lowercased() {
+            return .malformed(.unexpectedCallbackScheme)
+        }
+
+        guard let items = components.queryItems, !items.isEmpty else {
+            return .malformed(.noQueryParameters)
+        }
+
+        // A repeated parameter is ambiguous, and which copy wins is a parser
+        // detail an attacker can aim at. Refuse rather than pick.
+        for key in ["code", "state", "error"] where items.filter({ $0.name == key }).count > 1 {
+            return .malformed(.duplicateParameter(key))
+        }
+
+        let value = { (name: String) -> String? in
+            items.first { $0.name == name }?.value.flatMap { $0.isEmpty ? nil : $0 }
+        }
+
+        guard let state = value("state"), state == expectedState else {
+            return .stateMismatch
+        }
+
+        // Checked before `code`, so a response carrying both is treated as the
+        // failure it is rather than the success it pretends to be.
+        if let error = value("error") {
+            return .providerError(error: error, description: value("error_description"))
+        }
+
+        guard let code = value("code") else {
+            return .malformed(.missingCode)
+        }
+
+        return .success(code: code)
+    }
+}
+
+extension Data {
+    /// base64url per RFC 4648 section 5, unpadded.
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/mDone/Services/OIDCLogin.swift
+++ b/mDone/Services/OIDCLogin.swift
@@ -44,6 +44,27 @@ extension OIDCCallbackResult: CustomDebugStringConvertible {
     }
 }
 
+/// Reasons the app cannot start an OIDC login with a given provider.
+///
+/// These are all "this server is configured in a way we cannot use", not
+/// transient failures, so they are worth distinguishing from `NetworkError`.
+enum OIDCLoginError: LocalizedError, Equatable {
+    case invalidAuthorizationEndpoint
+    case insecureAuthorizationEndpoint
+    case missingClientID
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidAuthorizationEndpoint:
+            "This server's single sign-on address doesn't look right. Check the provider setup on your server."
+        case .insecureAuthorizationEndpoint:
+            "Single sign-on needs an https address. Your server is offering an insecure one, which iOS will not open."
+        case .missingClientID:
+            "This server's single sign-on provider is missing a client ID. Check the provider setup on your server."
+        }
+    }
+}
+
 enum OIDCLogin {
     /// Generates a CSRF token for the `state` parameter.
     ///
@@ -83,6 +104,65 @@ enum OIDCLogin {
         }
         return Data(bytes).base64URLEncodedString()
     }
+
+    /// Builds the authorization URL to hand to `ASWebAuthenticationSession`.
+    ///
+    /// Vikunja supplies only the resolved authorization endpoint in
+    /// `provider.authUrl`, taken from the provider's discovery document, so the
+    /// app supplies everything else.
+    ///
+    /// - Parameters:
+    ///   - provider: as advertised by `GET /api/v1/info`.
+    ///   - redirectURI: must match the value later sent to Vikunja's callback
+    ///     byte for byte, or the token exchange fails with `invalid_grant`.
+    ///   - state: from `generateState()`, compared on the way back.
+    ///   - nonce: from `generateNonce()`, and a different value from `state`.
+    static func authorizationURL(
+        for provider: OIDCProvider,
+        redirectURI: String,
+        state: String,
+        nonce: String
+    ) throws -> URL {
+        // `host` is non-nil but empty for input like "https://", so checking
+        // for nil alone would let a hostless URL through.
+        guard var components = URLComponents(string: provider.authUrl),
+              let host = components.host, !host.isEmpty
+        else {
+            throw OIDCLoginError.invalidAuthorizationEndpoint
+        }
+
+        // Sending an authorization request in clear text would expose the code
+        // in transit. iOS App Transport Security would refuse to load it anyway,
+        // so failing here gives a better message than a generic network error.
+        guard components.scheme?.lowercased() == "https" else {
+            throw OIDCLoginError.insecureAuthorizationEndpoint
+        }
+
+        guard let clientID = provider.clientId, !clientID.isEmpty else {
+            throw OIDCLoginError.missingClientID
+        }
+
+        // Some providers publish an authorization endpoint that already carries
+        // query parameters. Append rather than replace, so they survive.
+        var items = components.queryItems ?? []
+        items.append(contentsOf: [
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "scope", value: provider.scope ?? defaultScope),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "nonce", value: nonce),
+        ])
+        components.queryItems = items
+
+        guard let url = components.url else {
+            throw OIDCLoginError.invalidAuthorizationEndpoint
+        }
+        return url
+    }
+
+    /// Used when the server does not advertise a scope. Vikunja normally does.
+    static let defaultScope = "openid profile email"
 
     /// Parses the redirect the provider sends back to the app.
     ///

--- a/mDone/Services/ServerInfoService.swift
+++ b/mDone/Services/ServerInfoService.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Reads `GET /api/v1/info` from a server the app has no credentials for, so
+/// the setup screen can adapt to the auth methods that server actually offers.
+///
+/// Deliberately does **not** default to `APIClient.shared` the way the other
+/// services do. Probing through the shared client would overwrite the signed-in
+/// user's server URL and token with a half-typed hostname and an empty token on
+/// every keystroke, and a 401 from the probe would run through
+/// `executeWithRefresh` and could fire `onSessionExpired`, tearing down a
+/// perfectly good session.
+actor ServerInfoService {
+    private let apiClient: APIClient
+
+    init(apiClient: APIClient? = nil) {
+        self.apiClient = apiClient ?? APIClient(session: ServerInfoService.probeSession())
+    }
+
+    /// Fetches the instance info. Throws like any other API call; callers on the
+    /// setup screen should treat a failure as "we do not know" and fall back to
+    /// `AuthOptions.unknownServer` rather than blocking the user.
+    func fetch(from serverURL: URL) async throws -> ServerInfo {
+        await apiClient.configure(serverURL: serverURL.absoluteString, token: "")
+        return try await apiClient.fetch(Endpoint.info)
+    }
+
+    /// `APIClient` stamps its own 20s timeout on every request and retries
+    /// connection failures three times with 1s, 2s and 4s backoff. Against a
+    /// host that silently drops packets that is well over a minute before the
+    /// setup screen hears anything. `timeoutIntervalForResource` is the only
+    /// knob that bounds the whole ladder from outside.
+    private static func probeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForResource = 12
+        return URLSession(configuration: config)
+    }
+}

--- a/mDone/Services/ServerURL.swift
+++ b/mDone/Services/ServerURL.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Normalization and validation for the server URL the user types on the setup
+/// screen.
+///
+/// This used to live inline in `ServerSetupView.connect()`. It is pure and
+/// branchy, which makes it both a common source of "why won't it connect" and a
+/// cheap thing to test.
+enum ServerURL {
+    /// Cleans up what the user typed and returns a URL the API client can use,
+    /// or nil if it cannot be made sense of.
+    ///
+    /// Trims whitespace, defaults a missing scheme to https, and drops trailing
+    /// slashes so callers can append paths without doubling up.
+    static func normalized(_ raw: String) -> URL? {
+        var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return nil }
+
+        // A bare "vikunja.example.com" is the common case, and the safe default
+        // for a missing scheme is https, never http.
+        if !text.contains("://") {
+            text = "https://" + text
+        }
+
+        // Trailing slashes would produce "//api/v1/..." once a path is appended.
+        while text.hasSuffix("/") {
+            text.removeLast()
+        }
+
+        guard let components = URLComponents(string: text),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = components.host,
+              isValidHost(host)
+        else {
+            return nil
+        }
+
+        return components.url
+    }
+
+    /// Whether the text can be turned into a usable server URL.
+    static func isValid(_ raw: String) -> Bool {
+        normalized(raw) != nil
+    }
+
+    /// Self-hosted servers legitimately live on `localhost`, raw IP addresses
+    /// and single-label intranet names, so those are all allowed. The point of
+    /// this check is to catch typos and non-hostnames, not to enforce public DNS.
+    private static func isValidHost(_ host: String) -> Bool {
+        guard !host.isEmpty, !host.contains(" ") else { return false }
+
+        // IPv6 literals arrive from URLComponents already stripped of brackets.
+        if host.contains(":") {
+            return true
+        }
+
+        let labels = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard labels.allSatisfy({ !$0.isEmpty }) else { return false }
+
+        // "localhost", "vikunja", or an IPv4 literal.
+        if labels.count == 1 {
+            return labels[0].allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" }
+        }
+
+        if isIPv4(host) {
+            return true
+        }
+
+        // A dotted name needs a plausible TLD. A single character is always a
+        // typo, most often a missing character rather than a real suffix.
+        guard let tld = labels.last, tld.count >= 2 else { return false }
+        return tld.allSatisfy(\.isLetter)
+    }
+
+    private static func isIPv4(_ host: String) -> Bool {
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return false }
+        return parts.allSatisfy { part in
+            guard let value = Int(part), part.count <= 3, !part.isEmpty else { return false }
+            return (0 ... 255).contains(value)
+        }
+    }
+}

--- a/mDone/Services/WebAuthenticator.swift
+++ b/mDone/Services/WebAuthenticator.swift
@@ -1,0 +1,144 @@
+import AuthenticationServices
+import Foundation
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+
+enum WebAuthenticationError: LocalizedError, Equatable {
+    /// The user dismissed the browser or declined the system consent alert.
+    /// Not worth showing: the UI should simply go quiet.
+    case cancelled
+    /// `start()` refused, which in practice means a missing or dead
+    /// presentation anchor.
+    case cannotStart
+    case failed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .cancelled:
+            nil
+        case .cannotStart:
+            "Couldn't open the sign-in window. Please try again."
+        case let .failed(message):
+            message
+        }
+    }
+}
+
+/// The seam that keeps the login flow testable.
+///
+/// `ASWebAuthenticationSession` presents system UI and cannot run in a unit
+/// test, so everything above this protocol can be exercised with a fake that
+/// returns a canned callback URL.
+///
+/// `@MainActor` because `ASWebAuthenticationPresentationContextProviding` is
+/// main-actor isolated, and so fakes need no `Sendable` gymnastics.
+@MainActor
+protocol WebAuthenticating: AnyObject {
+    func authenticate(url: URL, callbackScheme: String, prefersEphemeralSession: Bool) async throws -> URL
+}
+
+/// Runs the OIDC authorization request in the system's own browser.
+///
+/// Chosen over an embedded `WKWebView` because it shows a real URL bar, which is
+/// the user's only defence against a spoofed identity provider, and because the
+/// app cannot read what the user types into it. See
+/// `docs/oidc-callback-decision.md`.
+@MainActor
+final class WebAuthenticator: NSObject, WebAuthenticating {
+    private var session: ASWebAuthenticationSession?
+    private var continuation: CheckedContinuation<URL, Error>?
+
+    func authenticate(
+        url: URL,
+        callbackScheme: String,
+        prefersEphemeralSession: Bool = true
+    ) async throws -> URL {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<URL, Error>) in
+                self.continuation = continuation
+
+                let session = ASWebAuthenticationSession(
+                    url: url,
+                    callback: .customScheme(callbackScheme)
+                ) { [weak self] callbackURL, error in
+                    guard let self else { return }
+                    MainActor.assumeIsolated {
+                        self.session = nil
+                        if let error {
+                            self.finish(.failure(Self.mapped(error)))
+                        } else if let callbackURL {
+                            self.finish(.success(callbackURL))
+                        } else {
+                            self.finish(.failure(WebAuthenticationError.failed("No callback URL")))
+                        }
+                    }
+                }
+
+                // Both have to be set before start(). The ephemeral flag is
+                // ignored afterwards, and a nil provider fails start() with
+                // .presentationContextNotProvided. The property is weak, so
+                // this object must outlive the session, which it does because
+                // the caller holds it.
+                session.prefersEphemeralWebBrowserSession = prefersEphemeralSession
+                session.presentationContextProvider = self
+                self.session = session
+
+                // A false return does not invoke the completion handler, so
+                // resume here or the continuation hangs forever.
+                guard session.start() else {
+                    self.session = nil
+                    finish(.failure(WebAuthenticationError.cannotStart))
+                    return
+                }
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in self?.cancel() }
+        }
+    }
+
+    func cancel() {
+        session?.cancel()
+        session = nil
+        finish(.failure(WebAuthenticationError.cancelled))
+    }
+
+    /// Resume-once. `cancel()` may or may not also run the completion handler,
+    /// and resuming a `CheckedContinuation` twice traps.
+    private func finish(_ result: Result<URL, Error>) {
+        guard let continuation else { return }
+        self.continuation = nil
+        continuation.resume(with: result)
+    }
+
+    private static func mapped(_ error: Error) -> Error {
+        guard let authError = error as? ASWebAuthenticationSessionError else {
+            return WebAuthenticationError.failed(error.localizedDescription)
+        }
+        return switch authError.code {
+        case .canceledLogin: WebAuthenticationError.cancelled
+        case .presentationContextNotProvided, .presentationContextInvalid: WebAuthenticationError.cannotStart
+        default: WebAuthenticationError.failed(authError.localizedDescription)
+        }
+    }
+}
+
+extension WebAuthenticator: ASWebAuthenticationPresentationContextProviding {
+    func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        #if os(iOS)
+        // Must be a window in a foreground-active scene, or start() fails with
+        // .presentationContextInvalid.
+        let window = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }?
+            .keyWindow
+        return window ?? ASPresentationAnchor()
+        #elseif os(macOS)
+        return NSApplication.shared.keyWindow
+            ?? NSApplication.shared.windows.first
+            ?? ASPresentationAnchor()
+        #endif
+    }
+}

--- a/mDone/Views/Setup/ServerSetupView.swift
+++ b/mDone/Views/Setup/ServerSetupView.swift
@@ -12,6 +12,20 @@ struct ServerSetupView: View {
     @State private var errorMessage: String?
     @State private var authMode: AuthMode = .credentials
 
+    /// What this server actually offers. Starts at the conservative default,
+    /// which matches how the screen behaved before issue #153: credentials
+    /// form, no SSO. A failed probe returns here rather than blocking anyone.
+    @State private var authOptions: AuthOptions = .unknownServer
+    @State private var probeTask: Task<Void, Never>?
+
+    /// Injectable so previews and any future UI test can avoid the real system
+    /// auth sheet, which cannot be driven from a test.
+    @State private var webAuthenticator: any WebAuthenticating
+
+    init(webAuthenticator: (any WebAuthenticating)? = nil) {
+        _webAuthenticator = State(initialValue: webAuthenticator ?? WebAuthenticator())
+    }
+
     @ScaledMetric(relativeTo: .largeTitle) private var logoSize: CGFloat = 64
 
     enum AuthMode: String, CaseIterable {
@@ -40,6 +54,10 @@ struct ServerSetupView: View {
                             .foregroundStyle(.secondary)
                     }
 
+                    if ssoIsPrimary {
+                        ssoSection
+                    }
+
                     // Form
                     VStack(spacing: 16) {
                         VStack(alignment: .leading, spacing: 6) {
@@ -58,16 +76,21 @@ struct ServerSetupView: View {
                                 .textInputAutocapitalization(.never)
                                 .keyboardType(.URL)
                             #endif
+                                .onChange(of: serverURL) { _, _ in checkServer(debounce: true) }
+                                .onSubmit { checkServer(debounce: false) }
                         }
 
-                        Picker("Auth Method", selection: $authMode) {
-                            ForEach(AuthMode.allCases, id: \.self) { mode in
-                                Text(mode.rawValue).tag(mode)
+                        // Only worth showing when there is a choice to make.
+                        if availableModes.count > 1 {
+                            Picker("Auth Method", selection: $authMode) {
+                                ForEach(availableModes, id: \.self) { mode in
+                                    Text(mode.rawValue).tag(mode)
+                                }
                             }
+                            .pickerStyle(.segmented)
                         }
-                        .pickerStyle(.segmented)
 
-                        if authMode == .credentials {
+                        if authMode == .credentials, authOptions.showsCredentials {
                             VStack(alignment: .leading, spacing: 6) {
                                 Text("Username")
                                     .font(.caption)
@@ -143,6 +166,10 @@ struct ServerSetupView: View {
                     .disabled(isFormIncomplete || isConnecting)
                     .padding(.horizontal)
 
+                    if !ssoIsPrimary {
+                        ssoSection
+                    }
+
                     if authMode == .credentials {
                         Text("Login with your Vikunja username and password for full functionality")
                             .font(.caption2)
@@ -165,11 +192,186 @@ struct ServerSetupView: View {
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif
+            // A prefilled URL (issue #80, after a session expires) deserves an
+            // immediate probe rather than waiting for a keystroke that may
+            // never come.
+            .task { checkServer(debounce: false) }
+            .onChange(of: authOptions) { _, _ in
+                // The picker's selection must stay inside its own ForEach or
+                // SwiftUI renders no segment as selected.
+                if !availableModes.contains(authMode) {
+                    authMode = availableModes.first ?? .apiToken
+                }
+            }
+            // The view is torn down the moment isAuthenticated flips, and a
+            // probe outliving it would write to @State on a dead view.
+            .onDisappear { probeTask?.cancel() }
+        }
+    }
+
+    /// SSO buttons, plus a divider when they are sharing the screen with a
+    /// password form.
+    @ViewBuilder
+    private var ssoSection: some View {
+        if !authOptions.providers.isEmpty {
+            VStack(spacing: 12) {
+                if !ssoIsPrimary {
+                    HStack(spacing: 12) {
+                        VStack { Divider() }
+                        Text("or")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        VStack { Divider() }
+                    }
+                }
+
+                ForEach(authOptions.providers) { provider in
+                    ssoButton(for: provider)
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+
+    /// Prominent when SSO is the only way in, quiet when it is sharing the
+    /// screen with a password form. Written out twice rather than through a
+    /// type-erased style, which SwiftUI has no public equivalent of.
+    @ViewBuilder
+    private func ssoButton(for provider: OIDCProvider) -> some View {
+        let disabled = isConnecting || ServerURL.normalized(serverURL) == nil
+        if ssoIsPrimary {
+            Button { signInWithSSO(provider) } label: { ssoLabel(provider) }
+                .buttonStyle(.borderedProminent)
+                .disabled(disabled)
+        } else {
+            Button { signInWithSSO(provider) } label: { ssoLabel(provider) }
+                .buttonStyle(.bordered)
+                .disabled(disabled)
+        }
+    }
+
+    private func ssoLabel(_ provider: OIDCProvider) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "person.badge.key.fill")
+            Text("Continue with \(provider.name)")
+                .fontWeight(.medium)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 44)
+    }
+
+    /// True when there is no password form for SSO to sit politely beneath.
+    private var ssoIsPrimary: Bool {
+        !authOptions.providers.isEmpty && !authOptions.showsCredentials
+    }
+
+    private var availableModes: [AuthMode] {
+        var modes: [AuthMode] = []
+        if authOptions.showsCredentials {
+            modes.append(.credentials)
+        }
+        if authOptions.showsAPIToken {
+            modes.append(.apiToken)
+        }
+        return modes
+    }
+
+    /// Asks the server which auth methods it offers.
+    ///
+    /// One function with a flag rather than the two near-identical copies PR
+    /// #103 grew (noted in the issue). Failure is deliberately silent: it lands
+    /// on `AuthOptions.unknownServer`, which shows the same form the screen
+    /// showed before any of this existed. Writing a probe failure into
+    /// `errorMessage` would flash an error on every keystroke, since cancelling
+    /// an in-flight request surfaces as one.
+    private func checkServer(debounce: Bool) {
+        probeTask?.cancel()
+
+        guard let url = ServerURL.normalized(serverURL) else {
+            authOptions = .unknownServer
+            return
+        }
+
+        probeTask = Task {
+            if debounce {
+                try? await Task.sleep(for: .milliseconds(600))
+                if Task.isCancelled {
+                    return
+                }
+            }
+
+            let info = try? await ServerInfoService().fetch(from: url)
+
+            // Cancellation is cooperative and the response may already be in
+            // flight, so re-check that the user has not moved on to a different
+            // server before writing the result back.
+            guard !Task.isCancelled, ServerURL.normalized(serverURL) == url else { return }
+            authOptions = info.map(AuthOptions.init(info:)) ?? .unknownServer
+        }
+    }
+
+    /// Runs the full OIDC flow for one provider.
+    private func signInWithSSO(_ provider: OIDCProvider) {
+        guard let serverURL = ServerURL.normalized(serverURL) else { return }
+        isConnecting = true
+        errorMessage = nil
+
+        Task {
+            defer { isConnecting = false }
+            do {
+                // Fresh per attempt, and never the same value for both.
+                let state = OIDCLogin.generateState()
+                let nonce = OIDCLogin.generateNonce()
+
+                let authorizationURL = try OIDCLogin.authorizationURL(
+                    for: provider,
+                    redirectURI: OIDCLogin.redirectURI,
+                    state: state,
+                    nonce: nonce
+                )
+
+                let callback = try await webAuthenticator.authenticate(
+                    url: authorizationURL,
+                    callbackScheme: OIDCLogin.callbackScheme,
+                    // Same isolation PR #103 wanted from a non-persistent data
+                    // store, without giving up the URL bar.
+                    prefersEphemeralSession: true
+                )
+
+                switch OIDCLogin.parseCallback(
+                    callback,
+                    expectedState: state,
+                    expectedScheme: OIDCLogin.callbackScheme
+                ) {
+                case let .success(code):
+                    try await appState.loginWithOIDC(
+                        serverURL: serverURL.absoluteString,
+                        provider: provider.key,
+                        code: code,
+                        redirectURI: OIDCLogin.redirectURI
+                    )
+
+                case let .providerError(error, description):
+                    errorMessage = description ?? "Your provider refused the sign-in (\(error))."
+
+                case .stateMismatch:
+                    errorMessage = "That sign-in response didn't match this request, so it was rejected."
+
+                case .malformed:
+                    errorMessage = "Your provider sent a sign-in response we couldn't read."
+                }
+            } catch WebAuthenticationError.cancelled {
+                // The user backed out. Say nothing.
+            } catch {
+                errorMessage = error.localizedDescription
+            }
         }
     }
 
     private var isFormIncomplete: Bool {
-        if serverURL.isEmpty { return true }
+        if serverURL.isEmpty {
+            return true
+        }
         if authMode == .credentials {
             return username.isEmpty || password.isEmpty
         } else {
@@ -181,10 +383,12 @@ struct ServerSetupView: View {
         isConnecting = true
         errorMessage = nil
 
-        var url = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !url.hasPrefix("http://"), !url.hasPrefix("https://") {
-            url = "https://" + url
+        guard let normalized = ServerURL.normalized(serverURL) else {
+            errorMessage = NetworkError.invalidURL.localizedDescription
+            isConnecting = false
+            return
         }
+        let url = normalized.absoluteString
 
         Task {
             do {

--- a/mDoneTests/AuthOptionsTests.swift
+++ b/mDoneTests/AuthOptionsTests.swift
@@ -1,0 +1,261 @@
+import XCTest
+@testable import mDone
+
+/// Decoding of `GET /api/v1/info` and the rules that turn it into a setup
+/// screen, for issue #153.
+///
+/// The JSON here is copied from a real Vikunja v2.4.0 with Authelia in front of
+/// it (see `scripts/dev-oidc-up.sh`), not hand-written from the docs.
+final class AuthOptionsTests: XCTestCase {
+    private func decode(_ json: String) throws -> ServerInfo {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(ServerInfo.self, from: Data(json.utf8))
+    }
+
+    // MARK: - Fixtures
+
+    /// Stock server, no identity provider configured. The common case.
+    private let stockJSON = """
+    {
+      "version": "v2.4.0",
+      "auth": {
+        "local": { "enabled": true, "registration_enabled": true },
+        "ldap": { "enabled": false },
+        "openid_connect": { "enabled": false, "providers": null }
+      }
+    }
+    """
+
+    /// Authelia configured, local auth still on.
+    private let oidcJSON = """
+    {
+      "version": "v2.4.0",
+      "auth": {
+        "local": { "enabled": true, "registration_enabled": true },
+        "ldap": { "enabled": false },
+        "openid_connect": {
+          "enabled": true,
+          "providers": [
+            {
+              "name": "Authelia",
+              "key": "authelia",
+              "auth_url": "https://auth.example.com/api/oidc/authorization",
+              "logout_url": "",
+              "client_id": "vikunja",
+              "scope": "openid profile email",
+              "email_fallback": false,
+              "username_fallback": false,
+              "force_user_info": false
+            }
+          ]
+        }
+      }
+    }
+    """
+
+    // MARK: - Decoding
+
+    func testStockServerDecodes() throws {
+        let info = try decode(stockJSON)
+        XCTAssertEqual(info.version, "v2.4.0")
+        XCTAssertTrue(info.auth.local.enabled)
+        XCTAssertEqual(info.auth.local.registrationEnabled, true)
+        XCTAssertFalse(info.auth.ldap.enabled)
+        XCTAssertFalse(info.auth.openidConnect.enabled)
+    }
+
+    func testNullProvidersDecodesRatherThanThrowing() throws {
+        // Vikunja sends null, not [], when nothing is configured. Decoding this
+        // as a non-optional array would fail on almost every real server.
+        let info = try decode(stockJSON)
+        XCTAssertNil(info.auth.openidConnect.providers)
+        XCTAssertTrue(AuthOptions(info: info).providers.isEmpty)
+    }
+
+    func testProviderDecodes() throws {
+        let info = try decode(oidcJSON)
+        let provider = try XCTUnwrap(info.auth.openidConnect.providers?.first)
+        XCTAssertEqual(provider.name, "Authelia")
+        XCTAssertEqual(provider.key, "authelia")
+        XCTAssertEqual(provider.clientId, "vikunja")
+        XCTAssertEqual(provider.scope, "openid profile email")
+        // Fully resolved by Vikunja from the provider's discovery document, so
+        // the app never has to build it.
+        XCTAssertEqual(provider.authorizationURL?.absoluteString, "https://auth.example.com/api/oidc/authorization")
+        XCTAssertEqual(provider.id, provider.key)
+    }
+
+    func testUnknownProviderFieldsAreIgnored() throws {
+        // email_fallback and friends are in the real payload and unused here.
+        XCTAssertNoThrow(try decode(oidcJSON))
+    }
+
+    // MARK: - Tolerating older or unexpected servers
+
+    func testMissingAuthBlockFallsBackToLocalOnly() throws {
+        // A server old enough to omit `auth` predates both OIDC and LDAP.
+        let info = try decode(#"{ "version": "v0.20.0" }"#)
+        XCTAssertTrue(info.auth.local.enabled)
+        XCTAssertFalse(info.auth.ldap.enabled)
+        XCTAssertFalse(info.auth.openidConnect.enabled)
+        XCTAssertTrue(AuthOptions(info: info).showsCredentials)
+    }
+
+    func testMissingLDAPKeyDefaultsToDisabled() throws {
+        let info = try decode("""
+        { "auth": { "local": { "enabled": true }, "openid_connect": { "enabled": false, "providers": null } } }
+        """)
+        XCTAssertFalse(info.auth.ldap.enabled)
+    }
+
+    func testEmptyProviderArrayIsTreatedLikeNone() throws {
+        let info = try decode("""
+        { "auth": { "local": { "enabled": true }, "openid_connect": { "enabled": true, "providers": [] } } }
+        """)
+        XCTAssertTrue(AuthOptions(info: info).providers.isEmpty)
+    }
+
+    // MARK: - The rules
+
+    func testStockServerShowsCredentialsAndNoSSO() throws {
+        let options = try AuthOptions(info: decode(stockJSON))
+        XCTAssertTrue(options.showsCredentials)
+        XCTAssertTrue(options.providers.isEmpty)
+        XCTAssertFalse(options.isAPITokenOnly)
+    }
+
+    func testBothAvailableShowsCredentialsAndSSO() throws {
+        let options = try AuthOptions(info: decode(oidcJSON))
+        XCTAssertTrue(options.showsCredentials)
+        XCTAssertEqual(options.providers.map(\.key), ["authelia"])
+    }
+
+    func testLocalAuthDisabledHidesCredentials() throws {
+        // The SSO-only case. Leaving the fields visible is not merely untidy:
+        // POST /api/v1/login returns 404 on such a server, so the user gets
+        // "Not Found" rather than anything actionable.
+        let info = try decode("""
+        {
+          "auth": {
+            "local": { "enabled": false, "registration_enabled": false },
+            "ldap": { "enabled": false },
+            "openid_connect": { "enabled": true, "providers": [
+              { "name": "Authelia", "key": "authelia", "auth_url": "https://auth.example.com/authorize" }
+            ] }
+          }
+        }
+        """)
+        let options = AuthOptions(info: info)
+        XCTAssertFalse(options.showsCredentials)
+        XCTAssertEqual(options.providers.count, 1)
+        XCTAssertFalse(options.isAPITokenOnly)
+    }
+
+    func testLDAPOnlyServerStillShowsCredentials() throws {
+        // The regression this rule exists to prevent. LDAP binds go through the
+        // same POST /login, so hiding the form on `local.enabled == false`
+        // alone would lock LDAP users out entirely. See issue #156.
+        let info = try decode("""
+        {
+          "auth": {
+            "local": { "enabled": false },
+            "ldap": { "enabled": true },
+            "openid_connect": { "enabled": false, "providers": null }
+          }
+        }
+        """)
+        XCTAssertTrue(AuthOptions(info: info).showsCredentials)
+    }
+
+    func testNoPasswordAndNoSSOLeavesOnlyAPIToken() throws {
+        let info = try decode("""
+        {
+          "auth": {
+            "local": { "enabled": false },
+            "ldap": { "enabled": false },
+            "openid_connect": { "enabled": false, "providers": null }
+          }
+        }
+        """)
+        let options = AuthOptions(info: info)
+        XCTAssertFalse(options.showsCredentials)
+        XCTAssertTrue(options.providers.isEmpty)
+        XCTAssertTrue(options.isAPITokenOnly)
+        XCTAssertTrue(options.showsAPIToken)
+    }
+
+    func testProvidersIgnoredWhenOIDCDisabled() throws {
+        // Trust the flag over a stale list.
+        let info = try decode("""
+        {
+          "auth": {
+            "local": { "enabled": true },
+            "openid_connect": { "enabled": false, "providers": [
+              { "name": "Authelia", "key": "authelia", "auth_url": "https://auth.example.com/authorize" }
+            ] }
+          }
+        }
+        """)
+        XCTAssertTrue(AuthOptions(info: info).providers.isEmpty)
+    }
+
+    func testOIDCEnabledWithNullProvidersYieldsNoButtons() throws {
+        // Not hypothetical: a misconfigured provider block leaves Vikunja
+        // reporting enabled: true with providers: null, which is what the dev
+        // stack did until the config was fixed. The screen must degrade to "no
+        // SSO buttons" rather than crash or show an empty row.
+        let info = try decode("""
+        {
+          "auth": {
+            "local": { "enabled": true },
+            "ldap": { "enabled": false },
+            "openid_connect": { "enabled": true, "providers": null }
+          }
+        }
+        """)
+        let options = AuthOptions(info: info)
+        XCTAssertTrue(options.providers.isEmpty)
+        XCTAssertTrue(options.showsCredentials)
+        XCTAssertFalse(options.isAPITokenOnly)
+    }
+
+    func testMissingLocalKeyDefaultsToEnabled() throws {
+        // Fail open on the password form: locking a user out of their own
+        // server is worse than showing a field the server will reject.
+        let info = try decode(#"{ "auth": { "ldap": { "enabled": false } } }"#)
+        XCTAssertTrue(info.auth.local.enabled)
+        XCTAssertTrue(AuthOptions(info: info).showsCredentials)
+    }
+
+    func testMissingOpenIDKeyDefaultsToDisabled() throws {
+        let info = try decode(#"{ "auth": { "local": { "enabled": true } } }"#)
+        XCTAssertFalse(info.auth.openidConnect.enabled)
+        XCTAssertTrue(AuthOptions(info: info).providers.isEmpty)
+    }
+
+    func testRulesHoldForValuesBuiltInCode() {
+        // Same rules, without going through JSON, so a decoding change cannot
+        // quietly mask a rules change.
+        let provider = OIDCProvider(name: "Authelia", key: "authelia", authUrl: "https://auth.example.com/authorize")
+        let info = ServerInfo(
+            version: "v2.4.0",
+            auth: .init(
+                local: .init(enabled: false),
+                ldap: .init(enabled: false),
+                openidConnect: .init(enabled: true, providers: [provider])
+            )
+        )
+        let options = AuthOptions(info: info)
+        XCTAssertFalse(options.showsCredentials)
+        XCTAssertEqual(options.providers, [provider])
+        XCTAssertEqual(provider.authorizationURL?.absoluteString, "https://auth.example.com/authorize")
+    }
+
+    func testUnknownServerDefaultMatchesPreIssueBehaviour() {
+        let options = AuthOptions.unknownServer
+        XCTAssertTrue(options.showsCredentials)
+        XCTAssertTrue(options.showsAPIToken)
+        XCTAssertTrue(options.providers.isEmpty)
+    }
+}

--- a/mDoneTests/EndpointPathEncodingTests.swift
+++ b/mDoneTests/EndpointPathEncodingTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import mDone
+
+/// `APIClient.buildRequest` builds URLs by string concatenation and a bare
+/// `URL(string:)`, with no escaping, so any endpoint that interpolates a
+/// server-supplied value into its path has to encode it itself.
+///
+/// This matters most for the OIDC callback, which is the request carrying the
+/// authorization code.
+final class EndpointPathEncodingTests: XCTestCase {
+    func testOrdinaryProviderKeyIsUnchanged() {
+        // The common case: Vikunja lowercases the provider name.
+        XCTAssertEqual(Endpoint.openIDCallback(provider: "authelia").path, "/api/v1/auth/openid/authelia/callback")
+        XCTAssertEqual(Endpoint.openIDCallback(provider: "keycloak-1").path, "/api/v1/auth/openid/keycloak-1/callback")
+    }
+
+    func testSlashCannotEscapeThePathSegment() {
+        // Without encoding this would POST the authorization code to
+        // /api/v1/auth/openid/../../../elsewhere.
+        let path = Endpoint.openIDCallback(provider: "a/../../evil").path
+        XCTAssertFalse(path.contains("a/"))
+        XCTAssertFalse(path.contains(".."))
+        XCTAssertEqual(path, "/api/v1/auth/openid/a%2F%2E%2E%2F%2E%2E%2Fevil/callback")
+    }
+
+    func testDotsAreEncodedSoTraversalCannotSurvive() {
+        XCTAssertFalse(Endpoint.openIDCallback(provider: "..").path.contains(".."))
+    }
+
+    func testQueryAndFragmentCannotBeInjected() {
+        let path = Endpoint.openIDCallback(provider: "x?a=b#frag").path
+        XCTAssertFalse(path.contains("?"))
+        XCTAssertFalse(path.contains("#"))
+    }
+
+    func testWhitespaceIsEncodedRatherThanProducingANilURL() {
+        // URL(string:) returns nil on a raw space, which would surface as a
+        // confusing invalidURL rather than a working request.
+        XCTAssertFalse(Endpoint.openIDCallback(provider: "two words").path.contains(" "))
+    }
+
+    func testEncodedSegmentStillProducesAUsableURL() {
+        for key in ["authelia", "a/b", "..", "two words", "ünïcode", ""] {
+            let path = Endpoint.openIDCallback(provider: key).path
+            XCTAssertNotNil(URL(string: "https://vikunja.example.com" + path), "unusable URL for key \(key)")
+        }
+    }
+
+    func testUnicodeKeyIsEncoded() {
+        let path = Endpoint.openIDCallback(provider: "ünïcode").path
+        XCTAssertTrue(path.contains("%"))
+        XCTAssertNotNil(URL(string: "https://vikunja.example.com" + path))
+    }
+}

--- a/mDoneTests/OIDCAuthorizationURLTests.swift
+++ b/mDoneTests/OIDCAuthorizationURLTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import mDone
+
+/// The app builds the authorization URL itself: Vikunja supplies only the
+/// resolved endpoint in `auth_url`. Getting a parameter wrong here fails at the
+/// provider, or worse at the token exchange, long after the user has finished
+/// logging in.
+final class OIDCAuthorizationURLTests: XCTestCase {
+    private let redirectURI = "mdone://oidc-callback"
+
+    private func provider(
+        authUrl: String = "https://auth.example.com/api/oidc/authorization",
+        clientId: String? = "vikunja",
+        scope: String? = "openid profile email"
+    ) -> OIDCProvider {
+        OIDCProvider(name: "Authelia", key: "authelia", authUrl: authUrl, clientId: clientId, scope: scope)
+    }
+
+    private func query(_ url: URL) -> [String: String] {
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        return items.reduce(into: [:]) { $0[$1.name] = $1.value }
+    }
+
+    // MARK: - Happy path
+
+    func testBuildsEveryRequiredParameter() throws {
+        let url = try OIDCLogin.authorizationURL(
+            for: provider(),
+            redirectURI: redirectURI,
+            state: "the-state",
+            nonce: "the-nonce"
+        )
+        let params = query(url)
+        XCTAssertEqual(params["client_id"], "vikunja")
+        XCTAssertEqual(params["response_type"], "code")
+        XCTAssertEqual(params["redirect_uri"], redirectURI)
+        XCTAssertEqual(params["scope"], "openid profile email")
+        XCTAssertEqual(params["state"], "the-state")
+        XCTAssertEqual(params["nonce"], "the-nonce")
+    }
+
+    func testKeepsTheProvidersEndpointIntact() throws {
+        let url = try OIDCLogin.authorizationURL(
+            for: provider(),
+            redirectURI: redirectURI,
+            state: "s",
+            nonce: "n"
+        )
+        XCTAssertEqual(url.scheme, "https")
+        XCTAssertEqual(url.host, "auth.example.com")
+        XCTAssertEqual(url.path, "/api/oidc/authorization")
+    }
+
+    func testCustomSchemeRedirectSurvivesEncoding() throws {
+        // The redirect URI has to match what Vikunja is later sent byte for
+        // byte, or the exchange fails with invalid_grant.
+        let url = try OIDCLogin.authorizationURL(
+            for: provider(),
+            redirectURI: redirectURI,
+            state: "s",
+            nonce: "n"
+        )
+        XCTAssertEqual(query(url)["redirect_uri"], "mdone://oidc-callback")
+    }
+
+    func testExistingQueryParametersOnTheEndpointArePreserved() throws {
+        // Some providers publish an authorization endpoint that already carries
+        // parameters. Replacing them would break those providers.
+        let url = try OIDCLogin.authorizationURL(
+            for: provider(authUrl: "https://auth.example.com/authorize?tenant=acme"),
+            redirectURI: redirectURI,
+            state: "s",
+            nonce: "n"
+        )
+        let params = query(url)
+        XCTAssertEqual(params["tenant"], "acme")
+        XCTAssertEqual(params["client_id"], "vikunja")
+    }
+
+    func testFallsBackToADefaultScope() throws {
+        // Vikunja normally advertises one, but do not send an empty scope if not.
+        let url = try OIDCLogin.authorizationURL(
+            for: provider(scope: nil),
+            redirectURI: redirectURI,
+            state: "s",
+            nonce: "n"
+        )
+        XCTAssertEqual(query(url)["scope"], OIDCLogin.defaultScope)
+        XCTAssertTrue(OIDCLogin.defaultScope.contains("openid"))
+    }
+
+    func testServerSuppliedScopeWins() throws {
+        let url = try OIDCLogin.authorizationURL(
+            for: provider(scope: "openid email groups"),
+            redirectURI: redirectURI,
+            state: "s",
+            nonce: "n"
+        )
+        XCTAssertEqual(query(url)["scope"], "openid email groups")
+    }
+
+    // MARK: - Rejections
+
+    func testInsecureEndpointIsRejected() throws {
+        // App Transport Security would refuse to load it anyway. Failing here
+        // gives a better message than a generic network error.
+        XCTAssertThrowsError(try OIDCLogin.authorizationURL(
+            for: provider(authUrl: "http://auth.example.com/authorize"),
+            redirectURI: redirectURI, state: "s", nonce: "n"
+        )) { XCTAssertEqual($0 as? OIDCLoginError, .insecureAuthorizationEndpoint) }
+    }
+
+    func testMissingClientIDIsRejected() throws {
+        XCTAssertThrowsError(try OIDCLogin.authorizationURL(
+            for: provider(clientId: nil), redirectURI: redirectURI, state: "s", nonce: "n"
+        )) { XCTAssertEqual($0 as? OIDCLoginError, .missingClientID) }
+    }
+
+    func testEmptyClientIDIsRejected() throws {
+        XCTAssertThrowsError(try OIDCLogin.authorizationURL(
+            for: provider(clientId: ""), redirectURI: redirectURI, state: "s", nonce: "n"
+        )) { XCTAssertEqual($0 as? OIDCLoginError, .missingClientID) }
+    }
+
+    func testUnusableEndpointsAreRejected() throws {
+        for bad in ["", "not a url", "/authorize", "https://"] {
+            XCTAssertThrowsError(try OIDCLogin.authorizationURL(
+                for: provider(authUrl: bad), redirectURI: redirectURI, state: "s", nonce: "n"
+            ), "expected \(bad) to be rejected")
+        }
+    }
+
+    func testEveryErrorHasAUserFacingMessage() {
+        // These surface on the setup screen, so none may fall through to the
+        // default "The operation couldn't be completed" text.
+        for error in [
+            OIDCLoginError.invalidAuthorizationEndpoint,
+            .insecureAuthorizationEndpoint,
+            .missingClientID,
+        ] {
+            XCTAssertFalse(error.localizedDescription.isEmpty)
+            XCTAssertFalse(error.localizedDescription.contains("couldn't be completed"))
+        }
+    }
+
+    // MARK: - Round trip with the real generators
+
+    func testGeneratedStateAndNonceSurviveTheURLAndComeBack() throws {
+        let state = OIDCLogin.generateState()
+        let nonce = OIDCLogin.generateNonce()
+        let url = try OIDCLogin.authorizationURL(
+            for: provider(), redirectURI: redirectURI, state: state, nonce: nonce
+        )
+        let params = query(url)
+        XCTAssertEqual(params["state"], state)
+        XCTAssertEqual(params["nonce"], nonce)
+        XCTAssertNotEqual(params["state"], params["nonce"])
+
+        // And the state we put in is the state the callback parser expects out.
+        let callback = try XCTUnwrap(URL(string: "mdone://oidc-callback?code=abc&state=\(state)"))
+        XCTAssertEqual(
+            OIDCLogin.parseCallback(callback, expectedState: state, expectedScheme: "mdone"),
+            .success(code: "abc")
+        )
+    }
+}

--- a/mDoneTests/OIDCCallbackTests.swift
+++ b/mDoneTests/OIDCCallbackTests.swift
@@ -1,0 +1,248 @@
+import XCTest
+@testable import mDone
+
+/// The redirect parser is the security-critical half of issue #153 and was
+/// untested in PR #103, which is where two of these cases come from directly:
+/// the `state` token that was generated and never compared, and the `error=`
+/// response that left the user on a stuck web view.
+final class OIDCCallbackTests: XCTestCase {
+    private let state = "expected-state-abc123"
+
+    private func callback(_ query: String, scheme: String = "mdone") -> URL {
+        URL(string: "\(scheme)://auth/openid/authelia?\(query)")!
+    }
+
+    // MARK: - Success
+
+    func testValidCallbackReturnsCode() {
+        let result = OIDCLogin.parseCallback(callback("code=auth-code-xyz&state=\(state)"), expectedState: state)
+        XCTAssertEqual(result, .success(code: "auth-code-xyz"))
+    }
+
+    func testParameterOrderDoesNotMatter() {
+        let result = OIDCLogin.parseCallback(callback("state=\(state)&code=auth-code-xyz"), expectedState: state)
+        XCTAssertEqual(result, .success(code: "auth-code-xyz"))
+    }
+
+    func testIssuerParameterIsTolerated() {
+        // Authelia returns `iss` per RFC 9207, alongside code and state.
+        let result = OIDCLogin.parseCallback(
+            callback("code=abc&state=\(state)&iss=https%3A%2F%2Fauth.example.com&scope=openid+profile"),
+            expectedState: state
+        )
+        XCTAssertEqual(result, .success(code: "abc"))
+    }
+
+    func testPercentEncodedCodeIsDecoded() {
+        // Real Authelia codes contain "." and "-"; other providers emit "/" and
+        // "+", which arrive percent-encoded.
+        let result = OIDCLogin.parseCallback(
+            callback("code=abc%2Fdef%2Bghi%3D&state=\(state)"),
+            expectedState: state
+        )
+        XCTAssertEqual(result, .success(code: "abc/def+ghi="))
+    }
+
+    // MARK: - State validation (the #103 bug)
+
+    func testMismatchedStateIsRejected() {
+        let result = OIDCLogin.parseCallback(callback("code=abc&state=attacker-chosen"), expectedState: state)
+        XCTAssertEqual(result, .stateMismatch)
+    }
+
+    func testMissingStateIsRejected() {
+        let result = OIDCLogin.parseCallback(callback("code=abc"), expectedState: state)
+        XCTAssertEqual(result, .stateMismatch)
+    }
+
+    func testEmptyStateIsRejected() {
+        let result = OIDCLogin.parseCallback(callback("code=abc&state="), expectedState: state)
+        XCTAssertEqual(result, .stateMismatch)
+    }
+
+    func testStateComparisonIsCaseSensitive() {
+        let result = OIDCLogin.parseCallback(callback("code=abc&state=\(state.uppercased())"), expectedState: state)
+        XCTAssertEqual(result, .stateMismatch)
+    }
+
+    func testStateIsCheckedBeforeErrorIsReported() {
+        // A forged error response should not get as far as being surfaced.
+        let result = OIDCLogin.parseCallback(callback("error=access_denied&state=wrong"), expectedState: state)
+        XCTAssertEqual(result, .stateMismatch)
+    }
+
+    // MARK: - Provider errors (the other #103 bug)
+
+    func testAccessDeniedIsSurfaced() {
+        let result = OIDCLogin.parseCallback(
+            callback("error=access_denied&error_description=User%20cancelled&state=\(state)"),
+            expectedState: state
+        )
+        XCTAssertEqual(result, .providerError(error: "access_denied", description: "User cancelled"))
+    }
+
+    func testErrorWithoutDescriptionIsSurfaced() {
+        let result = OIDCLogin.parseCallback(callback("error=server_error&state=\(state)"), expectedState: state)
+        XCTAssertEqual(result, .providerError(error: "server_error", description: nil))
+    }
+
+    func testErrorWinsOverCode() {
+        // A response carrying both is a failure pretending to be a success.
+        let result = OIDCLogin.parseCallback(
+            callback("code=abc&error=invalid_request&state=\(state)"),
+            expectedState: state
+        )
+        XCTAssertEqual(result, .providerError(error: "invalid_request", description: nil))
+    }
+
+    // MARK: - Malformed input
+
+    func testMissingCodeIsMalformed() {
+        let result = OIDCLogin.parseCallback(callback("state=\(state)"), expectedState: state)
+        XCTAssertEqual(result, .malformed(.missingCode))
+    }
+
+    func testEmptyCodeIsMalformed() {
+        let result = OIDCLogin.parseCallback(callback("code=&state=\(state)"), expectedState: state)
+        XCTAssertEqual(result, .malformed(.missingCode))
+    }
+
+    func testNoQueryParametersIsMalformed() throws {
+        let result = try OIDCLogin.parseCallback(
+            XCTUnwrap(URL(string: "mdone://auth/openid/authelia")),
+            expectedState: state
+        )
+        XCTAssertEqual(result, .malformed(.noQueryParameters))
+    }
+
+    func testDuplicateCodeIsRejected() {
+        // Which duplicate wins is a parser detail an attacker can aim at.
+        let result = OIDCLogin.parseCallback(
+            callback("code=good&code=evil&state=\(state)"),
+            expectedState: state
+        )
+        XCTAssertEqual(result, .malformed(.duplicateParameter("code")))
+    }
+
+    func testDuplicateStateIsRejected() {
+        let result = OIDCLogin.parseCallback(
+            callback("code=abc&state=\(state)&state=other"),
+            expectedState: state
+        )
+        XCTAssertEqual(result, .malformed(.duplicateParameter("state")))
+    }
+
+    func testUnexpectedSchemeIsRejected() {
+        let result = OIDCLogin.parseCallback(
+            callback("code=abc&state=\(state)", scheme: "https"),
+            expectedState: state,
+            expectedScheme: "mdone"
+        )
+        XCTAssertEqual(result, .malformed(.unexpectedCallbackScheme))
+    }
+
+    func testMatchingSchemeIsAccepted() {
+        let result = OIDCLogin.parseCallback(
+            callback("code=abc&state=\(state)"),
+            expectedState: state,
+            expectedScheme: "MDone" // registration is case-insensitive
+        )
+        XCTAssertEqual(result, .success(code: "abc"))
+    }
+
+    // MARK: - The code must not leak into logs
+
+    func testDebugDescriptionRedactsTheCode() {
+        let result = OIDCLogin.parseCallback(
+            callback("code=super-secret-code&state=\(state)"),
+            expectedState: state
+        )
+        // Catches the `print("\(result)")` that slips through review.
+        XCTAssertFalse(String(reflecting: result).contains("super-secret-code"))
+        XCTAssertTrue(String(reflecting: result).contains("redacted"))
+    }
+
+    func testProviderErrorDescriptionIsNotRedacted() {
+        // The error is diagnostic, not a credential, so it stays readable.
+        let result = OIDCLogin.parseCallback(
+            callback("error=access_denied&state=\(state)"),
+            expectedState: state
+        )
+        XCTAssertTrue(String(reflecting: result).contains("access_denied"))
+    }
+
+    func testDebugDescriptionCoversTheRejectionCases() {
+        let mismatch = OIDCLogin.parseCallback(callback("code=abc&state=wrong"), expectedState: state)
+        XCTAssertTrue(String(reflecting: mismatch).contains("stateMismatch"))
+
+        let malformed = OIDCLogin.parseCallback(callback("state=\(state)"), expectedState: state)
+        XCTAssertTrue(String(reflecting: malformed).contains("malformed"))
+        XCTAssertTrue(String(reflecting: malformed).contains("missingCode"))
+    }
+
+    // MARK: - State generation
+
+    func testGeneratedStateIsLongEnough() {
+        // 32 bytes base64url, unpadded.
+        XCTAssertEqual(OIDCLogin.generateState().count, 43)
+    }
+
+    func testGeneratedStateIsURLSafe() {
+        let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+        for _ in 0 ..< 100 {
+            let state = OIDCLogin.generateState()
+            XCTAssertTrue(state.unicodeScalars.allSatisfy { allowed.contains($0) }, "not URL safe: \(state)")
+        }
+    }
+
+    func testGeneratedStatesAreUnique() {
+        let states = Set((0 ..< 2000).map { _ in OIDCLogin.generateState() })
+        XCTAssertEqual(states.count, 2000)
+    }
+
+    // MARK: - Nonce generation
+
+    func testGeneratedNonceIsLongEnough() {
+        // 32 bytes base64url, unpadded. Providers enforce a floor: Authelia
+        // rejects a short nonce with `insufficient_entropy`, and it surfaces at
+        // the token exchange, long after the user finished logging in.
+        XCTAssertEqual(OIDCLogin.generateNonce().count, 43)
+    }
+
+    func testGeneratedNonceIsURLSafe() {
+        let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+        for _ in 0 ..< 100 {
+            let nonce = OIDCLogin.generateNonce()
+            XCTAssertTrue(nonce.unicodeScalars.allSatisfy { allowed.contains($0) }, "not URL safe: \(nonce)")
+        }
+    }
+
+    func testGeneratedNoncesAreUnique() {
+        let nonces = Set((0 ..< 2000).map { _ in OIDCLogin.generateNonce() })
+        XCTAssertEqual(nonces.count, 2000)
+    }
+
+    func testStateAndNonceAreIndependentValues() {
+        // The one mistake worth guarding against here. They protect against
+        // different attacks, and reusing a single token for both means a leak
+        // of either defeats both.
+        for _ in 0 ..< 100 {
+            XCTAssertNotEqual(OIDCLogin.generateState(), OIDCLogin.generateNonce())
+        }
+    }
+
+    func testStateAndNonceDrawFromTheSamePool() {
+        // Not a security property, just a guard against one of them being
+        // quietly reimplemented with a weaker or shorter source later.
+        XCTAssertEqual(OIDCLogin.generateState().count, OIDCLogin.generateNonce().count)
+    }
+
+    // MARK: - Round trip
+
+    func testGeneratedStateRoundTripsThroughAQueryString() {
+        // The whole point of base64url: no escaping on the way out or back.
+        let state = OIDCLogin.generateState()
+        let result = OIDCLogin.parseCallback(callback("code=abc&state=\(state)"), expectedState: state)
+        XCTAssertEqual(result, .success(code: "abc"))
+    }
+}

--- a/mDoneTests/ServerInfoServiceTests.swift
+++ b/mDoneTests/ServerInfoServiceTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import mDone
+
+/// The setup screen probes an unknown server before the user has any
+/// credentials for it, so this has to work unauthenticated and must never touch
+/// the shared client.
+final class ServerInfoServiceTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    private let oidcJSON = """
+    {
+      "version": "v2.4.0",
+      "auth": {
+        "local": { "enabled": true, "registration_enabled": true },
+        "ldap": { "enabled": false },
+        "openid_connect": {
+          "enabled": true,
+          "providers": [
+            { "name": "Authelia", "key": "authelia",
+              "auth_url": "https://auth.example.com/api/oidc/authorization",
+              "client_id": "vikunja", "scope": "openid profile email" }
+          ]
+        }
+      }
+    }
+    """
+
+    private func service() -> ServerInfoService {
+        ServerInfoService(apiClient: APIClient(session: MockURLProtocol.mockSession()))
+    }
+
+    func testFetchesTheInfoEndpoint() async throws {
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data(self.oidcJSON.utf8))
+        }
+        let info = try await service().fetch(from: XCTUnwrap(URL(string: "https://vikunja.example.com")))
+
+        XCTAssertEqual(MockURLProtocol.capturedRequests.first?.url?.path, "/api/v1/info")
+        XCTAssertEqual(info.auth.openidConnect.providers?.first?.key, "authelia")
+    }
+
+    func testSendsNoAuthorizationHeader() async throws {
+        // The probe runs before the user has credentials. An empty bearer token
+        // is not merely useless: a forward-auth proxy in front of Vikunja can
+        // reject the malformed header, which reads as an unreachable server.
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data(self.oidcJSON.utf8))
+        }
+        _ = try await service().fetch(from: XCTUnwrap(URL(string: "https://vikunja.example.com")))
+
+        let header = MockURLProtocol.capturedRequests.first?.value(forHTTPHeaderField: "Authorization")
+        XCTAssertNil(header)
+    }
+
+    func testDecodesWithSnakeCaseConversion() async throws {
+        // Without convertFromSnakeCase, openid_connect fails to map and decodes
+        // via decodeIfPresent to "disabled", so an SSO-capable server would
+        // render with no SSO buttons and no error anywhere.
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data(self.oidcJSON.utf8))
+        }
+        let info = try await service().fetch(from: XCTUnwrap(URL(string: "https://vikunja.example.com")))
+
+        XCTAssertTrue(info.auth.openidConnect.enabled)
+        XCTAssertEqual(
+            info.auth.openidConnect.providers?.first?.authUrl,
+            "https://auth.example.com/api/oidc/authorization"
+        )
+        XCTAssertEqual(info.auth.local.registrationEnabled, true)
+    }
+
+    func testTargetsTheServerItWasGiven() async throws {
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data(self.oidcJSON.utf8))
+        }
+        _ = try await service().fetch(from: XCTUnwrap(URL(string: "https://other.example.org:8443")))
+
+        let url = MockURLProtocol.capturedRequests.first?.url
+        XCTAssertEqual(url?.host, "other.example.org")
+        XCTAssertEqual(url?.port, 8443)
+    }
+
+    func testServerErrorPropagates() async throws {
+        // The caller degrades to AuthOptions.unknownServer; this only has to
+        // fail rather than hang or return something invented.
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 500, url: request.url), Data("{}".utf8))
+        }
+        do {
+            _ = try await service().fetch(from: XCTUnwrap(URL(string: "https://vikunja.example.com")))
+            XCTFail("expected a throw")
+        } catch {
+            // expected
+        }
+    }
+
+    func testMalformedJSONPropagates() async throws {
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data("not json".utf8))
+        }
+        do {
+            _ = try await service().fetch(from: XCTUnwrap(URL(string: "https://vikunja.example.com")))
+            XCTFail("expected a throw")
+        } catch {
+            // expected
+        }
+    }
+
+    func testDoesNotDisturbTheSharedClient() async throws {
+        // Probing on every keystroke must not overwrite a signed-in user's
+        // server URL and token on the shared singleton.
+        await APIClient.shared.configure(serverURL: "https://real.example.com", token: "real-token")
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data(self.oidcJSON.utf8))
+        }
+        _ = try await service().fetch(from: XCTUnwrap(URL(string: "https://someone-elses.example.org")))
+
+        // The probe configures its own client with an empty token. If it had
+        // used the singleton, this would now be "".
+        let stillConfigured = await APIClient.shared.currentToken()
+        XCTAssertEqual(stillConfigured, "real-token")
+        await APIClient.shared.clearCredentials()
+    }
+}

--- a/mDoneTests/ServerURLTests.swift
+++ b/mDoneTests/ServerURLTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import mDone
+
+/// `ServerURL` is pure and branchy, and it decides whether a user can connect
+/// at all, so it gets a table rather than a handful of examples. Extracted from
+/// `ServerSetupView.connect()` for issue #153.
+final class ServerURLTests: XCTestCase {
+    // MARK: - Normalization
+
+    func testMissingSchemeDefaultsToHTTPS() {
+        XCTAssertEqual(ServerURL.normalized("vikunja.example.com")?.absoluteString, "https://vikunja.example.com")
+    }
+
+    func testExistingSchemesArePreserved() {
+        XCTAssertEqual(ServerURL.normalized("http://vikunja.example.com")?.absoluteString, "http://vikunja.example.com")
+        XCTAssertEqual(
+            ServerURL.normalized("https://vikunja.example.com")?.absoluteString,
+            "https://vikunja.example.com"
+        )
+    }
+
+    func testTrailingSlashesAreStripped() {
+        // Otherwise appending a path yields "//api/v1/...".
+        XCTAssertEqual(ServerURL.normalized("https://example.com/")?.absoluteString, "https://example.com")
+        XCTAssertEqual(ServerURL.normalized("https://example.com///")?.absoluteString, "https://example.com")
+    }
+
+    func testSurroundingWhitespaceIsTrimmed() {
+        XCTAssertEqual(ServerURL.normalized("  example.com \n")?.absoluteString, "https://example.com")
+    }
+
+    func testSubpathIsPreserved() {
+        // Vikunja is often reverse-proxied under a path.
+        XCTAssertEqual(ServerURL.normalized("example.com/vikunja")?.absoluteString, "https://example.com/vikunja")
+    }
+
+    func testPortIsPreserved() {
+        XCTAssertEqual(ServerURL.normalized("http://localhost:3456")?.absoluteString, "http://localhost:3456")
+    }
+
+    // MARK: - Hosts a self-hoster legitimately uses
+
+    func testSelfHostedShapesAreAccepted() {
+        let accepted = [
+            "localhost",
+            "http://localhost:3456",
+            "127.0.0.1",
+            "http://127.0.0.1:3456",
+            "192.168.1.50",
+            "10.0.0.1:3456",
+            "vikunja", // single-label intranet name
+            "vikunja.local",
+            "vikunja.example.com",
+            "172.25.17.55.nip.io", // the dev stack's host
+            "http://[::1]:3456"
+        ]
+        for input in accepted {
+            XCTAssertTrue(ServerURL.isValid(input), "expected \(input) to be accepted")
+        }
+    }
+
+    // MARK: - Rejections
+
+    func testEmptyAndWhitespaceAreRejected() {
+        XCTAssertNil(ServerURL.normalized(""))
+        XCTAssertNil(ServerURL.normalized("   "))
+        XCTAssertNil(ServerURL.normalized("\n\t"))
+    }
+
+    func testNonHTTPSchemesAreRejected() {
+        // The user pasting one of these should not produce a "server URL".
+        for input in ["javascript:alert(1)", "file:///etc/passwd", "ftp://example.com", "mdone://callback"] {
+            XCTAssertNil(ServerURL.normalized(input), "expected \(input) to be rejected")
+        }
+    }
+
+    func testSingleCharacterTLDIsRejected() {
+        // Nearly always a truncated "example.co" or "example.com".
+        XCTAssertNil(ServerURL.normalized("example.c"))
+    }
+
+    func testMalformedHostsAreRejected() {
+        for input in ["https://", "http:///path", "exa mple.com", "example..com", ".example.com", "example.com."] {
+            XCTAssertNil(ServerURL.normalized(input), "expected \(input) to be rejected")
+        }
+    }
+
+    func testNumericTLDIsRejected() {
+        // Distinct from a bare IPv4, which is allowed above.
+        XCTAssertNil(ServerURL.normalized("example.123"))
+    }
+}

--- a/scripts/dev-macos-oidc.sh
+++ b/scripts/dev-macos-oidc.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Builds and launches a throwaway macOS build for testing SSO login, isolated
+# from your installed mDone.
+#
+#   ./scripts/dev-macos-oidc.sh            build and launch
+#   ./scripts/dev-macos-oidc.sh --cleanup  quit it and remove every trace
+#
+# Why the isolation matters: the normal macOS build shares bundle identifier
+# com.mdone.app with the copy in /Applications, so it reads the same keychain
+# and the same sandbox container. Running it would sign you straight into your
+# real server without ever showing the setup screen, and signing in to a test
+# server would overwrite the credentials your real app is using.
+#
+# Overriding PRODUCT_BUNDLE_IDENTIFIER gives the build its own keychain access
+# group and its own container, so nothing it does can touch the real app.
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+TEST_BUNDLE_ID="com.mdone.app.oidctest"
+BUILD_DIR=".build/macos-oidc"
+APP="${BUILD_DIR}/Build/Products/Debug/mDone-macOS.app"
+
+if [ "${1:-}" = "--cleanup" ]; then
+    pkill -f "macos-oidc/Build" 2>/dev/null || true
+    sleep 1
+    if [ -d "$APP" ]; then
+        /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
+            -u "$(pwd)/$APP" 2>/dev/null || true
+    fi
+    rm -rf "$BUILD_DIR"
+    # macOS guards the container's metadata, so this usually cannot be deleted
+    # outright. It is an empty sandbox belonging to a bundle id that no longer
+    # exists on disk, so leaving it costs nothing.
+    CONTAINER="$HOME/Library/Containers/${TEST_BUNDLE_ID}"
+    if [ -d "$CONTAINER" ]; then
+        rm -rf "$CONTAINER" 2>/dev/null || true
+        [ -d "$CONTAINER" ] && echo "==> note: macOS would not let us delete ${CONTAINER}. It is empty and harmless."
+    fi
+    echo "==> cleaned up. Your installed mDone was never touched."
+    exit 0
+fi
+
+echo "==> building an isolated macOS build (${TEST_BUNDLE_ID})"
+xcodebuild -project mDone.xcodeproj -scheme mDone-macOS \
+    -derivedDataPath "$BUILD_DIR" \
+    PRODUCT_BUNDLE_IDENTIFIER="$TEST_BUNDLE_ID" \
+    build >/dev/null 2>&1 || { echo "build failed, rerun without >/dev/null to see why" >&2; exit 1; }
+
+# Prove the isolation rather than assume it.
+BUNDLE=$(defaults read "$(pwd)/${APP}/Contents/Info.plist" CFBundleIdentifier)
+[ "$BUNDLE" = "$TEST_BUNDLE_ID" ] || { echo "bundle id override did not take: $BUNDLE" >&2; exit 1; }
+
+echo "==> launching"
+open -a "$(pwd)/$APP"
+
+cat <<EOF
+
+Isolated build running. Your installed mDone keeps its own login.
+
+  1. Paste your server URL into Server URL.
+  2. Wait a beat. If that server advertises an OIDC provider, a
+     "Continue with <provider>" button appears under Connect.
+  3. Click it. macOS opens your DEFAULT BROWSER, not an in-app sheet.
+  4. Sign in there.
+
+The thing to watch for is step 4's return: does the browser hand you back
+to mDone, and does mDone land on the task list? That is the one leg of
+this flow still unverified on macOS.
+
+If it hangs on the spinner instead, the callback is not reaching the app,
+and mdone://oidc-callback almost certainly needs registering as a redirect
+URI on the identity provider for that server.
+
+When done:  ./scripts/dev-macos-oidc.sh --cleanup
+EOF

--- a/scripts/dev-oidc-smoke.sh
+++ b/scripts/dev-oidc-smoke.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# End-to-end check of the OIDC leg the app has to perform, against the dev
+# stack from scripts/dev-oidc-up.sh:
+#
+#   authorize -> Authelia login -> code -> Vikunja callback -> JWT -> API call
+#
+# It also asserts the two security properties issue #153 calls out: that the
+# `state` round-trips unchanged, and that an authorization code is single use.
+#
+# This is the scripted stand-in for the browser flow. It does not exercise
+# ASWebAuthenticationSession, which is system UI and has to be checked by hand.
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+[ -f .env.oidc ] || { echo "run scripts/dev-oidc-up.sh first" >&2; exit 1; }
+# shellcheck disable=SC1091
+. .env.oidc
+
+CAROOT="$(mkcert -CAROOT)"
+CURL=(curl -sS --cacert "${CAROOT}/rootCA.pem")
+JAR="$(mktemp)"
+trap 'rm -f "$JAR"' EXIT
+
+AUTH_HOST="https://auth.${DEV_BASE}:8443"
+VIK_HOST="https://vikunja.${DEV_BASE}:8443"
+REDIRECT="${VIK_HOST}/auth/openid/authelia"
+STATE="state-$$-$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+NONCE="nonce-$$-$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "  ok: $*"; }
+
+echo "==> 1. authorization request"
+LOC=$("${CURL[@]}" -c "$JAR" -D- -o /dev/null \
+    "${AUTH_HOST}/api/oidc/authorization?client_id=vikunja&response_type=code&scope=openid+profile+email&redirect_uri=${REDIRECT}&state=${STATE}&nonce=${NONCE}" \
+    | grep -i '^location:' | tr -d '\r' | cut -d' ' -f2-)
+FLOW_ID=$(printf '%s' "$LOC" | sed -n 's/.*flow_id=\([0-9a-f-]*\).*/\1/p')
+[ -n "$FLOW_ID" ] || fail "no flow_id in redirect: $LOC"
+ok "redirected to the login portal (flow ${FLOW_ID:0:8}...)"
+
+echo "==> 2. first factor"
+REDIR=$("${CURL[@]}" -b "$JAR" -c "$JAR" -X POST "${AUTH_HOST}/api/firstfactor" \
+    -H 'Content-Type: application/json' -H "Origin: ${AUTH_HOST}" \
+    -d "{\"username\":\"devuser\",\"password\":\"devpassword\",\"keepMeLoggedIn\":false,\"flowID\":\"${FLOW_ID}\",\"flow\":\"openid_connect\"}" \
+    | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit("status "+d.get("status","?")) if d.get("status")!="OK" else print(d["data"]["redirect"])')
+ok "authenticated as devuser"
+
+echo "==> 3. consent and code issue"
+LOC=$("${CURL[@]}" -b "$JAR" -c "$JAR" -D- -o /dev/null "$REDIR" \
+    | grep -i '^location:' | tr -d '\r' | cut -d' ' -f2-)
+eval "$(printf '%s' "$LOC" | python3 -c '
+import sys, urllib.parse as u
+q = u.parse_qs(u.urlparse(sys.stdin.read().strip()).query)
+print("CODE=%s" % u.quote(q.get("code",[""])[0]))
+print("GOT_STATE=%s" % q.get("state",[""])[0])
+print("ERR=%s" % q.get("error",[""])[0])
+')"
+[ -z "${ERR:-}" ] || fail "provider returned error=${ERR}"
+[ -n "${CODE:-}" ] || fail "no code in callback: $LOC"
+ok "received an authorization code"
+
+echo "==> 4. state validation"
+[ "$GOT_STATE" = "$STATE" ] || fail "state mismatch: sent '$STATE', got '$GOT_STATE'"
+ok "state round-tripped unchanged"
+
+echo "==> 5. code exchange at Vikunja"
+TOKEN=$("${CURL[@]}" -X POST "${VIK_HOST}/api/v1/auth/openid/authelia/callback" \
+    -H 'Content-Type: application/json' \
+    -d "{\"code\":\"${CODE}\",\"redirect_url\":\"${REDIRECT}\"}" \
+    | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("token",""))')
+[ -n "$TOKEN" ] || fail "no token returned"
+ok "exchanged for a Vikunja JWT"
+
+echo "==> 6. the JWT is a working session"
+COUNT=$("${CURL[@]}" -H "Authorization: Bearer ${TOKEN}" "${VIK_HOST}/api/v1/projects" \
+    | python3 -c 'import json,sys; d=json.load(sys.stdin); print(len(d) if isinstance(d,list) else -1)')
+[ "$COUNT" -ge 0 ] || fail "the JWT did not authenticate against /projects"
+ok "GET /api/v1/projects returned ${COUNT} projects"
+
+echo "==> 7. the code is single use"
+REPLAY=$("${CURL[@]}" -o /dev/null -w '%{http_code}' -X POST "${VIK_HOST}/api/v1/auth/openid/authelia/callback" \
+    -H 'Content-Type: application/json' \
+    -d "{\"code\":\"${CODE}\",\"redirect_url\":\"${REDIRECT}\"}")
+[ "$REPLAY" != "200" ] || fail "replaying the code succeeded, it should not"
+ok "replaying the same code is rejected (HTTP ${REPLAY})"
+
+echo
+echo "PASS: code-to-JWT leg works end to end"

--- a/scripts/dev-oidc-smoke.sh
+++ b/scripts/dev-oidc-smoke.sh
@@ -23,18 +23,43 @@ CURL=(curl -sS --cacert "${CAROOT}/rootCA.pem")
 JAR="$(mktemp)"
 trap 'rm -f "$JAR"' EXIT
 
-AUTH_HOST="https://auth.${DEV_BASE}:8443"
 VIK_HOST="https://vikunja.${DEV_BASE}:8443"
-REDIRECT="${VIK_HOST}/auth/openid/authelia"
-STATE="state-$$-$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
-NONCE="nonce-$$-$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+
+# The app's own callback URI. See docs/oidc-callback-decision.md.
+REDIRECT="mdone://oidc-callback"
+
+# state and nonce are independent values, and providers enforce a floor on
+# nonce entropy: a short one is rejected with `insufficient_entropy` at the
+# token exchange, long after the user has finished logging in.
+STATE=$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')
+NONCE=$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "  ok: $*"; }
 
+echo "==> 0. discover the provider from /api/v1/info"
+# Read the provider exactly as the app does, rather than hardcoding it, so this
+# exercises the same data path: info -> provider -> authorization URL.
+eval "$("${CURL[@]}" "${VIK_HOST}/api/v1/info" | python3 -c '
+import json, sys
+auth = json.load(sys.stdin)["auth"]["openid_connect"]
+providers = auth.get("providers") or []
+if not auth.get("enabled") or not providers:
+    print("PROVIDER_KEY=")
+    sys.exit(0)
+p = providers[0]
+print("PROVIDER_KEY=%s" % p["key"])
+print("AUTH_URL=%s" % p["auth_url"])
+print("CLIENT_ID=%s" % (p.get("client_id") or ""))
+print("SCOPE=%s" % ((p.get("scope") or "openid profile email").replace(" ", "+")))
+')"
+[ -n "${PROVIDER_KEY:-}" ] || fail "no OIDC provider advertised by ${VIK_HOST}"
+AUTH_HOST="https://auth.${DEV_BASE}:8443"
+ok "provider '${PROVIDER_KEY}', client '${CLIENT_ID}', scope '${SCOPE//+/ }'"
+
 echo "==> 1. authorization request"
 LOC=$("${CURL[@]}" -c "$JAR" -D- -o /dev/null \
-    "${AUTH_HOST}/api/oidc/authorization?client_id=vikunja&response_type=code&scope=openid+profile+email&redirect_uri=${REDIRECT}&state=${STATE}&nonce=${NONCE}" \
+    "${AUTH_URL}?client_id=${CLIENT_ID}&response_type=code&redirect_uri=${REDIRECT}&scope=${SCOPE}&state=${STATE}&nonce=${NONCE}" \
     | grep -i '^location:' | tr -d '\r' | cut -d' ' -f2-)
 FLOW_ID=$(printf '%s' "$LOC" | sed -n 's/.*flow_id=\([0-9a-f-]*\).*/\1/p')
 [ -n "$FLOW_ID" ] || fail "no flow_id in redirect: $LOC"
@@ -66,7 +91,7 @@ echo "==> 4. state validation"
 ok "state round-tripped unchanged"
 
 echo "==> 5. code exchange at Vikunja"
-TOKEN=$("${CURL[@]}" -X POST "${VIK_HOST}/api/v1/auth/openid/authelia/callback" \
+TOKEN=$("${CURL[@]}" -X POST "${VIK_HOST}/api/v1/auth/openid/${PROVIDER_KEY}/callback" \
     -H 'Content-Type: application/json' \
     -d "{\"code\":\"${CODE}\",\"redirect_url\":\"${REDIRECT}\"}" \
     | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("token",""))')
@@ -80,7 +105,7 @@ COUNT=$("${CURL[@]}" -H "Authorization: Bearer ${TOKEN}" "${VIK_HOST}/api/v1/pro
 ok "GET /api/v1/projects returned ${COUNT} projects"
 
 echo "==> 7. the code is single use"
-REPLAY=$("${CURL[@]}" -o /dev/null -w '%{http_code}' -X POST "${VIK_HOST}/api/v1/auth/openid/authelia/callback" \
+REPLAY=$("${CURL[@]}" -o /dev/null -w '%{http_code}' -X POST "${VIK_HOST}/api/v1/auth/openid/${PROVIDER_KEY}/callback" \
     -H 'Content-Type: application/json' \
     -d "{\"code\":\"${CODE}\",\"redirect_url\":\"${REDIRECT}\"}")
 [ "$REPLAY" != "200" ] || fail "replaying the code succeeded, it should not"

--- a/scripts/dev-oidc-up.sh
+++ b/scripts/dev-oidc-up.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Brings up the dev Vikunja behind TLS with an Authelia OIDC provider, for work
+# on issue #153. Everything here is throwaway: never point it at a real Vikunja
+# or a real identity provider.
+#
+#   ./scripts/dev-oidc-up.sh                  local auth on  + OIDC
+#   ./scripts/dev-oidc-up.sh --no-local-auth  local auth off + OIDC
+#
+# The second form is what exercises "hide the username and password fields when
+# the server has local auth disabled".
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+LOCAL_AUTH=true
+for arg in "$@"; do
+    case "$arg" in
+        --no-local-auth) LOCAL_AUTH=false ;;
+        *) echo "unknown argument: $arg" >&2; exit 2 ;;
+    esac
+done
+
+command -v mkcert >/dev/null || { echo "mkcert not found: brew install mkcert" >&2; exit 1; }
+
+# One hostname has to resolve the same from the Mac, the Simulator and inside
+# the containers. See the header of docker-compose.oidc.yml. nip.io maps
+# <ip>.nip.io, and anything.<ip>.nip.io, straight back to <ip>.
+IP="$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || true)"
+[ -n "$IP" ] || { echo "No LAN IP on en0 or en1. Are you on a network?" >&2; exit 1; }
+DEV_BASE="${IP}.nip.io"
+
+if ! dig +short "vikunja.${DEV_BASE}" | grep -q .; then
+    echo "DNS cannot resolve vikunja.${DEV_BASE}." >&2
+    echo "nip.io needs working public DNS, and some resolvers block it as DNS rebinding." >&2
+    exit 1
+fi
+
+echo "==> dev host: ${DEV_BASE} (local auth: ${LOCAL_AUTH})"
+
+mkdir -p vikunja-dev-data/authelia dev/certs
+
+# Authelia's OIDC signing key. Generated on first run and gitignored: a private
+# key does not belong in the repo even when it is throwaway, and this one would
+# trip secret scanning.
+if [ ! -f dev/authelia/oidc.key ]; then
+    echo "==> generating Authelia OIDC signing key"
+    openssl genrsa -out dev/authelia/oidc.key 2048 2>/dev/null
+    chmod 600 dev/authelia/oidc.key
+fi
+
+# Wildcard leaf for both vikunja.* and auth.*. mkcert's CA already exists in
+# $(mkcert -CAROOT); we deliberately do not run `mkcert -install`, which would
+# need your password to touch the system trust store. Nothing here requires it:
+# Vikunja trusts the CA through SSL_CERT_FILE and the Simulator through
+# `simctl keychain add-root-cert` below.
+echo "==> issuing certificate for *.${DEV_BASE}"
+mkcert -cert-file dev/certs/cert.pem -key-file dev/certs/key.pem \
+    "*.${DEV_BASE}" "${DEV_BASE}" >/dev/null 2>&1
+
+# Vikunja's Go HTTP client needs the mkcert root to verify Authelia. Build a
+# bundle of the image's own roots plus that CA, rather than replacing the pool.
+CAROOT="$(mkcert -CAROOT)"
+docker run --rm vikunja/vikunja:latest cat /etc/ssl/certs/ca-certificates.crt \
+    > dev/certs/ca-bundle.crt 2>/dev/null || : > dev/certs/ca-bundle.crt
+cat "${CAROOT}/rootCA.pem" >> dev/certs/ca-bundle.crt
+chmod 644 dev/certs/cert.pem dev/certs/ca-bundle.crt
+chmod 640 dev/certs/key.pem
+
+export DEV_BASE VIKUNJA_LOCAL_AUTH="$LOCAL_AUTH"
+# shellcheck disable=SC2016
+envsubst '${DEV_BASE} ${VIKUNJA_LOCAL_AUTH}' \
+    < dev/vikunja/config.yml.template > dev/vikunja/config.yml
+
+printf 'DEV_BASE=%s\n' "$DEV_BASE" > .env.oidc
+
+COMPOSE=(docker compose --env-file .env.oidc -f docker-compose.dev.yml -f docker-compose.oidc.yml)
+"${COMPOSE[@]}" up -d --force-recreate
+
+echo "==> waiting for Authelia discovery"
+for _ in $(seq 1 60); do
+    curl -sf -m 2 "https://auth.${DEV_BASE}:8443/.well-known/openid-configuration" >/dev/null 2>&1 && break
+    sleep 1
+done
+
+echo "==> waiting for Vikunja"
+for _ in $(seq 1 60); do
+    curl -sf -m 2 "https://vikunja.${DEV_BASE}:8443/api/v1/info" >/dev/null 2>&1 && break
+    sleep 1
+done
+
+# The Simulator has its own trust store, separate from the Mac's.
+if xcrun simctl list devices booted 2>/dev/null | grep -q Booted; then
+    xcrun simctl keychain booted add-root-cert "${CAROOT}/rootCA.pem" 2>/dev/null \
+        && echo "==> added mkcert root to the booted Simulator"
+else
+    echo "==> no booted Simulator. After booting one, run:"
+    echo "    xcrun simctl keychain booted add-root-cert \"${CAROOT}/rootCA.pem\""
+fi
+
+echo
+echo "==> /api/v1/info auth block"
+curl -s "https://vikunja.${DEV_BASE}:8443/api/v1/info" \
+    | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin)["auth"], indent=2))'
+echo
+echo "Vikunja:  https://vikunja.${DEV_BASE}:8443"
+echo "Authelia: https://auth.${DEV_BASE}:8443   (devuser / devpassword)"
+echo "Down:     docker compose --env-file .env.oidc -f docker-compose.dev.yml -f docker-compose.oidc.yml down"


### PR DESCRIPTION
Closes #153. Takes over and finishes the work from marvin/issue-153-testing-9be846, rebased onto main.

## What this adds

- OIDC / SSO login from the setup screen. The app probes /api/v1/info as you type the server URL and shows a "Continue with <provider>" button per advertised provider, quiet under the password form when local auth is on, prominent when the server is SSO-only.
- The credentials form hides itself when the server has local auth (and LDAP) disabled, instead of failing with "Not Found".
- ASWebAuthenticationSession with the real URL bar rather than an embedded web view, per the issue's design decision. Ephemeral session gives the cookie isolation #103 wanted from a non-persistent WKWebView data store.
- All three #103 security requirements: state generated, stored and compared on the callback (mismatch treated as hostile), the error= redirect handled, and the authorization code kept out of every log and debug description.
- One shared completeLogin spine behind token, credentials and OIDC login. URL normalization consolidated in ServerURL, server probing in ServerInfoService, one checkServer(debounce:) function.
- Dev infrastructure: an Authelia + Caddy TLS overlay for the dev Vikunja (scripts/dev-oidc-up.sh), an end-to-end smoke test (scripts/dev-oidc-smoke.sh), an isolated macOS test build script, and docs/oidc-callback-decision.md recording the callback design and macOS caveats.

## Testing evidence

- Unit suite: 107 tests, 0 failures on the iPhone 17 simulator. New-code coverage: AuthOptions and ServerInfo 100%, OIDCLogin 94.7%, ServerURL 97.2%, Endpoint 99.2%. WebAuthenticator is the deliberately thin untestable system-UI seam.
- Smoke test end to end against the Authelia dev stack: discovery, authorization, login, consent, state round-trip verified unchanged, code exchange to a working Vikunja JWT, and code single-use confirmed (replay rejected with HTTP 400).
- Full in-app flow verified on the iPhone 17 simulator: typed the dev server URL, tapped Continue with Authelia, signed in on the Authelia page inside the auth sheet, and landed signed-in on the Inbox. Server log confirms the app's own POST /api/v1/auth/openid/authelia/callback returning 200 followed by authenticated fetches.
- Cancelling the sheet returns to the setup screen with no spurious error.
- macOS: verified up to and including the authorization request opening in the default browser. The return leg (browser back to the app) still needs a human click on the browser's "open app" dialog; docs/oidc-callback-decision.md records this.
- Also fixes the dev Vikunja container healthcheck, which probed with a wget the image does not contain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)