### PR TITLE
test: stop mDoneTests failing intermittently on the iOS Simulator

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -25,12 +25,32 @@ jobs:
           brew install xcodegen
           xcodegen generate
 
+      # The simulator intermittently fails to inject the test bundle into the
+      # host app: the app launches and idles in its run loop, XCTest never
+      # connects, and the run fails without executing a single test. It is an
+      # Xcode/CoreSimulator flake rather than anything in the code, so retry it
+      # once, and only for that signature. A run that actually executed tests
+      # fails the job as it always did.
       - name: Run unit tests
         run: |
-          xcodebuild \
-            -project mDone.xcodeproj \
-            -scheme mDone \
-            -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 17' \
-            -only-testing:mDoneTests \
-            test
+          set -o pipefail
+          run_tests() {
+            xcodebuild \
+              -project mDone.xcodeproj \
+              -scheme mDone \
+              -sdk iphonesimulator \
+              -destination 'platform=iOS Simulator,name=iPhone 17' \
+              -only-testing:mDoneTests \
+              test 2>&1 | tee "$1"
+          }
+
+          if run_tests test-run-1.log; then
+            exit 0
+          fi
+
+          if grep -qE 'hung before establishing connection|never finished bootstrapping' test-run-1.log; then
+            echo "::warning::Test bundle never connected to the host app; retrying once."
+            run_tests test-run-2.log
+          else
+            exit 1
+          fi

