### PR TITLE
test: check the Vikunja v1 contract nightly against a live server

### DIFF
--- a/.github/workflows/vikunja-integration.yml
+++ b/.github/workflows/vikunja-integration.yml
@@ -1,0 +1,146 @@
+name: Vikunja Integration
+
+# Nightly check that the v1 API mDone speaks hasn't moved under us.
+#
+# The unit suite mocks every response, so it stays green no matter what a
+# Vikunja release does to the wire format. These tests drive the real services
+# against a real server instead, which is the only way we find out about a
+# breaking change before a user does.
+#
+# Deliberately not on `pull_request`: it tests a moving upstream target, so it
+# must never be able to block a merge. Note that GitHub disables scheduled
+# workflows after 60 days with no repository activity.
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: vikunja-integration
+  cancel-in-progress: false
+
+jobs:
+  integration:
+    name: Vikunja ${{ matrix.vikunja }}
+    runs-on: macos-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        # `latest` is the canary: a failure there means upstream changed
+        # something. The pinned tag is the version docs/vikunja-api-inventory.md
+        # was verified against, so a failure there means *we* changed something.
+        # Bump it whenever that doc gets re-verified.
+        vikunja: ["latest", "2.5.0"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Start a Docker daemon
+        # macOS runners ship the Docker CLI but no daemon; Colima provides one.
+        run: |
+          brew list colima >/dev/null 2>&1 || brew install colima
+          brew list docker >/dev/null 2>&1 || brew install docker
+          colima start --cpu 2 --memory 4
+
+      - name: Start Vikunja ${{ matrix.vikunja }}
+        # No volume on purpose: CI wants an empty server every night, and the
+        # image's own /app/vikunja/files needs a mount or a writable basepath
+        # before it will start at all.
+        run: |
+          docker run -d --name vikunja -p 3456:3456 \
+            -e VIKUNJA_SERVICE_PUBLICURL=http://localhost:3456 \
+            -e VIKUNJA_SERVICE_SECRET=ci-only-not-a-real-secret \
+            -e VIKUNJA_DATABASE_TYPE=sqlite \
+            -e VIKUNJA_DATABASE_PATH=/tmp/vikunja/vikunja.db \
+            -e VIKUNJA_FILES_BASEPATH=/tmp/vikunja/files \
+            -e VIKUNJA_SERVICE_ENABLEREGISTRATION=true \
+            vikunja/vikunja:${{ matrix.vikunja }}
+          for i in $(seq 1 60); do
+            curl -fsS --max-time 2 http://localhost:3456/api/v1/info >/dev/null 2>&1 && break
+            sleep 2
+          done
+
+      - name: Record the server version
+        # Also the gate on the server actually being up: everything downstream
+        # would otherwise skip itself and report a green nightly that tested
+        # nothing.
+        run: |
+          version=$(curl -fsS --max-time 5 http://localhost:3456/api/v1/info | jq -r .version)
+          echo "VIKUNJA_SERVER_VERSION=$version" >> "$GITHUB_ENV"
+          echo "Image tag \`${{ matrix.vikunja }}\` is Vikunja \`$version\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Seed a user and sample data
+        run: ./scripts/seed-dev-vikunja.sh
+
+      - name: Generate Xcode project
+        run: |
+          brew install xcodegen
+          xcodegen generate
+
+      - name: Run integration tests
+        # Same simulator CI pins in ios-tests.yml; keep the two in step.
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project mDone.xcodeproj \
+            -scheme mDone \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 17' \
+            -only-testing:mDoneIntegrationTests \
+            -resultBundlePath integration.xcresult \
+            test | tee integration.log
+
+      - name: Fail if the suite skipped itself
+        # The tests skip when they can't reach a server, which is right on a dev
+        # machine and worthless here: it would look like a pass.
+        run: |
+          if grep -q "Test skipped - No Vikunja reachable" integration.log; then
+            echo "::error::Tests skipped themselves, the simulator could not reach the server. Nothing was verified."
+            exit 1
+          fi
+
+      - name: Upload the result bundle
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcresult-${{ matrix.vikunja }}
+          path: integration.xcresult
+          retention-days: 14
+
+      - name: Server logs
+        if: failure()
+        run: docker logs vikunja 2>&1 | tail -100
+
+      - name: Open or update the tracking issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "Nightly integration failed against Vikunja ${{ matrix.vikunja }}"
+        run: |
+          gh label create vikunja-nightly \
+            --color B60205 \
+            --description "Raised by the nightly Vikunja integration run" 2>/dev/null || true
+
+          body=$(cat <<EOF
+          The nightly run failed against \`vikunja/vikunja:${{ matrix.vikunja }}\`, which reported version \`${VIKUNJA_SERVER_VERSION:-unknown}\`.
+
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          Start with the failing test names: each one states the API assumption it checks, so the name says which part of the contract moved. The result bundle is attached to the run as an artifact.
+          EOF
+          )
+
+          existing=$(gh issue list --label vikunja-nightly --state open --json number,title \
+            --jq "[.[] | select(.title == \"$TITLE\")] | .[0].number // empty")
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$TITLE" --label vikunja-nightly --body "$body"
+          fi

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -91,6 +91,32 @@ Add new unit tests in `mDoneTests/` following the existing pattern: inject a `UR
 
 After `docker compose up -d` and the seed script, run the app and exercise the path you're changing. The Vikunja web UI is the ground-truth view: open it side-by-side with the Simulator to confirm what landed server-side.
 
+### Automated integration — against a live Vikunja
+
+`mDoneIntegrationTests` drives the real services (`TaskService`, `ProjectService`, `LabelService`, `APIClient`) against a running server instead of `MockURLProtocol`, so it catches the thing the unit suite structurally cannot: a Vikunja release changing the v1 API under us.
+
+```bash
+docker compose -f docker-compose.dev.yml up -d && ./scripts/seed-dev-vikunja.sh
+
+xcodebuild -project mDone.xcodeproj -scheme mDone \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:mDoneIntegrationTests test
+```
+
+Every test skips itself when nothing answers on the server URL, so a whole-scheme run stays green with Docker switched off. Point them elsewhere with `MDONE_INTEGRATION_SERVER_URL`, `MDONE_INTEGRATION_USER` and `MDONE_INTEGRATION_PASSWORD` (defaults: `http://localhost:3456`, `devuser`, `devpassword`). From `xcodebuild` those need the `TEST_RUNNER_` prefix to reach the test process:
+
+```bash
+TEST_RUNNER_MDONE_INTEGRATION_SERVER_URL=http://localhost:3457 xcodebuild ... test
+```
+
+Two things to know before adding tests here:
+
+- **Log in through `IntegrationSession`, never per test.** Vikunja rate-limits `POST /login` per user, and a login per test method starts returning 429 around the tenth test.
+- **Work inside `scratchProject`**, the per-test project the base class creates and deletes, so a run leaves the server as it found it.
+
+[.github/workflows/vikunja-integration.yml](../.github/workflows/vikunja-integration.yml) runs these nightly on a macOS runner (Colima provides the Docker daemon), against both `vikunja/vikunja:latest` and the pinned version below. It is never run on a PR: it tests a moving upstream target, so it must not be able to block a merge. A failure opens or comments on an issue labelled `vikunja-nightly`.
+
 ### Common scenarios
 
 - **First-run / onboarding** — reset Vikunja, skip the seed, install the app fresh (Simulator → Device → Erase All Content and Settings).
@@ -245,6 +271,8 @@ it as an optional array.
 `docker-compose.dev.yml` currently uses `vikunja/vikunja:latest`. When you start noticing odd behaviour after a `docker compose pull`, check the [Vikunja release notes](https://kolaente.dev/vikunja/vikunja/-/releases) and pin to a known-good tag.
 
 If you're chasing a bug that may be Vikunja-side, pin your dev compose file to the same version your prod instance runs to ensure the API shape matches.
+
+The nightly integration workflow tests two tags: `latest`, which tells us upstream changed something, and a pinned floor (currently `2.5.0`, the version [vikunja-api-inventory.md](vikunja-api-inventory.md) was verified against), which tells us we did. Bump the pin in the workflow matrix whenever that document is re-verified.
 
 ## When to update the Apple Review test server
 

--- a/mDoneIntegrationTests/VikunjaAPIContractTests.swift
+++ b/mDoneIntegrationTests/VikunjaAPIContractTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import XCTest
+@testable import mDone
+
+/// Live-server checks for the parts of Vikunja's v1 API that mDone depends on
+/// in ways a release could quietly change. Each test states the assumption the
+/// app makes, so a failure names the assumption rather than a status code.
+///
+/// See `docs/vikunja-api-inventory.md` for the hand-verified snapshot these
+/// keep honest.
+final class VikunjaAPIContractTests: VikunjaIntegrationCase {
+    // MARK: - Auth
+
+    /// Password login still returns a JWT (not an opaque token) and that JWT
+    /// authorizes ordinary reads. `JWTHelpers.isJWT` decides whether the client
+    /// arms refresh-on-401, so the token *shape* is load-bearing.
+    func testPasswordLoginReturnsAJWTThatAuthorizesRequests() async throws {
+        // A genuine login rather than the shared token, so this path is covered.
+        let token = try await IntegrationSession.login(config)
+        XCTAssertTrue(
+            JWTHelpers.isJWT(token),
+            "Login returned something that isn't a JWT: refresh handling would break"
+        )
+
+        let freshClient = APIClient()
+        await freshClient.configure(serverURL: config.serverURL, token: token)
+        let all: [Project] = try await freshClient.fetch(Endpoint.projects())
+        XCTAssertFalse(all.isEmpty, "The token from /login did not authorize a project read")
+    }
+
+    // MARK: - Creates are PUT, updates are POST
+
+    /// Vikunja inverts the usual REST convention. If a release ever "fixes"
+    /// that, every create in the app starts 404ing or 405ing.
+    func testProjectCreateIsPUTAndUpdateIsPOST() async throws {
+        XCTAssertEqual(Endpoint.createProject().method, .PUT)
+        XCTAssertEqual(Endpoint.updateProject(id: scratchProject.id).method, .POST)
+
+        let renamed = try await projects.updateProject(
+            id: scratchProject.id,
+            request: ProjectUpdateRequest(from: scratchProject, title: "renamed by integration test")
+        )
+        XCTAssertEqual(renamed.title, "renamed by integration test")
+
+        let refetched = try await projects.fetchProject(id: scratchProject.id)
+        XCTAssertEqual(refetched.title, "renamed by integration test")
+    }
+
+    /// `fetchProjects` pages and then de-duplicates, because Vikunja repeats
+    /// its negative-id pseudo-projects on every page (issue #139).
+    func testProjectListHasNoDuplicateIDs() async throws {
+        let all = try await projects.fetchProjects()
+        let ids = all.map(\.id)
+        XCTAssertEqual(ids.count, Set(ids).count, "Duplicate project ids would break the sidebar's ForEach")
+    }
+
+    // MARK: - View indirection
+
+    /// Per-project tasks and buckets are only reachable through a view id, and
+    /// the app assumes every project is born with a list view and a kanban one.
+    func testNewProjectGetsListAndKanbanViews() async throws {
+        let views = try await projects.fetchProjectViews(projectId: scratchProject.id)
+        let kinds = views.compactMap(\.viewKind)
+        XCTAssertTrue(kinds.contains("list"), "No list view on a fresh project, got \(kinds)")
+        XCTAssertTrue(kinds.contains("kanban"), "No kanban view on a fresh project, got \(kinds)")
+    }
+
+    func testTaskCreatedInProjectAppearsInItsListView() async throws {
+        let created = try await makeTask(TaskCreateRequest(title: "appears in the list view"))
+        let listViewId = try await viewId(kind: "list")
+
+        let viewTasks = try await tasks.fetchProjectTasks(projectId: scratchProject.id, viewId: listViewId)
+        XCTAssertTrue(viewTasks.contains { $0.id == created.id }, "Created task missing from the project's list view")
+    }
+
+    // MARK: - Full-replace update semantics (issue #147)
+
+    /// The behaviour that caused #147: `POST /tasks/{id}` replaces the whole
+    /// task, so a body that omits a field resets it. A failure here is not
+    /// automatically bad news, it means the server switched to partial updates
+    /// and `preservingExistingValues(from:)` may no longer be needed.
+    func testUpdateWithoutMergeStillWipesOmittedFields() async throws {
+        let created = try await makeTask(
+            TaskCreateRequest(title: "full replace", description: "carry me", priority: 4)
+        )
+        XCTAssertEqual(created.description, "carry me")
+
+        let updated = try await tasks.updateTask(id: created.id, request: TaskUpdateRequest(done: true))
+
+        XCTAssertTrue(updated.done)
+        XCTAssertTrue(
+            (updated.description ?? "").isEmpty,
+            "Server kept the description through a partial update: semantics changed, revisit the #147 workaround"
+        )
+        XCTAssertEqual(updated.priority, 0, "Server kept the priority through a partial update: semantics changed")
+    }
+
+    /// And the fix: merging the existing task in first survives the replace.
+    func testMergedUpdateKeepsDescriptionPriorityAndProgress() async throws {
+        let created = try await makeTask(
+            TaskCreateRequest(title: "merged update", description: "keep me", priority: 4)
+        )
+        let withProgress = try await tasks.updateTask(
+            id: created.id,
+            request: TaskUpdateRequest(percentDone: 0.5).preservingExistingValues(from: created)
+        )
+        XCTAssertEqual(withProgress.percentDone, 0.5)
+
+        let completed = try await tasks.updateTask(
+            id: created.id,
+            request: TaskUpdateRequest(done: true).preservingExistingValues(from: withProgress)
+        )
+
+        XCTAssertTrue(completed.done)
+        XCTAssertEqual(completed.description, "keep me")
+        XCTAssertEqual(completed.priority, 4)
+        XCTAssertEqual(completed.percentDone, 0.5)
+    }
+
+    // MARK: - Dates
+
+    /// Vikunja returns `0001-01-01T00:00:00Z` for unset dates rather than null,
+    /// and `APIClient` maps that to `.distantPast`. Everything downstream tests
+    /// against `.distantPast`, so a switch to null would silently change
+    /// meaning rather than fail to decode.
+    func testUnsetDueDateComesBackAsTheZeroDate() async throws {
+        let created = try await makeTask(TaskCreateRequest(title: "no due date"))
+        XCTAssertEqual(created.dueDate, .distantPast, "Unset due date is no longer Vikunja's zero date")
+    }
+
+    /// Round-trips a due date, then clears it the way the app does: by sending
+    /// the zero date back.
+    func testDueDateSetThenClearedWithTheZeroDate() async throws {
+        let due = Date(timeIntervalSince1970: 1_800_000_000)
+        let created = try await makeTask(TaskCreateRequest(title: "has a due date", dueDate: due))
+        XCTAssertEqual(
+            try XCTUnwrap(created.dueDate).timeIntervalSince1970,
+            due.timeIntervalSince1970,
+            accuracy: 1,
+            "Due date did not survive the round trip"
+        )
+
+        let cleared = try await tasks.updateTask(
+            id: created.id,
+            request: TaskUpdateRequest(clearDueDate: true).preservingExistingValues(from: created)
+        )
+        XCTAssertEqual(cleared.dueDate, .distantPast, "Sending the zero date no longer clears a due date")
+    }
+
+    // MARK: - Filter DSL
+
+    /// The advanced filter screen sends Vikunja's own filter syntax straight
+    /// through. A parser change upstream turns that into a 400 for every user
+    /// who saved a filter.
+    func testFilterDSLIsAcceptedAndApplied() async throws {
+        let done = try await makeTask(TaskCreateRequest(title: "filter: already done"))
+        _ = try await tasks.updateTask(
+            id: done.id,
+            request: TaskUpdateRequest(done: true).preservingExistingValues(from: done)
+        )
+        let open = try await makeTask(TaskCreateRequest(title: "filter: still open", priority: 3))
+
+        let results: [VTask] = try await client.fetch(
+            Endpoint.allTasks(perPage: 200, filter: "done = false && priority >= 3")
+        )
+
+        XCTAssertTrue(results.contains { $0.id == open.id }, "Filter dropped a task that matches it")
+        XCTAssertFalse(results.contains { $0.id == done.id }, "Filter returned a done task for `done = false`")
+    }
+
+    // MARK: - Relations
+
+    /// Relation kinds go over the wire as lowercase with no underscores, which
+    /// is what lets them survive `convertToSnakeCase` untouched. The server
+    /// also owns creating the inverse relation on the other task.
+    func testSubtaskRelationRoundTripsAndCreatesTheInverse() async throws {
+        let parent = try await makeTask(TaskCreateRequest(title: "parent"))
+        let child = try await makeTask(TaskCreateRequest(title: "child"))
+
+        try await tasks.createRelation(taskId: parent.id, otherTaskId: child.id, kind: .subtask)
+
+        let refetchedParent = try await tasks.fetchTask(id: parent.id)
+        XCTAssertEqual(refetchedParent.subtasks.map(\.id), [child.id], "Subtask relation missing on the parent")
+
+        let refetchedChild = try await tasks.fetchTask(id: child.id)
+        XCTAssertEqual(
+            refetchedChild.parentTasks.map(\.id),
+            [parent.id],
+            "Server no longer creates the inverse parenttask relation"
+        )
+
+        try await tasks.deleteRelation(taskId: parent.id, otherTaskId: child.id, kind: .subtask)
+        let afterDelete = try await tasks.fetchTask(id: parent.id)
+        XCTAssertTrue(afterDelete.subtasks.isEmpty, "Relation survived its DELETE")
+    }
+
+    // MARK: - Labels
+
+    func testLabelCreateAttachAndDetach() async throws {
+        let label = try await labels.createLabel(
+            LabelCreateRequest(title: "integration \(UUID().uuidString.prefix(6))", hexColor: "4287f5")
+        )
+        let task = try await makeTask(TaskCreateRequest(title: "gets a label"))
+
+        try await labels.addLabel(taskId: task.id, labelId: label.id)
+        let labelled = try await tasks.fetchTask(id: task.id)
+        XCTAssertEqual(labelled.labels?.map(\.id), [label.id], "Label did not attach to the task")
+
+        try await labels.removeLabel(taskId: task.id, labelId: label.id)
+        let unlabelled = try await tasks.fetchTask(id: task.id)
+        XCTAssertTrue((unlabelled.labels ?? []).isEmpty, "Label survived its DELETE")
+    }
+
+    // MARK: - Kanban
+
+    /// The board renders from one fetch because the view-tasks endpoint embeds
+    /// each bucket's tasks. The plain `/buckets` endpoint stopped doing that in
+    /// v0.24, so this is the assumption most likely to move again.
+    func testKanbanViewEmbedsTasksInTheirBuckets() async throws {
+        let created = try await makeTask(TaskCreateRequest(title: "on the board"))
+        let kanbanViewId = try await viewId(kind: "kanban")
+
+        let buckets = try await projects.fetchBuckets(projectId: scratchProject.id, viewId: kanbanViewId)
+        XCTAssertFalse(buckets.isEmpty, "A kanban view with no buckets")
+
+        let embedded = buckets.flatMap { $0.tasks ?? [] }
+        XCTAssertTrue(
+            embedded.contains { $0.id == created.id },
+            "Kanban view no longer embeds tasks in buckets, the board would render empty"
+        )
+    }
+
+    /// Moving a card between columns, and the empty-body response the client
+    /// expects back from it.
+    func testMoveTaskBetweenKanbanBuckets() async throws {
+        let created = try await makeTask(TaskCreateRequest(title: "moves columns"))
+        let kanbanViewId = try await viewId(kind: "kanban")
+        let buckets = try await projects.fetchBuckets(projectId: scratchProject.id, viewId: kanbanViewId)
+
+        guard let destination = buckets.last, buckets.count > 1 else {
+            throw XCTSkip("Project has fewer than two buckets, nothing to move between")
+        }
+
+        try await tasks.moveTaskToBucket(
+            taskId: created.id,
+            projectId: scratchProject.id,
+            viewId: kanbanViewId,
+            bucketId: destination.id
+        )
+
+        let after = try await projects.fetchBuckets(projectId: scratchProject.id, viewId: kanbanViewId)
+        let landed = after.first { ($0.tasks ?? []).contains { task in task.id == created.id } }
+        XCTAssertEqual(landed?.id, destination.id, "Task did not land in the destination bucket")
+    }
+}

--- a/mDoneIntegrationTests/VikunjaIntegrationCase.swift
+++ b/mDoneIntegrationTests/VikunjaIntegrationCase.swift
@@ -1,0 +1,225 @@
+import Foundation
+import XCTest
+@testable import mDone
+
+/// Base class for tests that run against a **real** Vikunja server rather than
+/// `MockURLProtocol`.
+///
+/// The unit suite pins our decoding against hand-written JSON, which is exactly
+/// the wrong shape of test for "did upstream change the wire format?": it stays
+/// green forever whatever the server does. These tests answer the other half by
+/// driving the real services against a live instance.
+///
+/// They are not part of the PR run. `.github/workflows/vikunja-integration.yml`
+/// brings a server up nightly and runs them against `vikunja/vikunja:latest`,
+/// so a release that breaks the v1 contract shows up as a red nightly instead
+/// of a user's bug report. With nothing reachable every test skips, which keeps
+/// a whole-scheme `xcodebuild test` green on a laptop with Docker switched off.
+///
+/// Point them somewhere else with `MDONE_INTEGRATION_SERVER_URL`,
+/// `MDONE_INTEGRATION_USER` and `MDONE_INTEGRATION_PASSWORD`. The defaults match
+/// the local dev server from `docker-compose.dev.yml` plus
+/// `scripts/seed-dev-vikunja.sh`.
+class VikunjaIntegrationCase: XCTestCase {
+    struct Config: Sendable {
+        var serverURL: String
+        var username: String
+        var password: String
+
+        static func fromEnvironment() -> Config {
+            let env = ProcessInfo.processInfo.environment
+            return Config(
+                serverURL: env["MDONE_INTEGRATION_SERVER_URL"] ?? "http://localhost:3456",
+                username: env["MDONE_INTEGRATION_USER"] ?? "devuser",
+                password: env["MDONE_INTEGRATION_PASSWORD"] ?? "devpassword"
+            )
+        }
+    }
+
+    private(set) var config = Config.fromEnvironment()
+
+    /// A client of our own rather than `APIClient.shared`: these tests run
+    /// inside the app's process, and configuring the singleton would point the
+    /// live app at the test server for the rest of the run.
+    private(set) var client: APIClient!
+    private(set) var tasks: TaskService!
+    private(set) var projects: ProjectService!
+    private(set) var labels: LabelService!
+
+    /// A project created per test and deleted in `tearDown`, so a run leaves the
+    /// server as it found it and no two tests fight over the same tasks.
+    private(set) var scratchProject: Project!
+
+    /// Server version string, e.g. `v2.6.0`, or nil if the server didn't report
+    /// one. Logged once per run so a red nightly names the release that broke us.
+    private(set) var serverVersion: String?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        config = Config.fromEnvironment()
+
+        // Throws XCTSkip when nothing answers. Probed once per process: the
+        // client retries a refused connection three times with backoff, so
+        // probing per test would cost ~7s each with no server running.
+        serverVersion = try await IntegrationSession.shared.serverVersion(for: config)
+
+        let token = try await IntegrationSession.shared.token(for: config)
+        client = APIClient()
+        await client.configure(serverURL: config.serverURL, token: token)
+
+        tasks = TaskService(apiClient: client)
+        projects = ProjectService(apiClient: client)
+        labels = LabelService(apiClient: client)
+
+        scratchProject = try await projects.createProject(
+            ProjectCreateRequest(title: "mDone integration \(UUID().uuidString.prefix(8))")
+        )
+    }
+
+    override func tearDown() async throws {
+        if let scratchProject, let projects {
+            // Best effort: a failed assertion mid-test still gets its project
+            // cleaned up, and a cleanup failure must not mask the real failure.
+            try? await projects.deleteProject(id: scratchProject.id)
+        }
+        scratchProject = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// The scratch project's view of the given kind, failing the test when the
+    /// server didn't create one.
+    func viewId(kind: String, file: StaticString = #filePath, line: UInt = #line) async throws -> Int64 {
+        let views = try await projects.fetchProjectViews(projectId: scratchProject.id)
+        guard let view = views.first(where: { $0.viewKind == kind }) else {
+            XCTFail(
+                "Project \(scratchProject.id) has no \(kind) view, got \(views.map { $0.viewKind ?? "nil" })",
+                file: file,
+                line: line
+            )
+            throw VikunjaIntegrationError.missingView(kind)
+        }
+        return view.id
+    }
+
+    /// Creates a task in the scratch project.
+    @discardableResult
+    func makeTask(_ request: TaskCreateRequest) async throws -> VTask {
+        try await tasks.createTask(projectId: scratchProject.id, request: request)
+    }
+}
+
+/// Per-process state shared by every integration test: one reachability probe
+/// and one login for the whole run.
+///
+/// Both are cached for the same reason, that repeating them per test method is
+/// expensive in a way that looks like a bug. The probe costs the client's full
+/// retry ladder when nothing is listening, and Vikunja rate-limits
+/// `POST /login` per user hard enough that a login per test starts returning
+/// 429 around the tenth test (observed on v2.4.0), which reads exactly like a
+/// broken login and isn't.
+actor IntegrationSession {
+    static let shared = IntegrationSession()
+
+    private struct Probe {
+        var version: String?
+        var skipReason: String?
+    }
+
+    private var probes: [String: Probe] = [:]
+    private var tokens: [String: String] = [:]
+    /// Why login failed, if it did. Cached alongside the tokens so a bad
+    /// password fails all 14 tests with the same clear message instead of
+    /// making 14 more login attempts and tripping the rate limiter, which
+    /// buries the real error under a pile of 429s.
+    private var loginFailures: [String: VikunjaIntegrationError] = [:]
+
+    /// The server's reported version, or `XCTSkip` if it can't be reached.
+    ///
+    /// Probes through the app's own `ServerInfoService`, so the nightly also
+    /// covers the code the setup screen runs before anyone can log in.
+    func serverVersion(for config: VikunjaIntegrationCase.Config) async throws -> String? {
+        if let probe = probes[config.serverURL] {
+            if let reason = probe.skipReason {
+                throw XCTSkip(reason)
+            }
+            return probe.version
+        }
+
+        guard let url = URL(string: config.serverURL) else {
+            let reason = "MDONE_INTEGRATION_SERVER_URL is not a URL: \(config.serverURL)"
+            probes[config.serverURL] = Probe(skipReason: reason)
+            throw XCTSkip(reason)
+        }
+
+        do {
+            let info = try await ServerInfoService().fetch(from: url)
+            probes[config.serverURL] = Probe(version: info.version)
+            print("[integration] \(config.serverURL) is Vikunja \(info.version ?? "unknown")")
+            return info.version
+        } catch {
+            let reason = """
+            No Vikunja reachable at \(config.serverURL) (\(error.localizedDescription)).
+            Start one with: docker compose -f docker-compose.dev.yml up -d && ./scripts/seed-dev-vikunja.sh
+            """
+            probes[config.serverURL] = Probe(skipReason: reason)
+            throw XCTSkip(reason)
+        }
+    }
+
+    /// The shared session token, logging in on first use.
+    func token(for config: VikunjaIntegrationCase.Config) async throws -> String {
+        let key = "\(config.serverURL)|\(config.username)"
+        if let cached = tokens[key] {
+            return cached
+        }
+        if let failure = loginFailures[key] {
+            throw failure
+        }
+        do {
+            let token = try await Self.login(config)
+            tokens[key] = token
+            return token
+        } catch let error as VikunjaIntegrationError {
+            loginFailures[key] = error
+            throw error
+        }
+    }
+
+    /// Performs a real password login and hands back the token.
+    static func login(_ config: VikunjaIntegrationCase.Config) async throws -> String {
+        let client = APIClient()
+        await client.configure(serverURL: config.serverURL, token: "")
+        do {
+            let response: LoginResponse = try await client.send(
+                Endpoint.login,
+                body: LoginRequest(username: config.username, password: config.password)
+            )
+            return response.token
+        } catch {
+            throw VikunjaIntegrationError.loginFailed(
+                user: config.username,
+                server: config.serverURL,
+                underlying: error
+            )
+        }
+    }
+}
+
+enum VikunjaIntegrationError: LocalizedError {
+    case missingView(String)
+    case loginFailed(user: String, server: String, underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case let .missingView(kind):
+            "The scratch project has no \(kind) view"
+        case let .loginFailed(user, server, underlying):
+            """
+            Could not log in as \(user) on \(server): \(underlying). \
+            If the server is up but has no seeded user, run ./scripts/seed-dev-vikunja.sh.
+            """
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -68,6 +68,7 @@ targets:
         - mDoneTests
         - mDoneUITests
         - mDoneWidgetRenderTests
+        - mDoneIntegrationTests
       gatherCoverageData: true
 
   mDone-macOS:
@@ -140,6 +141,26 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mdone.app.tests
+        GENERATE_INFOPLIST_FILE: "YES"
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/mDone.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/mDone"
+        BUNDLE_LOADER: "$(TEST_HOST)"
+
+  # Live-server tests: they drive the real services against a running Vikunja
+  # instead of MockURLProtocol. They skip themselves when no server answers on
+  # MDONE_INTEGRATION_SERVER_URL (default http://localhost:3456), so they are
+  # safe to leave in the scheme; PR CI passes -only-testing:mDoneTests, so it
+  # compiles them but never runs them. The nightly run lives in
+  # .github/workflows/vikunja-integration.yml.
+  mDoneIntegrationTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - mDoneIntegrationTests
+    dependencies:
+      - target: mDone
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.mdone.app.integrationtests
         GENERATE_INFOPLIST_FILE: "YES"
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/mDone.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/mDone"
         BUNDLE_LOADER: "$(TEST_HOST)"


### PR DESCRIPTION
## Summary

Adds `mDoneIntegrationTests`, a test target that drives the real services (`APIClient`, `TaskService`, `ProjectService`, `LabelService`) against a running Vikunja instead of `MockURLProtocol`, plus a nightly workflow that runs it against `vikunja/vikunja:latest`.

The unit suite asserts against hand-written JSON, so it stays green whatever a Vikunja release does to the wire format. Nothing in CI has ever talked to a real server, and the only record of what the API actually does is `docs/vikunja-api-inventory.md`, verified by hand in August against v2.5.0. `latest` is already v2.6.0.

Each test pins one assumption the app makes, so a failure names the assumption rather than a status code:

- creates are `PUT`, updates are `POST`
- per-project tasks and buckets are reachable only through a view id, and the kanban view embeds each bucket's tasks
- relation kinds are lowercase with no underscores, and the server creates the inverse relation
- unset dates come back as `0001-01-01T00:00:00Z`, and sending it back clears a date
- the filter DSL still parses
- `POST /tasks/{id}` is a full replace (the issue #147 pair: that an unmerged update still wipes omitted fields, and that `preservingExistingValues(from:)` prevents it)

Two design points came out of running them rather than from guesswork, both commented in place: one login per process, because Vikunja rate-limits `POST /login` per user and a login per test starts 429ing around the tenth test; and one reachability probe per process, because the client's retry ladder costs about 7s per test with nothing running.

The nightly runs on macOS with Colima for the Docker daemon, over a matrix of `latest` and a pinned `2.5.0` floor: `latest` says upstream changed something, the pin says we did. It is deliberately never run on a pull request, since it tests a moving upstream target and must not be able to block a merge. A failure opens or comments on a `vikunja-nightly` issue, and a run whose tests skipped themselves fails rather than reporting a green nightly that verified nothing.

The target sits in the `mDone` scheme but skips itself when no server answers, so a whole-scheme run stays green with Docker off, and PR CI's `-only-testing:mDoneTests` compiles it without running it.

## Related Issues

No tracking issue. Related to the #147 workaround, which now has a live-server assertion behind it.

## Testing

- 14/14 pass against `vikunja/vikunja:latest` (v2.6.0) and against v2.4.0, using the same volume-free container config the workflow uses and seeded with `scripts/seed-dev-vikunja.sh`.
- Skip path verified with the server stopped: every test skips and `xcodebuild` exits 0.
- `MDONE_INTEGRATION_SERVER_URL` override verified via the `TEST_RUNNER_` prefix, running against a second server on another port.
- macOS build succeeds after the `project.yml` change.
- The nightly workflow itself has not run on GitHub yet, so Colima startup and the issue-filing step are unproven in CI. First scheduled run, or a manual `workflow_dispatch`, will tell us.
- One local run failed with a simulator bootstrap crash before any test started and passed on retry, so expect that flake occasionally.

## Checklist

- [x] Builds on iOS and macOS
- [x] Tests pass
- [x] Ran `swiftlint lint --quiet` and `swiftformat .`
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
