### PR TITLE
release: 1.16.0 build 67

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -23,8 +23,8 @@ settings:
     # not feature-related — see PR "decisions".
     PRODUCT_NAME: "$(TARGET_NAME)"
     SWIFT_VERSION: "5.9"
-    MARKETING_VERSION: "1.15.0"
-    CURRENT_PROJECT_VERSION: "63"
+    MARKETING_VERSION: "1.16.0"
+    CURRENT_PROJECT_VERSION: "67"
     DEVELOPMENT_TEAM: "Z62E7MGREE"
     CODE_SIGN_IDENTITY: "Apple Development"
     CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
Bumps \`project.yml\` to 1.16.0 / build 67 so the file matches the build that is on TestFlight.

Build 67 was cut from main at 1a91292 (PRs #177, #180, #181 merged today) and uploaded to TestFlight for both iOS and macOS on 2026-09-08. It contains build 66's iPad detail pane (#34) plus two-factor sign-in (#179) and the API-token missing-permission fix (#178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)