--- a/mDone/App/AppDependencies.swift
+++ b/mDone/App/AppDependencies.swift
@@ -9,7 +9,29 @@ struct AppDependencies {
     /// rather than the app quietly coming back empty (issue #155).
     let storeRecovery: StoreRecovery
 
+    /// True when the app has been launched only to host the unit-test bundle.
+    ///
+    /// `XCTestConfigurationFilePath` is set in the host process for a unit-test
+    /// run and not for a UI-test run, where the app is launched normally by a
+    /// separate runner, so this leaves `mDoneUITests` on the real launch path.
+    static let isHostingUnitTests = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+
     init() {
+        // Hosting the unit tests means doing none of this. They build their own
+        // containers, services and sessions, so the production launch buys them
+        // nothing and costs them an on-disk SwiftData store that carries state
+        // between runs, plus a started `NWPathMonitor` whose path updates drive
+        // `refreshAll()` for the whole bundle. On a machine with a dev server
+        // configured, those refreshes print connection failures and their retry
+        // backoff into whichever test happens to be running at the time, which
+        // is exactly the misattributed noise this was traced through once.
+        if AppDependencies.isHostingUnitTests {
+            modelContainer = ModelStoreBootstrap.makeInMemoryContainer()
+            storeRecovery = .none
+            networkMonitor = NetworkMonitor(stubbedConnection: false)
+            return
+        }
+
         // A store that fails to open used to be a `fatalError`, which crashed
         // the app on every launch and left reinstalling as the only fix. That
         // threw away the offline edit queue with it, so recover instead.

--- a/mDone/App/ModelStoreBootstrap.swift
+++ b/mDone/App/ModelStoreBootstrap.swift
@@ -87,6 +87,20 @@ enum ModelStoreBootstrap {
         makeContainer(at: ModelConfiguration(schema: schema, isStoredInMemoryOnly: false).url)
     }
 
+    /// A store that touches no disk, for the last-resort recovery below and for
+    /// the launch that only exists to host the unit tests.
+    static func makeInMemoryContainer() -> ModelContainer {
+        let schema = schema
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        guard let container = try? ModelContainer(for: schema, configurations: [config]) else {
+            // An in-memory container can only fail on a malformed schema, which
+            // is a programming error rather than anything the user can recover
+            // from.
+            fatalError("Failed to create an in-memory ModelContainer")
+        }
+        return container
+    }
+
     static func makeContainer(at url: URL) -> Outcome {
         let schema = schema
 
@@ -141,13 +155,7 @@ enum ModelStoreBootstrap {
         // Last resort: launch on a throwaway store so the app still opens. The
         // salvaged work rides along so a reconnect during this session can still
         // flush it.
-        let memoryConfig = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
-        guard let container = try? ModelContainer(for: schema, configurations: [memoryConfig]) else {
-            // An in-memory container can only fail on a malformed schema, which
-            // is a programming error rather than anything the user can recover
-            // from.
-            fatalError("Failed to create an in-memory ModelContainer")
-        }
+        let container = makeInMemoryContainer()
         restore(salvaged, into: container)
         return Outcome(
             container: container,

--- a/mDone/App/mDoneApp.swift
+++ b/mDone/App/mDoneApp.swift
@@ -40,96 +40,111 @@ struct mDoneApp: App {
 
     var body: some Scene {
         WindowGroup {
-            Group {
-                if appState.isAuthenticated {
-                    #if os(iOS)
-                    MainTabView()
-                    #else
-                    MacContentView()
-                    #endif
-                } else {
-                    ServerSetupView()
+            if AppDependencies.isHostingUnitTests {
+                // The unit tests drive `AppState` and the services directly, so
+                // the real UI would only add its own network traffic on top: a
+                // `checkAuth()` against whatever server the simulator has
+                // configured, and a `refreshAll()` on every scene-phase and
+                // connectivity change, none of which any test observes. See
+                // `AppDependencies.isHostingUnitTests`.
+                Color.clear
+            } else {
+                appContent
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var appContent: some View {
+        Group {
+            if appState.isAuthenticated {
+                #if os(iOS)
+                MainTabView()
+                #else
+                MacContentView()
+                #endif
+            } else {
+                ServerSetupView()
+            }
+        }
+        .environment(appState)
+        .environment(dependencies.networkMonitor)
+        #if os(iOS)
+        .environment(focusManager)
+        .environment(focusOutbox)
+        #endif
+        .modelContainer(dependencies.modelContainer)
+        .onAppear {
+            #if os(iOS)
+            appState.onTaskCompleted = { taskId in
+                focusManager.handleTaskCompleted(taskId: taskId)
+            }
+            appState.onTaskDeleted = { taskId in
+                focusManager.handleTaskDeleted(taskId: taskId)
+            }
+            #endif
+
+            #if DEBUG
+            // Support auto-login via UserDefaults for testing (set via simctl)
+            let defaults = UserDefaults.standard
+            if !appState.isAuthenticated,
+               let serverURL = defaults.string(forKey: "MDONE_SERVER_URL"),
+               let token = defaults.string(forKey: "MDONE_TOKEN"),
+               !serverURL.isEmpty, !token.isEmpty
+            {
+                defaults.removeObject(forKey: "MDONE_SERVER_URL")
+                defaults.removeObject(forKey: "MDONE_TOKEN")
+                Task {
+                    try? await appState.login(serverURL: serverURL, token: token)
+                }
+            } else {
+                Task {
+                    await appState.checkAuth()
                 }
             }
-            .environment(appState)
-            .environment(dependencies.networkMonitor)
-            #if os(iOS)
-                .environment(focusManager)
-                .environment(focusOutbox)
-            #endif
-                .modelContainer(dependencies.modelContainer)
-                .onAppear {
-                    #if os(iOS)
-                    appState.onTaskCompleted = { taskId in
-                        focusManager.handleTaskCompleted(taskId: taskId)
-                    }
-                    appState.onTaskDeleted = { taskId in
-                        focusManager.handleTaskDeleted(taskId: taskId)
-                    }
-                    #endif
-
-                    #if DEBUG
-                    // Support auto-login via UserDefaults for testing (set via simctl)
-                    let defaults = UserDefaults.standard
-                    if !appState.isAuthenticated,
-                       let serverURL = defaults.string(forKey: "MDONE_SERVER_URL"),
-                       let token = defaults.string(forKey: "MDONE_TOKEN"),
-                       !serverURL.isEmpty, !token.isEmpty
-                    {
-                        defaults.removeObject(forKey: "MDONE_SERVER_URL")
-                        defaults.removeObject(forKey: "MDONE_TOKEN")
-                        Task {
-                            try? await appState.login(serverURL: serverURL, token: token)
-                        }
-                    } else {
-                        Task {
-                            await appState.checkAuth()
-                        }
-                    }
-                    #else
-                    Task {
-                        await appState.checkAuth()
-                    }
-                    #endif
-                }
-                .onChange(of: appState.isAuthenticated) { _, isAuthenticated in
-                    if isAuthenticated {
-                        Task {
-                            await appState.requestCalendarAccess()
-                        }
-                    }
-                }
-                .onChange(of: dependencies.networkMonitor.isConnected) { _, isConnected in
-                    appState.handleConnectivityChange(isConnected: isConnected)
-                    #if os(iOS)
-                    if isConnected {
-                        Task { await focusOutbox.drain() }
-                    }
-                    #endif
-                }
-                .onChange(of: scenePhase) { _, newPhase in
-                    if newPhase == .active, appState.isAuthenticated {
-                        Task { await appState.refreshAll() }
-                        #if os(iOS)
-                        Task { await focusOutbox.drain() }
-                        #endif
-                    }
-                }
-            #if os(iOS)
-                .onOpenURL { url in
-                    guard url.scheme == "mdone" else { return }
-                    switch url.host {
-                    case "focus":
-                        if focusManager.currentSession != nil {
-                            focusManager.showFocusView = true
-                        }
-                    case "create":
-                        appState.quickAddTrigger = UUID()
-                    default:
-                        break
-                    }
-                }
+            #else
+            Task {
+                await appState.checkAuth()
+            }
             #endif
         }
+        .onChange(of: appState.isAuthenticated) { _, isAuthenticated in
+            if isAuthenticated {
+                Task {
+                    await appState.requestCalendarAccess()
+                }
+            }
+        }
+        .onChange(of: dependencies.networkMonitor.isConnected) { _, isConnected in
+            appState.handleConnectivityChange(isConnected: isConnected)
+            #if os(iOS)
+            if isConnected {
+                Task { await focusOutbox.drain() }
+            }
+            #endif
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active, appState.isAuthenticated {
+                Task { await appState.refreshAll() }
+                #if os(iOS)
+                Task { await focusOutbox.drain() }
+                #endif
+            }
+        }
+        #if os(iOS)
+        .onOpenURL { url in
+            guard url.scheme == "mdone" else { return }
+            switch url.host {
+            case "focus":
+                if focusManager.currentSession != nil {
+                    focusManager.showFocusView = true
+                }
+            case "create":
+                appState.quickAddTrigger = UUID()
+            default:
+                break
+            }
+        }
+        #endif
     }
 }

--- a/mDone/Services/APIClient.swift
+++ b/mDone/Services/APIClient.swift
@@ -14,7 +14,11 @@ actor APIClient {
     private(set) var isRetrying: Bool = false
 
     private let maxRetries = 3
-    private let baseRetryDelay: UInt64 = 1_000_000_000 // 1 second in nanoseconds
+    /// Base of the exponential backoff, in nanoseconds: 1s, then 2s, then 4s.
+    /// Injectable so tests can exercise the retry paths without spending seven
+    /// real seconds per request, which also kept requests in flight long after
+    /// the test that started them had finished.
+    private let baseRetryDelay: UInt64
     private static let refreshCookieName = "vikunja_refresh_token"
 
     /// Per-request timeout, in seconds. URLSession's 60s default is far too
@@ -41,8 +45,9 @@ actor APIClient {
 
     static let shared = APIClient()
 
-    init(session: URLSession = .shared) {
+    init(session: URLSession = .shared, baseRetryDelay: UInt64 = 1_000_000_000) {
         self.session = session
+        self.baseRetryDelay = baseRetryDelay
 
         decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/mDoneTests/APIClientRefreshTests.swift
+++ b/mDoneTests/APIClientRefreshTests.swift
@@ -19,7 +19,7 @@ final class APIClientRefreshTests: XCTestCase {
     }
 
     private func makeClient() -> APIClient {
-        APIClient(session: MockURLProtocol.mockSession())
+        MockURLProtocol.mockClient()
     }
 
     // MARK: - Cookie capture

--- a/mDoneTests/APIClientTests.swift
+++ b/mDoneTests/APIClientTests.swift
@@ -191,7 +191,7 @@ final class APIClientTests: XCTestCase {
     // MARK: - APIClient Network Tests (using MockURLProtocol)
 
     private func makeTestClient() -> APIClient {
-        APIClient(session: MockURLProtocol.mockSession())
+        MockURLProtocol.mockClient()
     }
 
     override func setUp() {

--- a/mDoneTests/AppStateTests.swift
+++ b/mDoneTests/AppStateTests.swift
@@ -16,7 +16,7 @@ final class AppStateTests: XCTestCase {
     /// Builds an `AppState` whose `TaskService` talks to `MockURLProtocol`,
     /// so tests can drive `undoLastCompletion()`'s network path deterministically.
     private func makeMockedAppState() async -> AppState {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         return AppState(taskService: TaskService(apiClient: client))
     }
@@ -24,7 +24,7 @@ final class AppStateTests: XCTestCase {
     /// Builds an `AppState` whose `ProjectService` talks to `MockURLProtocol`,
     /// so project create/edit/archive/delete paths can be driven deterministically.
     private func makeProjectMockedAppState() async -> AppState {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         return AppState(projectService: ProjectService(apiClient: client))
     }

--- a/mDoneTests/CurrentTasksTests.swift
+++ b/mDoneTests/CurrentTasksTests.swift
@@ -19,7 +19,7 @@ final class CurrentTasksTests: XCTestCase {
 
     /// AppState whose task and label services both talk to `MockURLProtocol`.
     private func makeAppState() async -> AppState {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         return AppState(
             taskService: TaskService(apiClient: client),

--- a/mDoneTests/Helpers/MockURLProtocol.swift
+++ b/mDoneTests/Helpers/MockURLProtocol.swift
@@ -1,23 +1,51 @@
 import Foundation
+@testable import mDone
 
 /// A custom URLProtocol that intercepts network requests and returns mock responses.
 /// Used to test APIClient without making real network calls.
 final class MockURLProtocol: URLProtocol {
+    /// Guards every piece of static state below.
+    ///
+    /// The handlers are written from the test thread and read from URLSession's
+    /// own protocol threads, so leaving them as bare `static var`s was a data
+    /// race: a reader could observe a handler installed by a different test, and
+    /// the unsynchronised retain/release could take the whole test host down
+    /// mid-run. Only `capturedRequests` used to be locked.
+    private static let stateLock = NSLock()
+
+    private static var storedRequestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    private static var storedAsynchronousRequestHandler: ((URLRequest, MockURLProtocol) -> Void)?
+    private static var storedCapturedRequests: [URLRequest] = []
+
+    /// Bumped by every `reset()`, and stamped by `mockSession()` onto every
+    /// request that session makes.
+    ///
+    /// APIClient retries transient failures with a 1s/2s/4s backoff, so a
+    /// request can still be in flight long after the test that started it
+    /// returned. Without this stamp that straggler is handed whichever handler
+    /// the *next* test installed, and the next test then fails with an error it
+    /// never asked for. Comparing generations turns that into an explicit
+    /// failure against the test that leaked the request instead.
+    private static var generation: Int = 0
+    private static let generationHeader = "X-MockURLProtocol-Generation"
+
     /// Handler that receives a URLRequest and returns (HTTPURLResponse, Data).
     /// Set this before each test to control the mock response.
-    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        get { stateLock.withLock { storedRequestHandler } }
+        set { stateLock.withLock { storedRequestHandler = newValue } }
+    }
 
     /// Non-blocking variant for tests that need more than one request in flight.
     /// The handler must finish the request through `complete`.
-    static var asynchronousRequestHandler: ((URLRequest, MockURLProtocol) -> Void)?
+    static var asynchronousRequestHandler: ((URLRequest, MockURLProtocol) -> Void)? {
+        get { stateLock.withLock { storedAsynchronousRequestHandler } }
+        set { stateLock.withLock { storedAsynchronousRequestHandler = newValue } }
+    }
 
     /// Records all requests made so tests can verify endpoints, headers, etc.
-    private static let capturedRequestsLock = NSLock()
-    private static var storedCapturedRequests: [URLRequest] = []
     static var capturedRequests: [URLRequest] {
-        capturedRequestsLock.lock()
-        defer { capturedRequestsLock.unlock() }
-        return storedCapturedRequests
+        stateLock.withLock { storedCapturedRequests }
     }
 
     // swiftlint:disable:next static_over_final_class
@@ -31,14 +59,40 @@ final class MockURLProtocol: URLProtocol {
     }
 
     override func startLoading() {
-        MockURLProtocol.capture(request)
+        let requestGeneration = request.value(forHTTPHeaderField: MockURLProtocol.generationHeader).flatMap(Int.init)
 
-        if let handler = MockURLProtocol.asynchronousRequestHandler {
-            handler(request, self)
+        // Read the generation and both handlers in one critical section so the
+        // request is served by a consistent snapshot of the mock's state.
+        let (currentGeneration, syncHandler, asyncHandler) = MockURLProtocol.stateLock.withLock {
+            (
+                MockURLProtocol.generation,
+                MockURLProtocol.storedRequestHandler,
+                MockURLProtocol.storedAsynchronousRequestHandler
+            )
+        }
+
+        // A straggler from a finished test. Fail it rather than letting it run
+        // the current test's handler, and keep it out of `capturedRequests`.
+        if let requestGeneration, requestGeneration != currentGeneration {
+            let error = NSError(domain: "MockURLProtocol", code: -2, userInfo: [
+                NSLocalizedDescriptionKey: """
+                Request to \(request.url?.absoluteString ?? "<no URL>") arrived from a finished test \
+                (generation \(requestGeneration), current \(currentGeneration)). \
+                The test that started it returned while the request was still in flight.
+                """,
+            ])
+            client?.urlProtocol(self, didFailWithError: error)
             return
         }
 
-        guard let handler = MockURLProtocol.requestHandler else {
+        MockURLProtocol.capture(request)
+
+        if let asyncHandler {
+            asyncHandler(request, self)
+            return
+        }
+
+        guard let syncHandler else {
             let error = NSError(domain: "MockURLProtocol", code: -1, userInfo: [
                 NSLocalizedDescriptionKey: "No request handler set",
             ])
@@ -47,7 +101,7 @@ final class MockURLProtocol: URLProtocol {
         }
 
         do {
-            let (response, data) = try handler(request)
+            let (response, data) = try syncHandler(request)
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             client?.urlProtocol(self, didLoad: data)
             client?.urlProtocolDidFinishLoading(self)
@@ -60,17 +114,16 @@ final class MockURLProtocol: URLProtocol {
 
     /// Resets all state. Call in setUp/tearDown.
     static func reset() {
-        requestHandler = nil
-        asynchronousRequestHandler = nil
-        capturedRequestsLock.lock()
-        storedCapturedRequests = []
-        capturedRequestsLock.unlock()
+        stateLock.withLock {
+            storedRequestHandler = nil
+            storedAsynchronousRequestHandler = nil
+            storedCapturedRequests = []
+            generation += 1
+        }
     }
 
     private static func capture(_ request: URLRequest) {
-        capturedRequestsLock.lock()
-        defer { capturedRequestsLock.unlock() }
-        storedCapturedRequests.append(request)
+        stateLock.withLock { storedCapturedRequests.append(request) }
     }
 
     func complete(response: HTTPURLResponse, data: Data) {
@@ -92,17 +145,35 @@ final class MockURLProtocol: URLProtocol {
     }
 
     /// Creates a URLSession configured to use this mock protocol.
+    ///
+    /// The session is stamped with the generation current at the moment it is
+    /// built, which is what lets `startLoading` tell this test's requests apart
+    /// from a previous test's leftovers. Build the session inside the test, not
+    /// in `setUp` before `reset()`.
     static func mockSession() -> URLSession {
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [MockURLProtocol.self]
+        config.httpAdditionalHeaders = [generationHeader: String(stateLock.withLock { generation })]
         return URLSession(configuration: config)
+    }
+
+    /// An `APIClient` on the mock session, with the retry backoff collapsed.
+    ///
+    /// The production 1s/2s/4s backoff means a test exercising a 5xx or an
+    /// unreachable server sits for seven real seconds, and leaves the request in
+    /// flight for all of them. Retrying immediately keeps the retry paths under
+    /// test without the wall clock or the straggling requests.
+    static func mockClient() -> APIClient {
+        APIClient(session: mockSession(), baseRetryDelay: 0)
     }
 
     /// Returns a request's body. URLSession hands URLProtocol the body as a
     /// stream (`httpBody` is nil by the time the request reaches the handler),
     /// so tests asserting on request bodies must go through this.
     static func bodyData(from request: URLRequest) -> Data? {
-        if let body = request.httpBody { return body }
+        if let body = request.httpBody {
+            return body
+        }
         guard let stream = request.httpBodyStream else { return nil }
         stream.open()
         defer { stream.close() }

--- a/mDoneTests/KanbanTests.swift
+++ b/mDoneTests/KanbanTests.swift
@@ -115,7 +115,7 @@ final class KanbanTests: XCTestCase {
     // MARK: - ProjectService.fetchBuckets
 
     func testFetchBucketsReturnsBuckets() async throws {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         let service = ProjectService(apiClient: client)
 
@@ -192,7 +192,7 @@ final class KanbanTests: XCTestCase {
     }
 
     private func makeBucketService() async -> ProjectService {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         return ProjectService(apiClient: client)
     }
@@ -301,7 +301,7 @@ final class KanbanTests: XCTestCase {
     // MARK: - TaskService.moveTaskToBucket
 
     func testMoveTaskToBucketSendsTaskId() async throws {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         let service = TaskService(apiClient: client)
 
@@ -323,7 +323,7 @@ final class KanbanTests: XCTestCase {
 
     @MainActor
     func testAppStateFetchBucketsSortsAndMergesTasks() async {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         let appState = AppState(projectService: ProjectService(apiClient: client))
 
@@ -376,7 +376,7 @@ final class KanbanTests: XCTestCase {
 
     @MainActor
     func testAppStateMoveTaskUpdatesBucketLocally() async {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         let appState = AppState(taskService: TaskService(apiClient: client))
 
@@ -400,7 +400,7 @@ final class KanbanTests: XCTestCase {
 
     @MainActor
     func testAppStateMoveTaskInsertsMissingTask() async {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         let appState = AppState(taskService: TaskService(apiClient: client))
 

--- a/mDoneTests/LabelServiceTests.swift
+++ b/mDoneTests/LabelServiceTests.swift
@@ -13,7 +13,7 @@ final class LabelServiceTests: XCTestCase {
     }
 
     private func makeService() async -> LabelService {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         return LabelService(apiClient: client)
     }

--- a/mDoneTests/MockURLProtocolIsolationTests.swift
+++ b/mDoneTests/MockURLProtocolIsolationTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import mDone
+
+/// Covers the isolation guarantees the rest of the suite leans on.
+///
+/// `MockURLProtocol` holds its handler in static state shared by every test in
+/// the bundle, and APIClient retries transient failures, so a request can still
+/// be in flight after the test that started it has returned. Without these
+/// guarantees that straggler runs the *next* test's handler and fails it with an
+/// error it never set up, which is why a different test used to fail on each
+/// full-suite run.
+final class MockURLProtocolIsolationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    func testRequestFromABeforeResetSessionIsRejected() async throws {
+        // A session built by a "previous test", which then finished.
+        let staleSession = MockURLProtocol.mockSession()
+        MockURLProtocol.reset()
+
+        // The "next test" installs its own handler.
+        let served = expectation(description: "handler ran")
+        served.isInverted = true
+        MockURLProtocol.requestHandler = { request in
+            served.fulfill()
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data())
+        }
+
+        do {
+            _ = try await staleSession.data(from: XCTUnwrap(URL(string: "https://mock.vikunja.io/api/v1/tasks")))
+            XCTFail("A request from a finished test must not be served")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, "MockURLProtocol")
+        }
+
+        await fulfillment(of: [served], timeout: 0.5)
+        XCTAssertTrue(
+            MockURLProtocol.capturedRequests.isEmpty,
+            "A rejected straggler must not land in the current test's captured requests"
+        )
+    }
+
+    func testRequestFromTheCurrentSessionIsServed() async throws {
+        let session = MockURLProtocol.mockSession()
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data("{}".utf8))
+        }
+
+        let url = try XCTUnwrap(URL(string: "https://mock.vikunja.io/api/v1/tasks"))
+        let (data, response) = try await session.data(from: url)
+
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertEqual(data, Data("{}".utf8))
+        XCTAssertEqual(MockURLProtocol.capturedRequests.count, 1)
+    }
+
+    /// The retry paths have to stay exercised, just without the wall clock.
+    func testMockClientStillRetriesTransientFailuresWithoutTheBackoff() async throws {
+        let client = MockURLProtocol.mockClient()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+
+        MockURLProtocol.requestHandler = { _ in throw URLError(.cannotConnectToHost) }
+
+        let started = Date()
+        do {
+            let _: VTask = try await client.fetch(Endpoint.task(id: 1))
+            XCTFail("Expected the unreachable server to surface as an error")
+        } catch {
+            // Expected.
+        }
+
+        // 1 initial attempt + 3 retries, and none of the 1s/2s/4s backoff.
+        XCTAssertEqual(MockURLProtocol.capturedRequests.count, 4)
+        XCTAssertLessThan(Date().timeIntervalSince(started), 1.0)
+    }
+}

--- a/mDoneTests/OfflineCacheTests.swift
+++ b/mDoneTests/OfflineCacheTests.swift
@@ -33,7 +33,7 @@ final class OfflineCacheTests: XCTestCase {
     }
 
     private func makeSyncService(container: ModelContainer) async -> SyncService {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         return SyncService(
             taskService: TaskService(apiClient: client),
@@ -45,7 +45,7 @@ final class OfflineCacheTests: XCTestCase {
     /// An `AppState` whose task/project/label services all talk to
     /// `MockURLProtocol`, wired to `sync` and a monitor pinned to `connected`.
     private func makeAppState(sync: SyncService, connected: Bool) async -> AppState {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         let state = AppState(
             taskService: TaskService(apiClient: client),

--- a/mDoneTests/OfflineEditQueueTests.swift
+++ b/mDoneTests/OfflineEditQueueTests.swift
@@ -32,7 +32,7 @@ final class OfflineEditQueueTests: XCTestCase {
     }
 
     private func makeSyncService(container: ModelContainer) async -> SyncService {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         return SyncService(
             taskService: TaskService(apiClient: client),
@@ -43,7 +43,7 @@ final class OfflineEditQueueTests: XCTestCase {
     }
 
     private func makeAppState(sync: SyncService, connected: Bool) async -> AppState {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         let state = AppState(
             taskService: TaskService(apiClient: client),

--- a/mDoneTests/ProjectServiceTests.swift
+++ b/mDoneTests/ProjectServiceTests.swift
@@ -13,7 +13,7 @@ final class ProjectServiceTests: XCTestCase {
     }
 
     private func makeTestService() -> (ProjectService, APIClient) {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         let service = ProjectService(apiClient: client)
         return (service, client)
     }

--- a/mDoneTests/ServerInfoServiceTests.swift
+++ b/mDoneTests/ServerInfoServiceTests.swift
@@ -34,7 +34,7 @@ final class ServerInfoServiceTests: XCTestCase {
     """
 
     private func service() -> ServerInfoService {
-        ServerInfoService(apiClient: APIClient(session: MockURLProtocol.mockSession()))
+        ServerInfoService(apiClient: MockURLProtocol.mockClient())
     }
 
     func testFetchesTheInfoEndpoint() async throws {

--- a/mDoneTests/SyncServiceTests.swift
+++ b/mDoneTests/SyncServiceTests.swift
@@ -305,7 +305,7 @@ final class SyncServiceTests: XCTestCase {
         ])
         let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: schema, configurations: [config])
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         return SyncService(
             taskService: TaskService(apiClient: client),
             projectService: ProjectService(apiClient: client),

--- a/mDoneTests/TaskRelationTests.swift
+++ b/mDoneTests/TaskRelationTests.swift
@@ -36,14 +36,14 @@ final class TaskRelationTests: XCTestCase {
     }
 
     private func makeConfiguredService() async -> TaskService {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         return TaskService(apiClient: client)
     }
 
     @MainActor
     private func makeMockedAppState() async -> AppState {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
         return AppState(taskService: TaskService(apiClient: client))
     }

--- a/mDoneTests/TaskServiceTests.swift
+++ b/mDoneTests/TaskServiceTests.swift
@@ -500,7 +500,7 @@ final class TaskServiceTests: XCTestCase {
     // MARK: - TaskService Network Tests
 
     private func makeTestService() -> (TaskService, APIClient) {
-        let client = APIClient(session: MockURLProtocol.mockSession())
+        let client = MockURLProtocol.mockClient()
         let service = TaskService(apiClient: client)
         return (service, client)
     }


### PR DESCRIPTION
## Summary

`APIClientTests` (and occasionally `OfflineCacheTests.testSuccessfulRefreshClearsCachedDataFlag`) failed intermittently in full `mDoneTests` runs on the iOS Simulator but passed in isolation. A different test failed each run, always with `NSURLErrorDomain -1004` and APIClient's retry log.

There are two independent causes.

**1. `MockURLProtocol`'s handlers were unsynchronised shared state.** The scheme runs classes serially, and every class resets the handler in `setUp`/`tearDown`, so the concurrency comes from stragglers: APIClient retries transient failures with a 1s/2s/4s backoff, so a request started by one test was still in flight seven seconds later, during the next test, reading `requestHandler` on a URLSession thread while the next test wrote it. Only `capturedRequests` had a lock. `URLError(.cannotConnectToHost)` is thrown by exactly two handlers in the suite, both in `OfflineCacheTests`, which is where the -1004 in the `APIClientTests` failures came from.

- Both handlers now go through the same lock and are read as one snapshot in `startLoading`.
- `reset()` bumps a generation that `mockSession()` stamps on its requests. A straggler from a finished test is rejected with a message naming the leak instead of running the current test's handler, and stays out of `capturedRequests`.
- `APIClient` takes `baseRetryDelay` as a defaulted init parameter; `MockURLProtocol.mockClient()` sets it to 0. Retry paths stay covered, production timing is unchanged, and the bundle drops from 62s to under 5s.
- The app skips its production launch (on-disk store, `NWPathMonitor`, `checkAuth()`, `refreshAll()`) when the process only exists to host the unit tests, gated on `XCTestConfigurationFilePath`, which is unset for UI-test hosts. On a machine with a dev server configured, those refreshes printed connection failures and retry backoff into whichever test happened to be running.

**2. The simulator sometimes never injects the test bundle** ("hung before establishing connection" / "never finished bootstrapping"). A sampled hung host process is fully launched and idle in its run loop with no XCTest loaded at all, so this is an Xcode/CoreSimulator flake, not repo code. The launch gate above did not change its rate. `ios-tests.yml` now retries once on that signature only; a run that actually executed tests fails the job exactly as before.

## Related Issues

None filed; pre-existing flake noticed while working on the macOS test CI.

## Testing

- 12 consecutive full `mDoneTests` runs on `iPhone 17` that reached the tests: 644/644 passed every time, ~4.5s each (was 61.7s).
- The bundle-injection hang recurred at roughly 1 in 5 across ~20 runs before and after the change, and each time zero tests had run.
- New `MockURLProtocolIsolationTests` covers the straggler rejection, normal serving, and that `mockClient()` still performs all four attempts without the backoff.
- `swiftlint lint --quiet` reports only the pre-existing `opening_brace` warnings; `swiftformat` applied to changed files.

## Checklist

- [x] Builds on iOS and macOS
- [x] Tests pass
- [x] Ran `swiftlint lint --quiet` and `swiftformat .`
- [x] No breaking changes (or described in summary above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
