### PR TITLE
fix: stop assuming the main actor in the OIDC callback handler on macOS (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - On iPad, tapping a task now opens it in a panel beside the list instead of a sheet, so you can work through tasks without covering the list. The panel appears whenever the window is wide enough, including in Split View and Stage Manager, and hands back to the sheet when it is not. Escape cancels and Cmd-S saves from a hardware keyboard, and Kanban cards lift under a trackpad pointer (#34).
 
 ### Fixed
+- Signing in with single sign-on on a Mac no longer crashes the app the moment your identity provider hands back to it. macOS delivers the sign-in result on a background thread, and mDone insisted it was on the main one, which brought the app down on macOS 26 before the account could be added. The result is now passed to the main thread first (#182).
 - Signing in with an API token that was created without some permissions no longer throws you back to the login screen. Vikunja answers a missing permission with the same status it uses for a revoked token, and mDone used to take it as a revoked token, so a token without the notifications permission was logged out the moment the app opened. The app now checks whether the token still works before ending the session, keeps you signed in, and tells you which action the token cannot do so you can create one with more permissions (#178).
 
 ## [1.15.0] - 2026-09-03

--- a/docs/oidc-callback-decision.md
+++ b/docs/oidc-callback-decision.md
@@ -97,11 +97,16 @@ One thing that did check out: `mDoneApp`'s `onOpenURL` is `#if os(iOS)`, so a
 `mdone://` URL arriving on macOS through LaunchServices is inert. A callback
 that escapes the session cannot be consumed by accident.
 
-### Still to verify on macOS
+### The return leg on macOS, confirmed by issue #182
 
-Completing a sign-in in an external default browser and confirming the code
-reaches the app. Everything up to the provider's login page is confirmed; the
-return leg is not.
+A user completing a Keycloak sign-in on macOS 26 showed that the code does
+reach the app, and showed how: the completion handler runs on the browser
+agent's XPC reply queue (`com.apple.NSXPCConnection.m-user.com.apple.SafariLaunchAgent`),
+not the main thread. AuthenticationServices never promised a thread for it,
+and `WebAuthenticator` used to assume the main actor there, which trapped on
+every macOS sign-in. The handler now hops to the main actor instead of
+assuming it, and `WebAuthenticatorTests` delivers the callback from a
+background queue to keep it that way.
 
 ## Option B: https callback via Associated Domains (not viable)
 

--- a/mDone/Services/WebAuthenticator.swift
+++ b/mDone/Services/WebAuthenticator.swift
@@ -40,6 +40,20 @@ protocol WebAuthenticating: AnyObject {
     func authenticate(url: URL, callbackScheme: String, prefersEphemeralSession: Bool) async throws -> URL
 }
 
+/// The slice of `ASWebAuthenticationSession` that `WebAuthenticator` drives.
+///
+/// A real session opens the browser on `start()`, so a unit test substitutes a
+/// stand-in that opens nothing and invokes the completion handler from
+/// whatever thread the test chooses.
+protocol WebAuthenticationSession: AnyObject {
+    var prefersEphemeralWebBrowserSession: Bool { get set }
+    var presentationContextProvider: (any ASWebAuthenticationPresentationContextProviding)? { get set }
+    func start() -> Bool
+    func cancel()
+}
+
+extension ASWebAuthenticationSession: WebAuthenticationSession {}
+
 /// Runs the OIDC authorization request in the system's own browser.
 ///
 /// Chosen over an embedded `WKWebView` because it shows a real URL bar, which is
@@ -48,8 +62,23 @@ protocol WebAuthenticating: AnyObject {
 /// `docs/oidc-callback-decision.md`.
 @MainActor
 final class WebAuthenticator: NSObject, WebAuthenticating {
-    private var session: ASWebAuthenticationSession?
+    typealias SessionFactory = (
+        _ url: URL,
+        _ callbackScheme: String,
+        _ completion: @escaping ASWebAuthenticationSession.CompletionHandler
+    ) -> any WebAuthenticationSession
+
+    private let makeSession: SessionFactory
+    private var session: (any WebAuthenticationSession)?
     private var continuation: CheckedContinuation<URL, Error>?
+
+    /// `makeSession` exists for tests. The default builds the real thing.
+    init(makeSession: @escaping SessionFactory = { url, scheme, completion in
+        ASWebAuthenticationSession(url: url, callback: .customScheme(scheme), completionHandler: completion)
+    }) {
+        self.makeSession = makeSession
+        super.init()
+    }
 
     func authenticate(
         url: URL,
@@ -60,20 +89,15 @@ final class WebAuthenticator: NSObject, WebAuthenticating {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<URL, Error>) in
                 self.continuation = continuation
 
-                let session = ASWebAuthenticationSession(
-                    url: url,
-                    callback: .customScheme(callbackScheme)
-                ) { [weak self] callbackURL, error in
-                    guard let self else { return }
-                    MainActor.assumeIsolated {
-                        self.session = nil
-                        if let error {
-                            self.finish(.failure(Self.mapped(error)))
-                        } else if let callbackURL {
-                            self.finish(.success(callbackURL))
-                        } else {
-                            self.finish(.failure(WebAuthenticationError.failed("No callback URL")))
-                        }
+                // AuthenticationServices promises no thread for this handler.
+                // On macOS it arrives on the browser agent's XPC reply queue,
+                // so it must not assume the main actor: doing so trapped on
+                // every SSO sign-in there (#182). @Sendable keeps the closure
+                // out of this class's main-actor isolation, so the runtime
+                // does not assert on entry either; the hop happens inside.
+                let session = makeSession(url, callbackScheme) { @Sendable [weak self] callbackURL, error in
+                    Task { @MainActor in
+                        self?.sessionDidComplete(callbackURL: callbackURL, error: error)
                     }
                 }
 
@@ -103,6 +127,17 @@ final class WebAuthenticator: NSObject, WebAuthenticating {
         session?.cancel()
         session = nil
         finish(.failure(WebAuthenticationError.cancelled))
+    }
+
+    private func sessionDidComplete(callbackURL: URL?, error: (any Error)?) {
+        session = nil
+        if let error {
+            finish(.failure(Self.mapped(error)))
+        } else if let callbackURL {
+            finish(.success(callbackURL))
+        } else {
+            finish(.failure(WebAuthenticationError.failed("No callback URL")))
+        }
     }
 
     /// Resume-once. `cancel()` may or may not also run the completion handler,

--- a/mDoneTests/WebAuthenticatorTests.swift
+++ b/mDoneTests/WebAuthenticatorTests.swift
@@ -16,6 +16,8 @@ final class WebAuthenticatorTests: XCTestCase {
         var startReturns = true
         var onStart: () -> Void = {}
         var onCancel: () -> Void = {}
+        /// Runs on the background queue once the completion handler has returned.
+        var onCompletionDelivered: () -> Void = {}
         private(set) var startCount = 0
         private(set) var cancelCount = 0
 
@@ -33,9 +35,10 @@ final class WebAuthenticatorTests: XCTestCase {
         /// Reports the result the way AuthenticationServices does on macOS:
         /// on a thread that is not the main one.
         func completeOffMainThread(url: URL?, error: (any Error)?) {
-            DispatchQueue.global().async { [completion] in
+            DispatchQueue.global().async { [completion, onCompletionDelivered] in
                 XCTAssertFalse(Thread.isMainThread, "the test must exercise the off-main-thread path")
                 completion?(url, error)
+                onCompletionDelivered()
             }
         }
     }
@@ -109,14 +112,16 @@ final class WebAuthenticatorTests: XCTestCase {
 
     // MARK: - Cancellation
 
-    func testCancelResumesOnceEvenWhenTheSessionAlsoReportsIt() async throws {
+    func testCancelResumesOnceEvenWhenTheSessionAlsoReportsIt() async {
         let started = expectation(description: "session started")
         session.onStart = { started.fulfill() }
         // The real session may echo cancel() back through its completion
         // handler. That second report must be swallowed, not resumed again.
+        let echoed = expectation(description: "echoed cancellation delivered")
         session.onCancel = { [session] in
             session.completeOffMainThread(url: nil, error: ASWebAuthenticationSessionError(.canceledLogin))
         }
+        session.onCompletionDelivered = { echoed.fulfill() }
 
         let task = Task { [authenticator, authorizationURL] in
             try await authenticator!.authenticate(url: authorizationURL!, callbackScheme: "mdone")
@@ -130,8 +135,12 @@ final class WebAuthenticatorTests: XCTestCase {
             return XCTFail("expected cancellation, got \(result)")
         }
         XCTAssertEqual(error as? WebAuthenticationError, .cancelled)
-        // Let the echoed report land. Resuming twice would trap here.
-        try await Task.sleep(for: .milliseconds(100))
+        // Wait for the echo to be handed over, then let the main actor run
+        // once more: the echo's hop was queued before this one, so by the
+        // time this task runs the echo has landed. Resuming twice would
+        // have trapped.
+        await fulfillment(of: [echoed], timeout: 1)
+        await Task { @MainActor in }.value
     }
 
     func testTaskCancellationCancelsTheSession() async {

--- a/mDoneTests/WebAuthenticatorTests.swift
+++ b/mDoneTests/WebAuthenticatorTests.swift
@@ -1,0 +1,167 @@
+import AuthenticationServices
+import XCTest
+@testable import mDone
+
+/// `ASWebAuthenticationSession` opens a browser on `start()`, so these tests
+/// swap in a session that opens nothing and reports its result from a
+/// background queue. That is what the real one does on macOS, where the
+/// callback arrives on the browser agent's XPC reply queue rather than the
+/// main thread, and it is what crashed every SSO sign-in there (#182).
+@MainActor
+final class WebAuthenticatorTests: XCTestCase {
+    private final class StubSession: WebAuthenticationSession {
+        var prefersEphemeralWebBrowserSession = false
+        weak var presentationContextProvider: (any ASWebAuthenticationPresentationContextProviding)?
+        var completion: ASWebAuthenticationSession.CompletionHandler?
+        var startReturns = true
+        var onStart: () -> Void = {}
+        var onCancel: () -> Void = {}
+        private(set) var startCount = 0
+        private(set) var cancelCount = 0
+
+        func start() -> Bool {
+            startCount += 1
+            onStart()
+            return startReturns
+        }
+
+        func cancel() {
+            cancelCount += 1
+            onCancel()
+        }
+
+        /// Reports the result the way AuthenticationServices does on macOS:
+        /// on a thread that is not the main one.
+        func completeOffMainThread(url: URL?, error: (any Error)?) {
+            DispatchQueue.global().async { [completion] in
+                XCTAssertFalse(Thread.isMainThread, "the test must exercise the off-main-thread path")
+                completion?(url, error)
+            }
+        }
+    }
+
+    private var session = StubSession()
+    private var authenticator: WebAuthenticator!
+    private var authorizationURL: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        let session = StubSession()
+        self.session = session
+        authenticator = WebAuthenticator { _, _, completion in
+            session.completion = completion
+            return session
+        }
+        authorizationURL = try XCTUnwrap(URL(string: "https://auth.example.com/authorize?state=s"))
+    }
+
+    // MARK: - The callback reaching the app
+
+    func testCallbackDeliveredOffTheMainThreadResumesWithTheURL() async throws {
+        let expected = try XCTUnwrap(URL(string: "mdone://oidc-callback?code=abc&state=s"))
+        session.onStart = { [session] in session.completeOffMainThread(url: expected, error: nil) }
+
+        let url = try await authenticator.authenticate(url: authorizationURL, callbackScheme: "mdone")
+
+        XCTAssertEqual(url, expected)
+        XCTAssertEqual(session.startCount, 1)
+    }
+
+    func testCancelledLoginDeliveredOffTheMainThreadThrowsCancelled() async {
+        session.onStart = { [session] in
+            session.completeOffMainThread(url: nil, error: ASWebAuthenticationSessionError(.canceledLogin))
+        }
+
+        await assertAuthenticateThrows(.cancelled)
+    }
+
+    func testMissingCallbackURLDeliveredOffTheMainThreadThrowsFailed() async {
+        session.onStart = { [session] in session.completeOffMainThread(url: nil, error: nil) }
+
+        await assertAuthenticateThrows(.failed("No callback URL"))
+    }
+
+    // MARK: - Session setup
+
+    func testConfiguresTheSessionBeforeStarting() async throws {
+        var providerAtStart: (any ASWebAuthenticationPresentationContextProviding)?
+        var ephemeralAtStart: Bool?
+        session.onStart = { [session] in
+            providerAtStart = session.presentationContextProvider
+            ephemeralAtStart = session.prefersEphemeralWebBrowserSession
+            session.completeOffMainThread(url: URL(string: "mdone://oidc-callback"), error: nil)
+        }
+
+        _ = try await authenticator.authenticate(
+            url: authorizationURL, callbackScheme: "mdone", prefersEphemeralSession: true
+        )
+
+        XCTAssertTrue(providerAtStart === authenticator)
+        XCTAssertEqual(ephemeralAtStart, true)
+    }
+
+    func testStartRefusingThrowsCannotStartWithoutWaitingForACallback() async {
+        session.startReturns = false
+
+        await assertAuthenticateThrows(.cannotStart)
+        XCTAssertEqual(session.startCount, 1)
+    }
+
+    // MARK: - Cancellation
+
+    func testCancelResumesOnceEvenWhenTheSessionAlsoReportsIt() async throws {
+        let started = expectation(description: "session started")
+        session.onStart = { started.fulfill() }
+        // The real session may echo cancel() back through its completion
+        // handler. That second report must be swallowed, not resumed again.
+        session.onCancel = { [session] in
+            session.completeOffMainThread(url: nil, error: ASWebAuthenticationSessionError(.canceledLogin))
+        }
+
+        let task = Task { [authenticator, authorizationURL] in
+            try await authenticator!.authenticate(url: authorizationURL!, callbackScheme: "mdone")
+        }
+        await fulfillment(of: [started], timeout: 1)
+        authenticator.cancel()
+
+        let result = await task.result
+        XCTAssertEqual(session.cancelCount, 1)
+        guard case let .failure(error) = result else {
+            return XCTFail("expected cancellation, got \(result)")
+        }
+        XCTAssertEqual(error as? WebAuthenticationError, .cancelled)
+        // Let the echoed report land. Resuming twice would trap here.
+        try await Task.sleep(for: .milliseconds(100))
+    }
+
+    func testTaskCancellationCancelsTheSession() async {
+        let started = expectation(description: "session started")
+        session.onStart = { started.fulfill() }
+
+        let task = Task { [authenticator, authorizationURL] in
+            try await authenticator!.authenticate(url: authorizationURL!, callbackScheme: "mdone")
+        }
+        await fulfillment(of: [started], timeout: 1)
+        task.cancel()
+
+        let result = await task.result
+        guard case let .failure(error) = result else {
+            return XCTFail("expected cancellation, got \(result)")
+        }
+        XCTAssertEqual(error as? WebAuthenticationError, .cancelled)
+        XCTAssertEqual(session.cancelCount, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func assertAuthenticateThrows(
+        _ expected: WebAuthenticationError, file: StaticString = #filePath, line: UInt = #line
+    ) async {
+        do {
+            let url = try await authenticator.authenticate(url: authorizationURL, callbackScheme: "mdone")
+            XCTFail("expected \(expected), got \(url)", file: file, line: line)
+        } catch {
+            XCTAssertEqual(error as? WebAuthenticationError, expected, file: file, line: line)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Signing in with single sign-on on macOS crashed the app the moment the identity provider redirected back to `mdone://oidc-callback`. AuthenticationServices delivers the `ASWebAuthenticationSession` completion handler on the browser agent's XPC reply queue on macOS, not the main thread. The handler in `WebAuthenticator` wrapped its body in `MainActor.assumeIsolated`, and because it sat inside a main-actor class it was also implicitly main-actor isolated, so both the runtime's entry check and the explicit assertion trapped. That matches the two crash signatures in the issue, with and without the legacy executor override.

The handler is now a `@Sendable` closure (so nothing asserts on entry) that hops onto the main actor with a `Task` before touching state. A small session factory seam on `WebAuthenticator` lets a test substitute a session that opens no browser and reports its result from a background queue. `WebAuthenticatorTests` covers the off-main-thread callback, error mapping, session configuration, `start()` refusing, and resume-once on cancel.

Also: a Fixed entry in the changelog, and the "still to verify on macOS" section of `docs/oidc-callback-decision.md` now records what this issue showed about the return leg.

## Related Issues

Fixes #182

## Testing

- Ran the new `WebAuthenticatorTests` on macOS against the old handler first: the test host crashed five times, and the crash report's stack matched the issue frame for frame (`dispatch_assert_queue` → `_swift_task_checkIsolatedSwift` → `MainActor.assumeIsolated` → the closure in `WebAuthenticator.authenticate`).
- With the fix, the full unit suites pass: `mDoneMacTests` (671 tests) on macOS and `mDoneTests` (713 tests) on iPhone 17.
- `WebAuthenticator.swift` is at 87% line coverage per `xccov`; the uncovered lines are the real session factory and the window lookup, which need UI.
- Not verified here: a real Keycloak sign-in on macOS 26. The unit test reproduces the exact trap from the report, but an end-to-end confirmation from the reporter would be welcome.

## Checklist

- [x] Builds on iOS and macOS
- [x] Tests pass
- [x] Ran `swiftlint lint --quiet` and `swiftformat .`
- [x] No breaking changes (or described in summary above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
