### PR TITLE
feat: open tasks in a detail pane beside the list on iPad (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- On iPad, tapping a task now opens it in a panel beside the list instead of a sheet, so you can work through tasks without covering the list. The panel appears whenever the window is wide enough, including in Split View and Stage Manager, and hands back to the sheet when it is not. Escape cancels and Cmd-S saves from a hardware keyboard, and Kanban cards lift under a trackpad pointer (#34).
+
 ## [1.15.0] - 2026-09-03
 
 ### Added

--- a/mDone/Views/Projects/ProjectBoardView.swift
+++ b/mDone/Views/Projects/ProjectBoardView.swift
@@ -140,6 +140,11 @@ private struct BoardColumn: View {
 /// to" submenu and a done toggle via its context menu.
 private struct BoardTaskCard: View {
     @Environment(AppState.self) private var appState
+    #if os(iOS)
+    /// Present while the hosting screen shows an inline detail pane (iPad,
+    /// regular width); absent, a tap opens the sheet.
+    @Environment(InlineTaskSelection.self) private var inlineSelection: InlineTaskSelection?
+    #endif
     let task: VTask
     let otherBuckets: [Bucket]
     let project: Project
@@ -151,7 +156,15 @@ private struct BoardTaskCard: View {
         card
             #if os(iOS)
             .contentShape(Rectangle())
-            .onTapGesture { showDetail = true }
+            .onTapGesture {
+                if let inlineSelection {
+                    inlineSelection.task = task
+                } else {
+                    showDetail = true
+                }
+            }
+            // Cards lift under a trackpad or mouse pointer on iPad.
+            .hoverEffect(.lift)
             .sheet(isPresented: $showDetail) {
                 TaskDetailSheet(task: task)
             }

--- a/mDone/Views/Tasks/InlineTaskDetail.swift
+++ b/mDone/Views/Tasks/InlineTaskDetail.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// Where a tapped task opens on the screen that hosts the row.
+///
+/// On a phone a task opens in a sheet. On an iPad with room to spare the
+/// screen shows a detail pane beside the list instead, and tapping a row
+/// selects the task into that pane. `TaskListScreen` puts an instance in the
+/// environment only while the pane is on screen, so a row that finds none
+/// falls back to the sheet. The decision lives at the screen, not the row,
+/// because a Split View or Stage Manager resize can take the pane away while
+/// the list stays where it is (issue #34).
+@Observable
+final class InlineTaskSelection {
+    /// The task shown in the pane. A snapshot: the pane prefers the live copy
+    /// from `AppState` when there is one, and falls back to this for tasks
+    /// that only exist in a board's buckets.
+    var task: VTask?
+}
+
+/// Pure layout rules for the inline detail pane, kept free of views so they
+/// can be unit tested.
+enum InlineTaskDetailLayout {
+    /// Below this width the list and the pane would both be cramped, so the
+    /// task opens in a sheet even though the size class is regular. An iPad
+    /// in a two-thirds Split View or a 10-inch iPad in portrait clears it.
+    static let minimumContainerWidth: CGFloat = 700
+
+    /// The pane takes this share of the container, within the clamp below.
+    static let paneFraction: CGFloat = 0.42
+    static let minimumPaneWidth: CGFloat = 340
+    static let maximumPaneWidth: CGFloat = 460
+
+    /// True when the screen should host the pane rather than present a sheet.
+    static func showsPane(isRegularWidth: Bool, containerWidth: CGFloat) -> Bool {
+        isRegularWidth && containerWidth >= minimumContainerWidth
+    }
+
+    /// The pane's width for a container of the given width.
+    static func paneWidth(for containerWidth: CGFloat) -> CGFloat {
+        min(max(containerWidth * paneFraction, minimumPaneWidth), maximumPaneWidth)
+    }
+}

--- a/mDone/Views/Tasks/TaskDetailSheet.swift
+++ b/mDone/Views/Tasks/TaskDetailSheet.swift
@@ -295,7 +295,9 @@ struct TaskDetailSheet: View {
         }
         .alert("Delete Task?", isPresented: $showDeleteConfirm) {
             Button("Delete", role: .destructive) {
-                Task {
+                // Explicitly main-actor: `close()` touches view state
+                // (dismiss, or the pane's selection) after the await.
+                Task { @MainActor in
                     await appState.deleteTask(task)
                     close()
                 }
@@ -330,7 +332,7 @@ struct TaskDetailSheet: View {
             clearStartDate: startDate == nil,
             clearEndDate: endDate == nil
         )
-        Task {
+        Task { @MainActor in
             await appState.updateTask(id: task.id, request: request)
             close()
         }

--- a/mDone/Views/Tasks/TaskDetailSheet.swift
+++ b/mDone/Views/Tasks/TaskDetailSheet.swift
@@ -1,5 +1,16 @@
 import SwiftUI
 
+/// How `TaskDetailSheet` is shown.
+enum TaskDetailPresentation {
+    /// A modal sheet with Cancel and Save in its navigation bar: iPhone, and
+    /// any iPad layout too narrow for a pane.
+    case sheet
+    /// A pane beside the task list on iPad, with its own header row in place
+    /// of a navigation bar. `onClose` replaces dismiss: it runs when the user
+    /// cancels, saves or deletes (issue #34).
+    case inline(onClose: () -> Void)
+}
+
 struct TaskDetailSheet: View {
     @Environment(AppState.self) private var appState
     @Environment(\.dismiss) private var dismiss
@@ -7,6 +18,7 @@ struct TaskDetailSheet: View {
     @Environment(FocusManager.self) private var focusManager
     #endif
     let task: VTask
+    var presentation: TaskDetailPresentation = .sheet
 
     @State private var title: String
     @State private var description: String
@@ -23,8 +35,9 @@ struct TaskDetailSheet: View {
     @State private var estimateSeconds: TimeInterval?
     @State private var percentDone: Double
 
-    init(task: VTask) {
+    init(task: VTask, presentation: TaskDetailPresentation = .sheet) {
         self.task = task
+        self.presentation = presentation
         let initialDescription = task.userVisibleDescription ?? ""
         _title = State(initialValue: task.title)
         _description = State(initialValue: initialDescription)
@@ -48,197 +61,249 @@ struct TaskDetailSheet: View {
     }
 
     var body: some View {
-        NavigationStack {
-            Form {
-                Section {
-                    TextField("Task title", text: $title)
-                        .font(.headline)
-
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            Text("Description")
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                            Spacer()
-                            Button {
-                                isShowingDescriptionPreview.toggle()
-                            } label: {
-                                Image(systemName: isShowingDescriptionPreview ? "pencil" : "eye")
-                                    .font(.caption)
-                            }
-                            .buttonStyle(.borderless)
-                            .accessibilityLabel(isShowingDescriptionPreview ? "Edit description" :
-                                "Preview description")
+        switch presentation {
+        case .sheet:
+            NavigationStack {
+                form
+                    .navigationTitle("Edit Task")
+                    #if os(iOS)
+                    .navigationBarTitleDisplayMode(.inline)
+                    #endif
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") { close() }
                         }
-
-                        if isShowingDescriptionPreview {
-                            if description.isEmpty {
-                                Text("No description")
-                                    .font(.body)
-                                    .foregroundStyle(.secondary)
-                                    .italic()
-                            } else {
-                                Text(RichTextRenderer.render(description))
-                                    .font(.body)
-                                    .textSelection(.enabled)
-                            }
-                        } else {
-                            TextEditor(text: $description)
-                                .font(.body)
-                                .frame(minHeight: 80)
-                                .scrollContentBackground(.hidden)
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Save") { saveTask() }
+                                .fontWeight(.semibold)
+                                .disabled(!canSave)
                         }
                     }
-                }
+            }
+            #if os(iOS)
+            .presentationDetents([.medium, .large])
+            #endif
+        case .inline:
+            VStack(spacing: 0) {
+                inlineHeader
+                Divider()
+                form
+            }
+            #if os(iOS)
+            // Match the list's grouped background, and carry it up under the
+            // floating top bar the way the list does, so the pane does not
+            // sit on a white strip.
+            .background(Color(.systemGroupedBackground).ignoresSafeArea())
+            #endif
+        }
+    }
 
-                #if os(iOS)
-                Section("Focus") {
-                    if focusManager.focusedTaskId == task.id {
+    /// The header the inline pane shows instead of a navigation bar. Escape
+    /// and Cmd-S mirror the sheet's Cancel and Save for an iPad keyboard.
+    private var inlineHeader: some View {
+        ZStack {
+            Text("Edit Task")
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+
+            HStack {
+                Button("Cancel") { close() }
+                    .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button("Save") { saveTask() }
+                    .fontWeight(.semibold)
+                    .keyboardShortcut("s", modifiers: .command)
+                    .disabled(!canSave)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+        .background(.bar)
+    }
+
+    private var canSave: Bool {
+        !title.isEmpty && TaskScheduleEditor.isValid(startDate: startDate, endDate: endDate)
+    }
+
+    /// Leaves the detail view the way it was shown: dismissing the sheet, or
+    /// telling the hosting screen to clear the pane.
+    private func close() {
+        switch presentation {
+        case .sheet:
+            dismiss()
+        case let .inline(onClose):
+            onClose()
+        }
+    }
+
+    private var form: some View {
+        Form {
+            Section {
+                TextField("Task title", text: $title)
+                    .font(.headline)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Description")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        Spacer()
                         Button {
-                            focusManager.endFocus()
+                            isShowingDescriptionPreview.toggle()
                         } label: {
-                            Label("End Focus", systemImage: "scope")
-                                .foregroundStyle(.orange)
+                            Image(systemName: isShowingDescriptionPreview ? "pencil" : "eye")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.borderless)
+                        .accessibilityLabel(isShowingDescriptionPreview ? "Edit description" :
+                            "Preview description")
+                    }
+
+                    if isShowingDescriptionPreview {
+                        if description.isEmpty {
+                            Text("No description")
+                                .font(.body)
+                                .foregroundStyle(.secondary)
+                                .italic()
+                        } else {
+                            Text(RichTextRenderer.render(description))
+                                .font(.body)
+                                .textSelection(.enabled)
                         }
                     } else {
-                        Button {
-                            let projectName = appState.projects
-                                .first(where: { $0.id == task.projectId })?.title ?? String(localized: "Inbox")
-                            focusManager.startFocus(task: task, projectName: projectName)
-                        } label: {
-                            Label("Focus on This Task", systemImage: "scope")
-                        }
+                        TextEditor(text: $description)
+                            .font(.body)
+                            .frame(minHeight: 80)
+                            .scrollContentBackground(.hidden)
                     }
-                    FocusHistoryRow(taskId: task.id)
                 }
-                #endif
+            }
 
-                Section("Current") {
+            #if os(iOS)
+            Section("Focus") {
+                if focusManager.focusedTaskId == task.id {
                     Button {
-                        Task { await appState.toggleCurrent(task) }
+                        focusManager.endFocus()
                     } label: {
-                        Label(
-                            isCurrentNow ? "Remove from Current" : "Mark as Current",
-                            systemImage: isCurrentNow ? "pin.slash" : "pin"
-                        )
+                        Label("End Focus", systemImage: "scope")
+                            .foregroundStyle(.orange)
                     }
+                } else {
+                    Button {
+                        let projectName = appState.projects
+                            .first(where: { $0.id == task.projectId })?.title ?? String(localized: "Inbox")
+                        focusManager.startFocus(task: task, projectName: projectName)
+                    } label: {
+                        Label("Focus on This Task", systemImage: "scope")
+                    }
+                }
+                FocusHistoryRow(taskId: task.id)
+            }
+            #endif
 
-                    VStack(alignment: .leading, spacing: 4) {
+            Section("Current") {
+                Button {
+                    Task { await appState.toggleCurrent(task) }
+                } label: {
+                    Label(
+                        isCurrentNow ? "Remove from Current" : "Mark as Current",
+                        systemImage: isCurrentNow ? "pin.slash" : "pin"
+                    )
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Progress")
+                        Spacer()
+                        Text("\(Int((percentDone * 100).rounded()))%")
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(value: $percentDone, in: 0 ... 1, step: 0.05)
+                        .accessibilityLabel("Progress")
+                        .accessibilityValue("\(Int((percentDone * 100).rounded())) percent")
+                }
+            }
+
+            TaskRelationsSections(task: task)
+
+            TaskScheduleEditor(
+                dueDate: $dueDate,
+                startDate: $startDate,
+                endDate: $endDate
+            )
+
+            Section {
+                EstimatePicker(estimateSeconds: $estimateSeconds)
+            }
+
+            Section("Repeat") {
+                Picker("Repeat", selection: $repeatInterval) {
+                    Text("Never").tag(Int64(0))
+                    Text("Daily").tag(Int64(86400))
+                    Text("Weekly").tag(Int64(604_800))
+                    Text("Every 2 Weeks").tag(Int64(1_209_600))
+                    Text("Monthly").tag(Int64(2_592_000))
+                    Text("Yearly").tag(Int64(31_536_000))
+                }
+            }
+
+            Section("Reminders") {
+                ReminderEditor(reminders: $reminders)
+            }
+
+            Section("Priority") {
+                Picker("Priority", selection: $priority) {
+                    ForEach(PriorityLevel.allCases, id: \.rawValue) { level in
                         HStack {
-                            Text("Progress")
-                            Spacer()
-                            Text("\(Int((percentDone * 100).rounded()))%")
-                                .monospacedDigit()
-                                .foregroundStyle(.secondary)
+                            PriorityBadge(priority: level)
+                            Text(level.label)
                         }
-                        Slider(value: $percentDone, in: 0 ... 1, step: 0.05)
-                            .accessibilityLabel("Progress")
-                            .accessibilityValue("\(Int((percentDone * 100).rounded())) percent")
+                        .tag(Int64(level.rawValue))
                     }
                 }
+                .pickerStyle(.menu)
+            }
 
-                TaskRelationsSections(task: task)
-
-                TaskScheduleEditor(
-                    dueDate: $dueDate,
-                    startDate: $startDate,
-                    endDate: $endDate
-                )
-
-                Section {
-                    EstimatePicker(estimateSeconds: $estimateSeconds)
-                }
-
-                Section("Repeat") {
-                    Picker("Repeat", selection: $repeatInterval) {
-                        Text("Never").tag(Int64(0))
-                        Text("Daily").tag(Int64(86400))
-                        Text("Weekly").tag(Int64(604_800))
-                        Text("Every 2 Weeks").tag(Int64(1_209_600))
-                        Text("Monthly").tag(Int64(2_592_000))
-                        Text("Yearly").tag(Int64(31_536_000))
-                    }
-                }
-
-                Section("Reminders") {
-                    ReminderEditor(reminders: $reminders)
-                }
-
-                Section("Priority") {
-                    Picker("Priority", selection: $priority) {
-                        ForEach(PriorityLevel.allCases, id: \.rawValue) { level in
-                            HStack {
-                                PriorityBadge(priority: level)
-                                Text(level.label)
-                            }
-                            .tag(Int64(level.rawValue))
+            if !appState.projects.isEmpty {
+                Section("Project") {
+                    Picker("Project", selection: $selectedProjectId) {
+                        ForEach(appState.projects.projectHierarchy().flattened { _ in true }) { row in
+                            Text(String(repeating: "  ", count: row.depth) + row.project.title)
+                                .tag(row.project.id)
                         }
                     }
                     .pickerStyle(.menu)
                 }
+            }
 
-                if !appState.projects.isEmpty {
-                    Section("Project") {
-                        Picker("Project", selection: $selectedProjectId) {
-                            ForEach(appState.projects.projectHierarchy().flattened { _ in true }) { row in
-                                Text(String(repeating: "  ", count: row.depth) + row.project.title)
-                                    .tag(row.project.id)
-                            }
+            if let labels = task.labels, !labels.isEmpty {
+                Section("Labels") {
+                    FlowLayout(spacing: 8) {
+                        ForEach(labels) { label in
+                            LabelChip(label: label)
                         }
-                        .pickerStyle(.menu)
-                    }
-                }
-
-                if let labels = task.labels, !labels.isEmpty {
-                    Section("Labels") {
-                        FlowLayout(spacing: 8) {
-                            ForEach(labels) { label in
-                                LabelChip(label: label)
-                            }
-                        }
-                    }
-                }
-
-                Section {
-                    Button("Delete Task", role: .destructive) {
-                        showDeleteConfirm = true
                     }
                 }
             }
-            .navigationTitle("Edit Task")
-            #if os(iOS)
-                .navigationBarTitleDisplayMode(.inline)
-            #endif
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { dismiss() }
-                    }
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button("Save") { saveTask() }
-                            .fontWeight(.semibold)
-                            .disabled(
-                                title.isEmpty || !TaskScheduleEditor.isValid(
-                                    startDate: startDate,
-                                    endDate: endDate
-                                )
-                            )
-                    }
+
+            Section {
+                Button("Delete Task", role: .destructive) {
+                    showDeleteConfirm = true
                 }
-                .alert("Delete Task?", isPresented: $showDeleteConfirm) {
-                    Button("Delete", role: .destructive) {
-                        Task {
-                            await appState.deleteTask(task)
-                            dismiss()
-                        }
-                    }
-                    Button("Cancel", role: .cancel) {}
-                } message: {
-                    Text("This action cannot be undone.")
-                }
+            }
         }
-        #if os(iOS)
-        .presentationDetents([.medium, .large])
-        #endif
+        .alert("Delete Task?", isPresented: $showDeleteConfirm) {
+            Button("Delete", role: .destructive) {
+                Task {
+                    await appState.deleteTask(task)
+                    close()
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This action cannot be undone.")
+        }
     }
 
     private func saveTask() {
@@ -267,7 +332,7 @@ struct TaskDetailSheet: View {
         )
         Task {
             await appState.updateTask(id: task.id, request: request)
-            dismiss()
+            close()
         }
     }
 }

--- a/mDone/Views/Tasks/TaskListScreen.swift
+++ b/mDone/Views/Tasks/TaskListScreen.swift
@@ -15,6 +15,11 @@ struct TaskListScreen: View {
     @AppStorage("calmMode") private var calmMode = false
     #if os(iOS)
     @State private var showBoard = false
+    /// On iPad, a task opens in a pane beside the list when there is room;
+    /// see `InlineTaskSelection`. Held here so Inbox and each project screen
+    /// keep their own selection.
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @State private var inlineSelection = InlineTaskSelection()
     #endif
 
     /// A board (Kanban) view is offered only for real, editable projects that
@@ -49,7 +54,7 @@ struct TaskListScreen: View {
 
     var body: some View {
         @Bindable var bindableAppState = appState
-        content
+        adaptiveContent
             .task(id: projectFilter?.id) {
                 if let projectFilter {
                     await appState.fetchProjectTasks(project: projectFilter)
@@ -78,6 +83,51 @@ struct TaskListScreen: View {
                     }
                 }
     }
+
+    /// The list (or board) alone on iPhone; on iPad with room, the same beside
+    /// the selected task's detail pane. The size is read here, not at the
+    /// row, because Split View and Stage Manager can resize the window with
+    /// the list on screen: the pane then gives way and taps go back to
+    /// opening a sheet (issue #34).
+    @ViewBuilder
+    private var adaptiveContent: some View {
+        #if os(iOS)
+        GeometryReader { geometry in
+            let showsPane = InlineTaskDetailLayout.showsPane(
+                isRegularWidth: horizontalSizeClass == .regular,
+                containerWidth: geometry.size.width
+            )
+            HStack(spacing: 0) {
+                content
+                    .environment(showsPane ? inlineSelection : nil)
+
+                if showsPane, let task = inlineTask {
+                    Divider()
+                    TaskDetailSheet(task: task, presentation: .inline { inlineSelection.task = nil })
+                        // Fresh editing state per task; without this the
+                        // pane would keep the previous task's edits.
+                        .id(task.id)
+                        .frame(width: InlineTaskDetailLayout.paneWidth(for: geometry.size.width))
+                        .transition(.move(edge: .trailing).combined(with: .opacity))
+                }
+            }
+            .animation(.snappy, value: showsPane && inlineTask != nil)
+        }
+        #else
+        content
+        #endif
+    }
+
+    #if os(iOS)
+    /// The task to show in the pane: the live copy from `AppState` when it
+    /// has one, so edits made from the row are reflected, else the snapshot
+    /// the row was tapped with (board cards can carry tasks the main list
+    /// does not hold).
+    private var inlineTask: VTask? {
+        guard let selected = inlineSelection.task else { return nil }
+        return appState.tasks.first(where: { $0.id == selected.id }) ?? selected
+    }
+    #endif
 
     @ViewBuilder
     private var content: some View {

--- a/mDone/Views/Tasks/TaskRow.swift
+++ b/mDone/Views/Tasks/TaskRow.swift
@@ -4,6 +4,9 @@ struct TaskRow: View {
     @Environment(AppState.self) private var appState
     #if os(iOS)
     @Environment(FocusManager.self) private var focusManager
+    /// Present only while the hosting screen shows an inline detail pane
+    /// (iPad, regular width). Absent, a tap opens the sheet as on iPhone.
+    @Environment(InlineTaskSelection.self) private var inlineSelection: InlineTaskSelection?
     #endif
     let task: VTask
     /// When true, the row is display-only: no completion toggle, swipe actions,
@@ -33,6 +36,21 @@ struct TaskRow: View {
     private var isFocused: Bool {
         focusManager.focusedTaskId == task.id
     }
+
+    /// True while this task is the one open in the inline detail pane.
+    private var isSelectedInline: Bool {
+        inlineSelection?.task?.id == task.id
+    }
+
+    private var rowBackground: Color? {
+        if isFocused {
+            return Color.orange.opacity(0.08)
+        }
+        if isSelectedInline {
+            return Color.accentColor.opacity(0.12)
+        }
+        return nil
+    }
     #endif
 
     var body: some View {
@@ -40,11 +58,14 @@ struct TaskRow: View {
         #if os(iOS)
         .contentShape(Rectangle())
         .onTapGesture {
-            if !readOnly {
+            guard !readOnly else { return }
+            if let inlineSelection {
+                inlineSelection.task = task
+            } else {
                 showDetail = true
             }
         }
-        .listRowBackground(isFocused ? Color.orange.opacity(0.08) : nil)
+        .listRowBackground(rowBackground)
         #endif
         .swipeActions(edge: .leading) {
             if !readOnly {

--- a/mDoneTests/InlineTaskDetailTests.swift
+++ b/mDoneTests/InlineTaskDetailTests.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import XCTest
+@testable import mDone
+
+/// The layout rules behind the iPad detail pane (issue #34). The views
+/// themselves are not unit tested; these pin down when the pane appears and
+/// how wide it is, which is what a Split View or Stage Manager resize
+/// exercises.
+final class InlineTaskDetailTests: XCTestCase {
+    // MARK: - showsPane
+
+    func testCompactWidthNeverShowsPane() {
+        XCTAssertFalse(InlineTaskDetailLayout.showsPane(isRegularWidth: false, containerWidth: 1366))
+    }
+
+    func testRegularWidthShowsPaneAtOrAboveMinimum() {
+        let minimum = InlineTaskDetailLayout.minimumContainerWidth
+        XCTAssertTrue(InlineTaskDetailLayout.showsPane(isRegularWidth: true, containerWidth: minimum))
+        XCTAssertTrue(InlineTaskDetailLayout.showsPane(isRegularWidth: true, containerWidth: 1366))
+    }
+
+    func testRegularWidthBelowMinimumFallsBackToSheet() {
+        let minimum = InlineTaskDetailLayout.minimumContainerWidth
+        XCTAssertFalse(InlineTaskDetailLayout.showsPane(isRegularWidth: true, containerWidth: minimum - 1))
+    }
+
+    func testTypicalIPadLayoutsShowPane() {
+        // 11-inch portrait, 11-inch landscape, 13-inch landscape, and a
+        // two-thirds Split View on a 13-inch (about 910pt).
+        for width: CGFloat in [834, 1194, 1366, 910] {
+            XCTAssertTrue(
+                InlineTaskDetailLayout.showsPane(isRegularWidth: true, containerWidth: width),
+                "expected a pane at \(width)pt"
+            )
+        }
+    }
+
+    // MARK: - paneWidth
+
+    func testPaneWidthIsClampedToMinimum() {
+        // 700 * 0.42 = 294, below the floor.
+        XCTAssertEqual(InlineTaskDetailLayout.paneWidth(for: 700), InlineTaskDetailLayout.minimumPaneWidth)
+    }
+
+    func testPaneWidthIsClampedToMaximum() {
+        // 1366 * 0.42 = 573, above the ceiling.
+        XCTAssertEqual(InlineTaskDetailLayout.paneWidth(for: 1366), InlineTaskDetailLayout.maximumPaneWidth)
+    }
+
+    func testPaneWidthScalesBetweenClamps() {
+        let width = InlineTaskDetailLayout.paneWidth(for: 1000)
+        XCTAssertEqual(width, 1000 * InlineTaskDetailLayout.paneFraction, accuracy: 0.001)
+    }
+
+    func testPaneLeavesTheListAtLeastAsWideAsAPhone() {
+        // At the narrowest container that gets a pane, the list must still
+        // have room for a phone-width row.
+        let container = InlineTaskDetailLayout.minimumContainerWidth
+        let list = container - InlineTaskDetailLayout.paneWidth(for: container)
+        XCTAssertGreaterThanOrEqual(list, 320)
+    }
+
+    // MARK: - InlineTaskSelection
+
+    func testSelectionStartsEmptyAndHoldsTask() {
+        let selection = InlineTaskSelection()
+        XCTAssertNil(selection.task)
+
+        let task = VTask(id: 7, title: "Test", done: false, priority: 0, projectId: 1)
+        selection.task = task
+        XCTAssertEqual(selection.task?.id, 7)
+
+        selection.task = nil
+        XCTAssertNil(selection.task)
+    }
+}


### PR DESCRIPTION
## Summary

Picks up the remaining layout item from #34. On an iPad with a regular-width window, tapping a task row or a Kanban card opens it in a pane beside the list instead of a sheet. iPhone is unchanged.

- `TaskDetailSheet` gains an `inline` presentation: same form, with a Cancel / Edit Task / Save header in place of the navigation bar. Escape cancels, Cmd-S saves.
- `TaskListScreen` hosts the pane. It decides from the size class plus the measured width (700pt floor), so a Split View or Stage Manager resize takes the pane away and taps fall back to the sheet.
- `InlineTaskSelection` is an `@Observable` put in the environment only while the pane is shown. `TaskRow` and `BoardTaskCard` set it if present, else present the sheet as before. The selected row is highlighted.
- The pane closes on Cancel, Save and Delete, and switches task when another row is tapped.
- Board cards get `.hoverEffect(.lift)` for trackpad pointers.
- Layout rules are in `InlineTaskDetailLayout` and covered by `InlineTaskDetailTests` (9 tests).

## Verified

- Built iOS and macOS. Full `mDoneTests` run: 685 tests, 0 failures.
- On the iPad Pro 11-inch simulator against the local dev Vikunja: Inbox, a project list, and the project board all open the pane; Cancel and Save close it; tapping another row or card switches it; the pane shares the list's grouped background under the floating top bar.
- On the iPhone 17 simulator a tap still opens the sheet.

## Status of #34 after this PR

Done across 1.14.0 and this PR: adaptive sidebar, hardware keyboard shortcuts, inline detail pane, Split View / Slide Over / Stage Manager (no `UIRequiresFullScreen`, all orientations), context menus, pointer hover on cards, universal app icon, iPad widget sizes (#66).

Deliberately not in this PR: multi-window (`UIApplicationSupportsMultipleScenes` stays off), and the Calendar tab's day list still uses the sheet since that screen is a grid plus list stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
