### PR TITLE
release: 1.15.0 build 63

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -23,8 +23,8 @@ settings:
     # not feature-related — see PR "decisions".
     PRODUCT_NAME: "$(TARGET_NAME)"
     SWIFT_VERSION: "5.9"
-    MARKETING_VERSION: "1.6.2"
-    CURRENT_PROJECT_VERSION: "44"
+    MARKETING_VERSION: "1.15.0"
+    CURRENT_PROJECT_VERSION: "63"
     DEVELOPMENT_TEAM: "Z62E7MGREE"
     CODE_SIGN_IDENTITY: "Apple Development"
     CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
Commits the version and build number that shipped to TestFlight today (iOS and macOS build 63, both uploads clean). project.yml had lagged at 1.6.2 build 44 since June because every release bumped it locally and reverted; from now on the file matches App Store Connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)