### PR TITLE
fix: keep API-token sessions alive when a route is not permitted (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - A wrong username or password now says so, instead of "Something went wrong with that request" (#179).
 - On iPad, tapping a task now opens it in a panel beside the list instead of a sheet, so you can work through tasks without covering the list. The panel appears whenever the window is wide enough, including in Split View and Stage Manager, and hands back to the sheet when it is not. Escape cancels and Cmd-S saves from a hardware keyboard, and Kanban cards lift under a trackpad pointer (#34).
 
+### Fixed
+- Signing in with an API token that was created without some permissions no longer throws you back to the login screen. Vikunja answers a missing permission with the same status it uses for a revoked token, and mDone used to take it as a revoked token, so a token without the notifications permission was logged out the moment the app opened. The app now checks whether the token still works before ending the session, keeps you signed in, and tells you which action the token cannot do so you can create one with more permissions (#178).
+
 ## [1.15.0] - 2026-09-03
 
 ### Added

--- a/mDone/Models/APIModels.swift
+++ b/mDone/Models/APIModels.swift
@@ -61,6 +61,10 @@ enum NetworkError: LocalizedError {
     case totpRequired
     /// `POST /login` rejected the two-factor passcode that was sent.
     case invalidTOTPPasscode
+    /// The API token is valid but was created without the permission this
+    /// request needs. Distinct from `.unauthorized` so callers do not end the
+    /// session over it (#178).
+    case missingPermission
     case serverError(statusCode: Int, message: String?)
     case decodingError(Error)
     case networkUnavailable
@@ -85,6 +89,8 @@ enum NetworkError: LocalizedError {
             String(
                 localized: "That two-factor code wasn't accepted. Codes change every 30 seconds, so check your authenticator app and try again."
             )
+        case .missingPermission:
+            String(localized: "Your API token doesn't have permission for this.")
         case let .serverError(code, _):
             if code >= 500 {
                 String(localized: "The server is having trouble. Please try again in a moment.")
@@ -118,6 +124,10 @@ enum NetworkError: LocalizedError {
             String(localized: "Open your authenticator app and enter the current six-digit code.")
         case .invalidTOTPPasscode:
             String(localized: "Make sure your device's clock is correct, then enter a fresh code.")
+        case .missingPermission:
+            String(
+                localized: "In Vikunja, create a new API token with every permission ticked, then sign in with it in Settings."
+            )
         case let .serverError(code, _):
             if code >= 500 {
                 String(localized: "The server may be temporarily unavailable. Wait a moment and try again.")
@@ -150,6 +160,8 @@ enum NetworkError: LocalizedError {
             "person.badge.key"
         case .totpRequired, .invalidTOTPPasscode:
             "lock.shield"
+        case .missingPermission:
+            "person.badge.key"
         case .serverError:
             "exclamationmark.icloud"
         case .decodingError:
@@ -182,7 +194,7 @@ enum NetworkError: LocalizedError {
     /// Whether this error is critical and requires user action (should not auto-dismiss).
     var isCritical: Bool {
         switch self {
-        case .unauthorized, .invalidURL:
+        case .unauthorized, .invalidURL, .missingPermission:
             true
         default:
             false

--- a/mDone/Services/APIClient.swift
+++ b/mDone/Services/APIClient.swift
@@ -48,6 +48,12 @@ actor APIClient {
     /// and one probe answers for all of them.
     private var inFlightTokenProbe: Task<Bool, Error>?
 
+    /// How many callers are currently parked on `inFlightTokenProbe` waiting
+    /// for someone else's probe to answer. Read by the single-flight test so it
+    /// can release a held probe only once the second 401 has actually joined
+    /// it, instead of sleeping and hoping.
+    private(set) var tokenProbeWaiterCount = 0
+
     /// The route used to tell a revoked API token from one that merely lacks a
     /// permission. Login proves a token by fetching projects, so no token that
     /// cannot read projects ever gets past the login screen. A 401 here means
@@ -379,6 +385,8 @@ actor APIClient {
     /// showing a connectivity error and letting the caller retry.
     private func probeAPITokenLiveness() async throws -> Bool {
         if let inFlightTokenProbe {
+            tokenProbeWaiterCount += 1
+            defer { tokenProbeWaiterCount -= 1 }
             return try await inFlightTokenProbe.value
         }
         let task = Task<Bool, Error> { [self] in

--- a/mDone/Services/APIClient.swift
+++ b/mDone/Services/APIClient.swift
@@ -43,6 +43,18 @@ actor APIClient {
     /// racing each other with the now-invalidated cookie.
     private var inFlightRefresh: Task<Void, Error>?
 
+    /// Single-flight for `probeAPITokenLiveness()`, same reasoning as
+    /// `inFlightRefresh`: several requests can 401 at once right after launch
+    /// and one probe answers for all of them.
+    private var inFlightTokenProbe: Task<Bool, Error>?
+
+    /// The route used to tell a revoked API token from one that merely lacks a
+    /// permission. Login proves a token by fetching projects, so no token that
+    /// cannot read projects ever gets past the login screen. A 401 here means
+    /// the token itself is dead; a 200 here after a 401 elsewhere means the
+    /// token is alive and the other route was simply not granted (#178).
+    private static let tokenLivenessEndpoint = Endpoint.projects(page: 1, perPage: 1)
+
     static let shared = APIClient()
 
     init(session: URLSession = .shared, baseRetryDelay: UInt64 = 1_000_000_000) {
@@ -292,8 +304,26 @@ actor APIClient {
             return (data, httpResponse)
         }
 
-        // 401 with no refresh capability — let the caller see it.
-        guard isJWTSession, refreshToken != nil else {
+        // API-token session. Vikunja answers 401 both for a revoked token and
+        // for a route the token was never granted, so the status alone cannot
+        // say whether the session is over. Ask a route every token has before
+        // logging the user out: a token created without, say, the
+        // notifications permission used to be kicked to the login screen by
+        // the first notification fetch after launch (#178).
+        guard isJWTSession else {
+            if request.url?.path == Self.tokenLivenessPath {
+                notifySessionExpired()
+                return (data, httpResponse)
+            }
+            if try await probeAPITokenLiveness() {
+                throw NetworkError.missingPermission
+            }
+            notifySessionExpired()
+            return (data, httpResponse)
+        }
+
+        // JWT with no refresh capability — let the caller see it.
+        guard refreshToken != nil else {
             notifySessionExpired()
             return (data, httpResponse)
         }
@@ -334,6 +364,35 @@ actor APIClient {
             notifySessionExpired()
         }
         return (retryData, retryResponse)
+    }
+
+    /// Path of `tokenLivenessEndpoint`, for recognising the probe route when it
+    /// is the request that 401'd in the first place.
+    private static let tokenLivenessPath = tokenLivenessEndpoint.path
+
+    /// Whether the current API token is still accepted by the server.
+    ///
+    /// Returns `true` when the liveness route answers 2xx and `false` when it
+    /// answers 401. Any other outcome (transport failure, 5xx, rate limit)
+    /// throws the matching `NetworkError` rather than guessing, because a
+    /// wrong "dead" verdict clears the Keychain, which is far worse than
+    /// showing a connectivity error and letting the caller retry.
+    private func probeAPITokenLiveness() async throws -> Bool {
+        if let inFlightTokenProbe {
+            return try await inFlightTokenProbe.value
+        }
+        let task = Task<Bool, Error> { [self] in
+            defer { self.inFlightTokenProbe = nil }
+            let request = try buildRequest(for: Self.tokenLivenessEndpoint)
+            let (data, response) = try await performRequest(request)
+            if response.statusCode == 401 {
+                return false
+            }
+            _ = try handleResponse(data: data, httpResponse: response)
+            return true
+        }
+        inFlightTokenProbe = task
+        return try await task.value
     }
 
     /// Single-flight wrapper around `performRefresh()`. Concurrent callers

--- a/mDoneTests/APIClientRefreshTests.swift
+++ b/mDoneTests/APIClientRefreshTests.swift
@@ -226,6 +226,194 @@ final class APIClientRefreshTests: XCTestCase {
         XCTAssertEqual(expiredFlag.value, true)
     }
 
+    // MARK: - API token scope vs revoked token (#178)
+
+    func testAPIToken401WithLiveProbeThrowsMissingPermissionWithoutExpiring() async {
+        let client = makeClient()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "tk_apikey_abcdef123456")
+
+        let expiredFlag = AsyncBox<Bool>()
+        await client.setOnSessionExpired { expiredFlag.set(true) }
+
+        let counter = RequestCounter()
+        MockURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            counter.record(
+                path: path,
+                authorization: request.value(forHTTPHeaderField: "Authorization") ?? "",
+                cookie: nil
+            )
+            if path.hasSuffix("/projects") {
+                return (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data("[]".utf8))
+            }
+            // The token was created without the notifications permission.
+            return (MockURLProtocol.makeResponse(statusCode: 401, url: request.url), Data())
+        }
+
+        do {
+            let _: [VNotification] = try await client.fetch(Endpoint.notifications())
+            XCTFail("Expected missingPermission")
+        } catch let error as NetworkError {
+            guard case .missingPermission = error else {
+                return XCTFail("Expected .missingPermission, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        XCTAssertNil(expiredFlag.value, "A token that still reads projects is alive; the session must survive")
+        let probes = counter.entries(forPath: "/api/v1/projects")
+        XCTAssertEqual(probes.count, 1, "Exactly one liveness probe")
+        XCTAssertEqual(
+            probes.first?.authorization,
+            "Bearer tk_apikey_abcdef123456",
+            "The probe must use the same token that was refused"
+        )
+        XCTAssertEqual(counter.totalCount, 2, "Original request plus one probe, nothing else")
+    }
+
+    func testAPIToken401WithDeadProbeSurfacesUnauthorizedAndExpires() async {
+        let client = makeClient()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "tk_apikey_abcdef123456")
+
+        let expiredFlag = AsyncBox<Bool>()
+        await client.setOnSessionExpired { expiredFlag.set(true) }
+
+        let counter = RequestCounter()
+        MockURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            counter.record(path: path, authorization: "", cookie: nil)
+            // Revoked token: every route 401s, including the probe.
+            return (MockURLProtocol.makeResponse(statusCode: 401, url: request.url), Data())
+        }
+
+        do {
+            let _: [VNotification] = try await client.fetch(Endpoint.notifications())
+            XCTFail("Expected unauthorized")
+        } catch let error as NetworkError {
+            guard case .unauthorized = error else {
+                return XCTFail("Expected .unauthorized, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        XCTAssertEqual(expiredFlag.value, true, "A token the probe route also refuses is dead")
+        XCTAssertEqual(counter.count(forPath: "/api/v1/projects"), 1)
+    }
+
+    func testAPIToken401OnTheProbeRouteItselfExpiresWithoutProbing() async {
+        let client = makeClient()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "tk_apikey_abcdef123456")
+
+        let expiredFlag = AsyncBox<Bool>()
+        await client.setOnSessionExpired { expiredFlag.set(true) }
+
+        let counter = RequestCounter()
+        MockURLProtocol.requestHandler = { request in
+            counter.record(path: request.url?.path ?? "", authorization: "", cookie: nil)
+            return (MockURLProtocol.makeResponse(statusCode: 401, url: request.url), Data())
+        }
+
+        do {
+            let _: [Project] = try await client.fetch(Endpoint.projects(page: 1, perPage: 50))
+            XCTFail("Expected unauthorized")
+        } catch let error as NetworkError {
+            guard case .unauthorized = error else {
+                return XCTFail("Expected .unauthorized, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        XCTAssertEqual(expiredFlag.value, true)
+        XCTAssertEqual(counter.totalCount, 1, "Probing the route that just 401'd would only repeat the answer")
+    }
+
+    func testAPIToken401WithProbeTransportFailureDoesNotExpire() async {
+        let client = makeClient()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "tk_apikey_abcdef123456")
+
+        let expiredFlag = AsyncBox<Bool>()
+        await client.setOnSessionExpired { expiredFlag.set(true) }
+
+        MockURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/projects") {
+                throw URLError(.notConnectedToInternet)
+            }
+            return (MockURLProtocol.makeResponse(statusCode: 401, url: request.url), Data())
+        }
+
+        do {
+            let _: [VNotification] = try await client.fetch(Endpoint.notifications())
+            XCTFail("Expected a connectivity error")
+        } catch let error as NetworkError {
+            XCTAssertTrue(error.isConnectivityFailure, "Expected a connectivity error, got \(error)")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        XCTAssertNil(expiredFlag.value, "Not knowing whether the token is alive must never clear the Keychain")
+    }
+
+    func testConcurrentAPIToken401sShareOneProbe() async {
+        let client = makeClient()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "tk_apikey_abcdef123456")
+
+        let expiredFlag = AsyncBox<Bool>()
+        await client.setOnSessionExpired { expiredFlag.set(true) }
+
+        let counter = RequestCounter()
+        let probeGate = HeldRequests()
+        MockURLProtocol.asynchronousRequestHandler = { request, proto in
+            let path = request.url?.path ?? ""
+            counter.record(path: path, authorization: "", cookie: nil)
+            if path.hasSuffix("/projects") {
+                // Hold the probe open until both 401s have queued behind it.
+                probeGate.hold(proto, url: request.url)
+                return
+            }
+            proto.complete(response: MockURLProtocol.makeResponse(statusCode: 401, url: request.url), data: Data())
+        }
+
+        let outcomes = OutcomeBox()
+        let firstDone = Task {
+            do {
+                let _: [VNotification] = try await client.fetch(Endpoint.notifications())
+                outcomes.append(nil)
+            } catch {
+                outcomes.append(error)
+            }
+        }
+        let secondDone = Task {
+            do {
+                let _: [VNotification] = try await client.fetch(Endpoint.notifications())
+                outcomes.append(nil)
+            } catch {
+                outcomes.append(error)
+            }
+        }
+
+        await probeGate.waitUntilHeld(count: 1)
+        // Give the second 401 time to reach the single-flight join before the
+        // probe answers, otherwise it could legitimately start its own.
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        probeGate.releaseAll(statusCode: 200, data: Data("[]".utf8))
+        await firstDone.value
+        await secondDone.value
+
+        XCTAssertEqual(outcomes.errors.count, 2)
+        for error in outcomes.errors {
+            guard case NetworkError.missingPermission? = error as? NetworkError else {
+                return XCTFail("Expected .missingPermission, got \(String(describing: error))")
+            }
+        }
+
+        XCTAssertNil(expiredFlag.value)
+        XCTAssertEqual(counter.count(forPath: "/api/v1/projects"), 1, "Both 401s must share one probe")
+    }
+
     // MARK: - Callback contract
 
     func testRefreshFiresOnTokensUpdatedCallback() async throws {
@@ -509,5 +697,56 @@ private final class RequestCounter: @unchecked Sendable {
     func entries(forPath path: String) -> [Entry] {
         lock.lock(); defer { lock.unlock() }
         return perPath[path] ?? []
+    }
+}
+
+/// Collects the errors (or nil for success) of concurrently finishing tasks.
+private final class OutcomeBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [Error?] = []
+
+    var errors: [Error?] {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+
+    func append(_ error: Error?) {
+        lock.lock()
+        defer { lock.unlock() }
+        stored.append(error)
+    }
+}
+
+/// Parks in-flight mock requests so a test can release them together.
+private final class HeldRequests: @unchecked Sendable {
+    private let lock = NSLock()
+    private var held: [(MockURLProtocol, URL?)] = []
+
+    func hold(_ proto: MockURLProtocol, url: URL?) {
+        lock.lock()
+        defer { lock.unlock() }
+        held.append((proto, url))
+    }
+
+    func waitUntilHeld(count: Int) async {
+        for _ in 0 ..< 200 {
+            let current = lock.withLock { held.count }
+            if current >= count {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    func releaseAll(statusCode: Int, data: Data) {
+        let toRelease = lock.withLock { () -> [(MockURLProtocol, URL?)] in
+            let copy = held
+            held = []
+            return copy
+        }
+        for (proto, url) in toRelease {
+            proto.complete(response: MockURLProtocol.makeResponse(statusCode: statusCode, url: url), data: data)
+        }
     }
 }

--- a/mDoneTests/APIClientRefreshTests.swift
+++ b/mDoneTests/APIClientRefreshTests.swift
@@ -395,10 +395,14 @@ final class APIClientRefreshTests: XCTestCase {
             }
         }
 
-        await probeGate.waitUntilHeld(count: 1)
-        // Give the second 401 time to reach the single-flight join before the
-        // probe answers, otherwise it could legitimately start its own.
-        try? await Task.sleep(nanoseconds: 200_000_000)
+        let probeHeld = await probeGate.waitUntilHeld(count: 1)
+        XCTAssertTrue(probeHeld, "The first 401 should have started a probe that the mock is holding")
+        // Release the probe only once the second 401 has actually joined it.
+        // Released any earlier, the second caller could legitimately start a
+        // probe of its own and the shared-probe assertion below would be
+        // testing a race rather than the client.
+        let secondJoined = await waitUntil { await client.tokenProbeWaiterCount == 1 }
+        XCTAssertTrue(secondJoined, "The second 401 should be parked on the first caller's probe")
         probeGate.releaseAll(statusCode: 200, data: Data("[]".utf8))
         await firstDone.value
         await secondDone.value
@@ -729,14 +733,12 @@ private final class HeldRequests: @unchecked Sendable {
         held.append((proto, url))
     }
 
-    func waitUntilHeld(count: Int) async {
-        for _ in 0 ..< 200 {
-            let current = lock.withLock { held.count }
-            if current >= count {
-                return
-            }
-            try? await Task.sleep(nanoseconds: 10_000_000)
-        }
+    /// Polls until at least `count` requests are parked. Returns `false` if
+    /// that never happens within the bound, so a test can fail on the
+    /// precondition instead of carrying on into an assertion that then fails
+    /// for a confusing reason.
+    func waitUntilHeld(count: Int) async -> Bool {
+        await waitUntil { [self] in lock.withLock { held.count } >= count }
     }
 
     func releaseAll(statusCode: Int, data: Data) {
@@ -749,4 +751,17 @@ private final class HeldRequests: @unchecked Sendable {
             proto.complete(response: MockURLProtocol.makeResponse(statusCode: statusCode, url: url), data: data)
         }
     }
+}
+
+/// Polls `condition` every 10ms for up to two seconds. Returns whether it
+/// became true, so tests can assert the state they were waiting for rather
+/// than sleeping for a fixed time and hoping the other side got there.
+private func waitUntil(_ condition: () async -> Bool) async -> Bool {
+    for _ in 0 ..< 200 {
+        if await condition() {
+            return true
+        }
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    return false
 }

--- a/mDoneTests/OfflineEditQueueTests.swift
+++ b/mDoneTests/OfflineEditQueueTests.swift
@@ -289,9 +289,15 @@ final class OfflineEditQueueTests: XCTestCase {
         await state.toggleTaskDone(state.tasks[1])
         XCTAssertEqual(sync.pendingOperationCount(), 2)
 
-        var requestCount = 0
+        var replayCount = 0
         MockURLProtocol.requestHandler = { request in
-            requestCount += 1
+            // "test-token" is not a JWT, so on a 401 APIClient asks the projects
+            // route once to tell a revoked token from a missing permission
+            // (#178). That probe is not an operation replay.
+            let isLivenessProbe = request.url?.path.hasSuffix("/projects") ?? false
+            if !isLivenessProbe {
+                replayCount += 1
+            }
             return (MockURLProtocol.makeResponse(statusCode: 401, url: request.url), Data())
         }
 
@@ -299,7 +305,7 @@ final class OfflineEditQueueTests: XCTestCase {
 
         XCTAssertEqual(sync.pendingOperationCount(), 2, "nothing may be dropped for an expired session")
         XCTAssertTrue(sync.failedOperations().isEmpty)
-        XCTAssertEqual(requestCount, 1, "should stop after the first 401, not retry every operation")
+        XCTAssertEqual(replayCount, 1, "should stop after the first 401, not retry every operation")
     }
 
     // MARK: - Things that genuinely can't be done offline


### PR DESCRIPTION
Closes #178.

## Problem

Vikunja answers 401 both for a revoked API token and for a route the token was never granted. `APIClient.executeWithRefresh` treated every 401 on a non-JWT session as a revoked token and fired `onSessionExpired`, which clears the Keychain. A token created without the notifications permission was logged out by the notification fetch that `MainTabView` and `MacContentView` run on appear, right after a login that had just succeeded (login only validates with the projects route).

## Fix

On a 401 in an API-token session the client now probes `GET /projects`, the one route every usable token has because login validates with it:

- Probe 2xx: the token is alive and the original route was simply not permitted. The request throws the new `NetworkError.missingPermission` and the session stays up. The error is `isCritical`, so the banner stays until dismissed, and its copy tells the user to create a token with every permission ticked.
- Probe 401: the token is dead. Session ends exactly as before.
- Anything else (transport failure, 5xx, 429): that error surfaces instead of a guess. A wrong "dead" verdict costs the user their login, a wrong "alive" verdict costs one retry.

Concurrent 401s share one in-flight probe, mirroring the refresh single-flight. A 401 on the probe route itself skips the probe. JWT sessions are untouched.

`SyncService` and `AppState` only end the session on `.unauthorized`, so a `.missingPermission` from a replayed offline edit or from `refreshAll` no longer logs the user out either.

## Tests

Five new cases in `APIClientRefreshTests` cover: live probe keeps the session and throws `missingPermission`; dead probe expires as before; 401 on the probe route expires without a second request; probe transport failure surfaces a connectivity error and does not expire; two concurrent 401s share one probe. `OfflineEditQueueTests.testExpiredSessionPausesTheQueueWithoutLosingAnything` now counts only operation replays, since its opaque test token triggers the probe.

Verified locally: `mDoneTests` full suite on iPhone 17 simulator, and `APIClientRefreshTests` on macOS.

## Not in this PR

The stale "API tokens have limited permissions" copy on the login screen and TOTP support are tracked in #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)