### PR TITLE
feat: manual sort with drag reorder in lists and on the Kanban board (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Sort a project by "Manual" to put its tasks in whatever order you like. Drag the handle on a row to move it, on iPhone, iPad and Mac. The order is the same one Vikunja's web app shows, so a list you arrange in one place looks the same in the other, and it does not touch due dates: a task due tomorrow can sit below one due next month if that is how you want it. The sort you pick is remembered per project, and the Inbox keeps its date sections (#183).
+- Drag cards up and down a Kanban column, or into another column, to reorder them. Drop a card on the top half of another card to put it above, on the bottom half to put it below, or on empty space in a column to add it at the end. "Move to" in a card's menu still reaches columns that are off screen. Boards whose columns are filled by filters cannot be rearranged, as in the web app (#183).
+
 - You can now sign in with a username and password on an account that has two-factor authentication turned on. If your server supports two-factor, the login screen shows a "Two-factor code" field beside the password; leave it empty if your account does not use one. If a sign-in is refused because a code is needed, the field appears and tells you so, and a wrong or expired code says that rather than a generic error. Previously such accounts could only use an API token or single sign-on (#179).
 
 ### Changed
+- The sort menu remembers your choice for each project and for the Inbox, instead of going back to "Due Date" every time you open the list (#183).
 - The login screen's note about API tokens no longer claims they cannot reorder tasks. A token created with every permission can do everything mDone does. The note now explains the real difference: a token can be revoked on its own without changing your password, and needs every permission when you create it (#179).
 - A wrong username or password now says so, instead of "Something went wrong with that request" (#179).
 - On iPad, tapping a task now opens it in a panel beside the list instead of a sheet, so you can work through tasks without covering the list. The panel appears whenever the window is wide enough, including in Split View and Stage Manager, and hands back to the sheet when it is not. Escape cancels and Cmd-S saves from a hardware keyboard, and Kanban cards lift under a trackpad pointer (#34).
 
 ### Fixed
+- Dragging a task to a new place in a project list no longer snaps back. The move was saved on the server but the list kept sorting by due date, so it never showed. Drag handles now appear only when the list is sorted by "Manual", where the order you make is the order you see. The Inbox's date sections, which span every project, no longer offer a drag that could not be shown (#183).
 - Signing in with an API token that was created without some permissions no longer throws you back to the login screen. Vikunja answers a missing permission with the same status it uses for a revoked token, and mDone used to take it as a revoked token, so a token without the notifications permission was logged out the moment the app opened. The app now checks whether the token still works before ending the session, keeps you signed in, and tells you which action the token cannot do so you can create one with more permissions (#178).
 
 ## [1.15.0] - 2026-09-03

--- a/docs/vikunja-api-inventory.md
+++ b/docs/vikunja-api-inventory.md
@@ -167,6 +167,8 @@ Relations are bidirectional: creating subtask(A->B) also creates parenttask(B->A
 
 Positions are per-view. When sorting by position, you must be within a view context.
 
+The same endpoint orders cards inside a kanban bucket: send the kanban view's id. A task with no position row reads back as `0` and sorts last. The server does not reject any value, but from v1.0 it repairs collisions and anything under `0.01` by redistributing the whole view, and it can also settle on a different number than the one sent (observed on v2.4.0 for a drop at the top of a list view). Read the view back after a write rather than trusting the number that went out. `TaskPositioning` in the app produces the same numbers as the web app's `calculateItemPosition`: midpoint between neighbours, half the first position at the top, last position plus 2^16 at the bottom.
+
 ### 1.8 Task Bucket Assignment (Kanban)
 
 | Method | Path | Description |

--- a/mDone/App/AppState.swift
+++ b/mDone/App/AppState.swift
@@ -96,6 +96,15 @@ final class AppState {
     /// Per-project ordered task lists fetched from the view endpoint (preserves positions).
     var projectTaskCache: [Int64: [VTask]] = [:]
 
+    /// Sort choices changed this session, keyed by list. Lives here rather
+    /// than in view state so it survives navigation and so every screen
+    /// showing the same project agrees; `UserDefaults` holds the rest.
+    private var sortPreferences: [TaskSortScope: TaskSortPreference] = [:]
+
+    /// Bumped by every reorder so a refetch started by an earlier drag cannot
+    /// overwrite the order a later drag produced.
+    @ObservationIgnored private var reorderGeneration = 0
+
     var unreadNotificationCount: Int {
         notifications.filter(\.isUnread).count
     }
@@ -1566,27 +1575,41 @@ final class AppState {
     /// Fetches tasks for a specific project via the view endpoint, which returns correct positions.
     @MainActor
     func fetchProjectTasks(project: Project) async {
-        guard let viewId = project.listViewId else { return }
+        guard let viewTasks = await loadProjectTasks(project: project) else { return }
+        applyProjectTasks(viewTasks, projectId: project.id)
+    }
+
+    /// Reads the project's list view. `nil` when the project has no list view
+    /// or the request failed; the caller keeps whatever it was showing.
+    @MainActor
+    private func loadProjectTasks(project: Project) async -> [VTask]? {
+        guard let viewId = project.listViewId else { return nil }
         do {
             let viewTasks: [VTask] = try await taskService.fetchProjectTasks(
                 projectId: project.id, viewId: viewId
             )
-            // Store in cache — these have correct per-view positions.
             // Dedupe by id: Vikunja's view-tasks endpoint can return the same task
             // more than once when task_positions has duplicate rows for the view.
-            projectTaskCache[project.id] = Self.uniquedById(viewTasks)
-            // Also update the global task list with any new tasks
-            for viewTask in viewTasks {
-                if let index = tasks.firstIndex(where: { $0.id == viewTask.id }) {
-                    tasks[index] = viewTask
-                } else {
-                    tasks.append(viewTask)
-                }
-            }
+            return Self.uniquedById(viewTasks)
         } catch {
             #if DEBUG
             print("[mDone] fetchProjectTasks error: \(error)")
             #endif
+            return nil
+        }
+    }
+
+    /// Stores a view's tasks as the project's order (they carry per-view
+    /// positions) and folds them into the global task list.
+    @MainActor
+    private func applyProjectTasks(_ viewTasks: [VTask], projectId: Int64) {
+        projectTaskCache[projectId] = viewTasks
+        for viewTask in viewTasks {
+            if let index = tasks.firstIndex(where: { $0.id == viewTask.id }) {
+                tasks[index] = viewTask
+            } else {
+                tasks.append(viewTask)
+            }
         }
     }
 
@@ -1966,25 +1989,91 @@ final class AppState {
         return project?.listViewId ?? 0
     }
 
+    /// Moves `task` to `position` in its project's list view.
+    ///
+    /// `newOrder` is the list as the user just dropped it. It is shown at once
+    /// so the row stays where it landed, then the view is refetched so the
+    /// server's positions win: Vikunja repairs colliding or too-small
+    /// positions and answers with a different number than it was sent. A
+    /// failed request puts the old order back. Returns `true` on success.
+    ///
+    /// Not queued for offline replay: a stale position replayed against a
+    /// list that has since moved on would land the task somewhere random, so
+    /// this asks for a connection instead.
     @MainActor
-    func moveTask(_ task: VTask, toPosition position: Double, viewId: Int64 = 0) async {
-        let resolvedViewId = viewId > 0 ? viewId : listViewId(for: task)
-        guard resolvedViewId > 0 else { return }
+    @discardableResult
+    func moveTask(_ task: VTask, toPosition position: Double, newOrder: [VTask]? = nil) async -> Bool {
+        let viewId = listViewId(for: task)
+        guard viewId > 0 else { return false }
+        if isEffectivelyOffline {
+            rejectOffline("Reordering tasks")
+            return false
+        }
+
+        reorderGeneration += 1
+        let generation = reorderGeneration
+        let previousOrder = projectTaskCache[task.projectId]
+        if let newOrder {
+            projectTaskCache[task.projectId] = newOrder
+        }
+
         do {
-            try await taskService.updatePosition(taskId: task.id, position: position, viewId: resolvedViewId)
-            if let index = tasks.firstIndex(where: { $0.id == task.id }) {
-                tasks[index].position = position
+            try await taskService.updatePosition(taskId: task.id, position: position, viewId: viewId)
+        } catch {
+            if generation == reorderGeneration {
+                projectTaskCache[task.projectId] = previousOrder
             }
-            // Update cached project task order
-            if var cached = projectTaskCache[task.projectId] {
-                if let cacheIndex = cached.firstIndex(where: { $0.id == task.id }) {
-                    cached[cacheIndex].position = position
-                }
-                projectTaskCache[task.projectId] = cached.sorted { ($0.position ?? 0) < ($1.position ?? 0) }
-            }
+            handleError(error)
+            return false
+        }
+
+        if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+            tasks[index].position = position
+        }
+        guard let project = projects.first(where: { $0.id == task.projectId }) else { return true }
+        if let refreshed = await loadProjectTasks(project: project), generation == reorderGeneration {
+            applyProjectTasks(refreshed, projectId: project.id)
+        }
+        return true
+    }
+
+    /// Puts `task` at `position` on the project's board, moving it into
+    /// `bucketId` first when it is in another column. The position row is per
+    /// view, not per bucket, so a cross-column drop is the bucket move plus
+    /// the same position write as a same-column one. Returns `true` when
+    /// every call succeeded.
+    @MainActor
+    @discardableResult
+    func placeTask(_ task: VTask, inBucket bucketId: Int64, at position: Double, in project: Project) async -> Bool {
+        guard let viewId = project.kanbanViewId else { return false }
+        if isEffectivelyOffline {
+            rejectOffline("Moving tasks on the board")
+            return false
+        }
+        if task.bucketId != bucketId {
+            guard await moveTask(task, toBucket: bucketId, in: project) else { return false }
+        }
+        do {
+            try await taskService.updatePosition(taskId: task.id, position: position, viewId: viewId)
+            return true
         } catch {
             handleError(error)
+            return false
         }
+    }
+
+    // MARK: - Sort Preferences
+
+    /// The sort for a list. Falls through to `UserDefaults` until the list is
+    /// changed in this session; no write happens here, since views ask for
+    /// it mid-body.
+    func sortPreference(for scope: TaskSortScope) -> TaskSortPreference {
+        sortPreferences[scope] ?? TaskSortPreference.load(for: scope)
+    }
+
+    func setSortPreference(_ preference: TaskSortPreference, for scope: TaskSortScope) {
+        sortPreferences[scope] = preference
+        preference.save(for: scope)
     }
 
     func datesWithTasks(in month: Date) -> [Date: [VTask]] {

--- a/mDone/App/TaskSortOrder.swift
+++ b/mDone/App/TaskSortOrder.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// How a task list is ordered. `manual` shows the order stored on the server
+/// (Vikunja keeps a position per task per view) and is the only mode in which
+/// rows can be dragged: in any other mode a drag would be re-sorted away the
+/// moment it landed, which is what issue #183 reported. The same rule as
+/// Vikunja's own list view, which only enables drag when sorted "Manually".
+enum TaskSortOrder: String, CaseIterable, Identifiable {
+    case manual
+    case dueDate
+    case priority
+    case title
+
+    var id: String {
+        rawValue
+    }
+
+    var label: String {
+        switch self {
+        case .manual: String(localized: "Manual")
+        case .dueDate: String(localized: "Due Date")
+        case .priority: String(localized: "Priority")
+        case .title: String(localized: "Title")
+        }
+    }
+
+    /// Manual order has no ascending/descending: it is whatever the user
+    /// dragged it into.
+    var supportsDirection: Bool {
+        self != .manual
+    }
+
+    /// Orders `tasks`. Manual returns the input untouched, so callers pass the
+    /// list in server (position) order.
+    func apply(to tasks: [VTask], ascending: Bool = true) -> [VTask] {
+        switch self {
+        case .manual:
+            tasks
+        case .dueDate, .priority, .title:
+            tasks.sorted { a, b in
+                let result: Bool = switch self {
+                case .dueDate:
+                    (a.effectiveDueDate ?? .distantFuture) < (b.effectiveDueDate ?? .distantFuture)
+                case .priority:
+                    a.priority > b.priority
+                case .title:
+                    a.title.localizedCompare(b.title) == .orderedAscending
+                case .manual:
+                    true
+                }
+                return ascending ? result : !result
+            }
+        }
+    }
+}
+
+/// Which list a sort preference belongs to. The Inbox is one cross-project
+/// list; each project has its own so a project you order by hand stays that
+/// way while the rest keep sorting by date.
+enum TaskSortScope: Hashable {
+    case inbox
+    case project(Int64)
+
+    var storageKey: String {
+        switch self {
+        case .inbox: "taskSort.inbox"
+        case let .project(id): "taskSort.project.\(id)"
+        }
+    }
+
+    /// Manual order only exists inside a project: the Inbox sections are
+    /// defined by date and span every project, so a position written there
+    /// could never be shown.
+    var allowsManual: Bool {
+        if case .project = self {
+            return true
+        }
+        return false
+    }
+
+    var availableOrders: [TaskSortOrder] {
+        TaskSortOrder.allCases.filter { allowsManual || $0 != .manual }
+    }
+}
+
+/// A sort choice for one list, persisted in `UserDefaults` under the scope's key.
+struct TaskSortPreference: Equatable {
+    var order: TaskSortOrder
+    var ascending: Bool
+
+    /// Due date first, which is what every list showed before manual order
+    /// existed, so nobody's list changes on upgrade.
+    static let `default` = TaskSortPreference(order: .dueDate, ascending: true)
+
+    /// The result of tapping `order` in the sort menu: picking the current
+    /// order again flips the direction, picking another starts it ascending.
+    func selecting(_ newOrder: TaskSortOrder) -> TaskSortPreference {
+        if newOrder == order, newOrder.supportsDirection {
+            return TaskSortPreference(order: order, ascending: !ascending)
+        }
+        return TaskSortPreference(order: newOrder, ascending: true)
+    }
+
+    func apply(to tasks: [VTask]) -> [VTask] {
+        order.apply(to: tasks, ascending: ascending)
+    }
+
+    // MARK: Persistence
+
+    /// Stored as `"<order>:<asc|desc>"`, one string per scope.
+    var storedValue: String {
+        "\(order.rawValue):\(ascending ? "asc" : "desc")"
+    }
+
+    init(order: TaskSortOrder, ascending: Bool) {
+        self.order = order
+        self.ascending = ascending
+    }
+
+    /// `nil` for anything that isn't a value `storedValue` produced.
+    init?(storedValue: String) {
+        let parts = storedValue.split(separator: ":", maxSplits: 1).map(String.init)
+        guard let order = TaskSortOrder(rawValue: parts.first ?? "") else { return nil }
+        let ascending = parts.count < 2 || parts[1] != "desc"
+        self.init(order: order, ascending: ascending)
+    }
+
+    static func load(for scope: TaskSortScope, defaults: UserDefaults = .standard) -> TaskSortPreference {
+        guard let stored = defaults.string(forKey: scope.storageKey),
+              let preference = TaskSortPreference(storedValue: stored),
+              scope.allowsManual || preference.order != .manual
+        else { return .default }
+        return preference
+    }
+
+    func save(for scope: TaskSortScope, defaults: UserDefaults = .standard) {
+        defaults.set(storedValue, forKey: scope.storageKey)
+    }
+}

--- a/mDone/App/TaskSortOrder.swift
+++ b/mDone/App/TaskSortOrder.swift
@@ -37,19 +37,26 @@ enum TaskSortOrder: String, CaseIterable, Identifiable {
         case .manual:
             tasks
         case .dueDate, .priority, .title:
+            // Descending swaps the operands rather than negating the result,
+            // so equal elements still compare `false` both ways and the
+            // comparator stays a strict weak ordering.
             tasks.sorted { a, b in
-                let result: Bool = switch self {
-                case .dueDate:
-                    (a.effectiveDueDate ?? .distantFuture) < (b.effectiveDueDate ?? .distantFuture)
-                case .priority:
-                    a.priority > b.priority
-                case .title:
-                    a.title.localizedCompare(b.title) == .orderedAscending
-                case .manual:
-                    true
-                }
-                return ascending ? result : !result
+                ascending ? precedes(a, b) : precedes(b, a)
             }
+        }
+    }
+
+    /// Whether `a` sorts before `b` in this order's ascending direction.
+    private func precedes(_ a: VTask, _ b: VTask) -> Bool {
+        switch self {
+        case .dueDate:
+            (a.effectiveDueDate ?? .distantFuture) < (b.effectiveDueDate ?? .distantFuture)
+        case .priority:
+            a.priority > b.priority
+        case .title:
+            a.title.localizedCompare(b.title) == .orderedAscending
+        case .manual:
+            false
         }
     }
 }
@@ -121,7 +128,12 @@ struct TaskSortPreference: Equatable {
     init?(storedValue: String) {
         let parts = storedValue.split(separator: ":", maxSplits: 1).map(String.init)
         guard let order = TaskSortOrder(rawValue: parts.first ?? "") else { return nil }
-        let ascending = parts.count < 2 || parts[1] != "desc"
+        let ascending: Bool
+        switch parts.count < 2 ? "asc" : parts[1] {
+        case "asc": ascending = true
+        case "desc": ascending = false
+        default: return nil
+        }
         self.init(order: order, ascending: ascending)
     }
 

--- a/mDone/Models/Bucket.swift
+++ b/mDone/Models/Bucket.swift
@@ -5,6 +5,11 @@ import Foundation
 /// (`/views/{view}/tasks`) returns these buckets with their tasks embedded
 /// (`tasks`), so a single fetch is enough to render a board. `tasks` is omitted
 /// entirely for empty buckets (Vikunja marshals it with `omitempty`).
+///
+/// Equality is the synthesised, whole-value kind on purpose. The board holds
+/// its buckets in `@State`, and SwiftUI skips the update when a new value
+/// compares equal to the old one: with id-only equality, reordering the
+/// cards in a column left the screen showing the old order.
 struct Bucket: Codable, Identifiable, Hashable {
     let id: Int64
     var title: String
@@ -15,14 +20,6 @@ struct Bucket: Codable, Identifiable, Hashable {
     /// Server-reported task count for the bucket. May be absent.
     var count: Int64?
     var position: Double?
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
-
-    static func == (lhs: Bucket, rhs: Bucket) -> Bool {
-        lhs.id == rhs.id
-    }
 
     /// Non-done tasks in this bucket, in their stored order. Done tasks are
     /// hidden so a board mirrors the rest of the app (which hides completed work).

--- a/mDone/Models/Project.swift
+++ b/mDone/Models/Project.swift
@@ -40,7 +40,8 @@ struct Project: Codable, Identifiable, Hashable {
     /// expressions, so the server has nowhere to put a manual placement;
     /// Vikunja's own board disables dragging there too.
     var boardAllowsManualPlacement: Bool {
-        views?.first(where: { $0.viewKind == "kanban" })?.bucketConfigurationMode != "filter"
+        guard let kanban = views?.first(where: { $0.viewKind == "kanban" }) else { return false }
+        return kanban.bucketConfigurationMode != "filter"
     }
 }
 

--- a/mDone/Models/Project.swift
+++ b/mDone/Models/Project.swift
@@ -34,6 +34,14 @@ struct Project: Codable, Identifiable, Hashable {
     var kanbanViewId: Int64? {
         views?.first(where: { $0.viewKind == "kanban" })?.id
     }
+
+    /// Whether cards on this project's board can be dragged. A view whose
+    /// `bucket_configuration_mode` is `filter` fills its columns from filter
+    /// expressions, so the server has nowhere to put a manual placement;
+    /// Vikunja's own board disables dragging there too.
+    var boardAllowsManualPlacement: Bool {
+        views?.first(where: { $0.viewKind == "kanban" })?.bucketConfigurationMode != "filter"
+    }
 }
 
 struct ProjectView: Codable, Identifiable {

--- a/mDone/Models/TaskPositioning.swift
+++ b/mDone/Models/TaskPositioning.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Works out the `position` to send when a task is dragged somewhere new.
+///
+/// Vikunja stores one float position per task per view and sorts ascending,
+/// so a move is "pick a number between the new neighbours". The rules here are
+/// the ones Vikunja's own web app uses (`calculateItemPosition.ts`), so mDone
+/// and the web app produce the same numbers for the same drag:
+///
+/// - between two neighbours: the midpoint
+/// - dropped at the top: half the first task's position
+/// - dropped at the bottom: the last task's position plus 2^16
+/// - neighbours that share a position: just above the lower one
+/// - into an empty list: 0
+///
+/// A task with no position row reports `0` from the server; `0` and any
+/// value under 0.01 make Vikunja (v1.0+) recalculate the whole view and
+/// answer with a repaired number, so callers refetch after a move rather
+/// than trusting what they sent. Pure and DB-free so it stays unit-testable.
+enum TaskPositioning {
+    /// Gap left after the last task, so many appends fit before neighbours
+    /// need repairing. Vikunja's `2^16`.
+    static let endGap: Double = 65536
+
+    /// Vikunja's `MIN_POSITION_SPACING`: the nudge used when two neighbours
+    /// already share a position.
+    static let minimumSpacing: Double = 0.01
+
+    /// The position for a task landing between `before` and `after`, either
+    /// of which is `nil` when the task landed at that end of the list.
+    static func position(between before: Double?, and after: Double?) -> Double {
+        switch (before, after) {
+        case (nil, nil):
+            return 0
+        case let (nil, after?):
+            return after / 2
+        case let (before?, nil):
+            return before + endGap
+        case let (before?, after?):
+            if before == after {
+                return after + minimumSpacing
+            }
+            return before + (after - before) / 2
+        }
+    }
+
+    /// The outcome of a list drag: which task moved, the position to send for
+    /// it, and the list in its new order for the UI to show straight away.
+    struct Move: Equatable {
+        var task: VTask
+        var position: Double
+        var reordered: [VTask]
+    }
+
+    /// Applies a SwiftUI `onMove` (`source` offsets, `destination` in the
+    /// pre-move indexing) to `tasks`, which must be in the order on screen.
+    /// Returns `nil` for a drop that changes nothing, and for a multi-row
+    /// selection: the position endpoint moves one task at a time.
+    static func move(_ tasks: [VTask], fromOffsets source: IndexSet, toOffset destination: Int) -> Move? {
+        guard source.count == 1, let from = source.first, tasks.indices.contains(from) else { return nil }
+        var reordered = tasks
+        reordered.move(fromOffsets: source, toOffset: destination)
+        guard reordered != tasks else { return nil }
+
+        let landed = from < destination ? destination - 1 : destination
+        return Move(
+            task: tasks[from],
+            position: position(forIndex: landed, in: reordered),
+            reordered: reordered
+        )
+    }
+
+    /// The position for `task` placed at `index` in `tasks`, a list that does
+    /// not yet contain it (a board column, say). `index` past the end appends.
+    static func position(forInserting task: VTask, at index: Int, into tasks: [VTask]) -> Double {
+        let others = tasks.filter { $0.id != task.id }
+        let clamped = min(max(index, 0), others.count)
+        var placed = others
+        placed.insert(task, at: clamped)
+        return position(forIndex: clamped, in: placed)
+    }
+
+    /// The position for the task at `index` of `ordered`, read from its
+    /// neighbours. A neighbour with no position (never fetched through a
+    /// view) counts as `0`, the value the server reports for it.
+    private static func position(forIndex index: Int, in ordered: [VTask]) -> Double {
+        let before = index > 0 ? (ordered[index - 1].position ?? 0) : nil
+        let after = index < ordered.count - 1 ? (ordered[index + 1].position ?? 0) : nil
+        return position(between: before, and: after)
+    }
+}

--- a/mDone/Views/Components/TaskSortMenu.swift
+++ b/mDone/Views/Components/TaskSortMenu.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// The toolbar sort menu shared by the iOS and Mac task lists. Picks from
+/// the orders the list supports (Manual only inside a project), flips the
+/// direction when the current order is picked again, and stores the choice
+/// through `AppState` so it sticks per list.
+struct TaskSortMenu: View {
+    @Environment(AppState.self) private var appState
+    let scope: TaskSortScope
+
+    private var preference: TaskSortPreference {
+        appState.sortPreference(for: scope)
+    }
+
+    var body: some View {
+        Menu {
+            ForEach(scope.availableOrders) { order in
+                Button {
+                    appState.setSortPreference(preference.selecting(order), for: scope)
+                } label: {
+                    HStack {
+                        Text(order.label)
+                        if preference.order == order {
+                            if order.supportsDirection {
+                                Image(systemName: preference.ascending ? "chevron.up" : "chevron.down")
+                            } else {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "arrow.up.arrow.down")
+        }
+        .help("Sort tasks")
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        guard preference.order.supportsDirection else {
+            return String(localized: "Sort by \(preference.order.label)")
+        }
+        return preference.ascending
+            ? String(localized: "Sort by \(preference.order.label), ascending")
+            : String(localized: "Sort by \(preference.order.label), descending")
+    }
+}

--- a/mDone/Views/Mac/MacTaskListView.swift
+++ b/mDone/Views/Mac/MacTaskListView.swift
@@ -4,23 +4,29 @@ struct MacTaskListView: View {
     @Environment(AppState.self) private var appState
     let section: MacContentView.SidebarSection?
     @Binding var selectedTask: VTask?
-    @State private var sortOrder: SortOrder = .dueDate
-    @State private var sortAscending: Bool = true
     @State private var showAdvancedFilter = false
     @AppStorage("calmMode") private var calmMode = false
 
-    enum SortOrder: String, CaseIterable {
-        case dueDate = "Due Date"
-        case priority = "Priority"
-        case title = "Title"
-
-        var label: String {
-            switch self {
-            case .dueDate: String(localized: "Due Date")
-            case .priority: String(localized: "Priority")
-            case .title: String(localized: "Title")
-            }
+    private var sortScope: TaskSortScope {
+        if case let .project(project) = section {
+            return .project(project.id)
         }
+        return .inbox
+    }
+
+    private var sortPreference: TaskSortPreference {
+        appState.sortPreference(for: sortScope)
+    }
+
+    /// Rows can be dragged only while a project list shows the server's
+    /// order, with nothing filtered out: under another sort the drop would
+    /// be sorted straight back, and a filtered list's indices don't line up
+    /// with the project's order.
+    private var manualOrderActive: Bool {
+        guard case .project = section else { return false }
+        return sortPreference.order == .manual
+            && appState.activeFilter == nil
+            && appState.searchQuery.isEmpty
     }
 
     var body: some View {
@@ -116,22 +122,22 @@ struct MacTaskListView: View {
                 }
                 .listStyle(.inset)
             } else {
-                List(TaskNesting.rows(for: tasks), selection: $selectedTask) { row in
-                    TaskRow(task: row.task, indentLevel: row.depth)
-                        .tag(row.task)
-                        .draggable(String(row.task.id)) {
-                            Text(row.task.title)
-                                .padding(8)
-                                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
-                        }
+                let rows = TaskNesting.rows(for: tasks)
+                let hasNesting = rows.contains { $0.depth > 0 }
+                List(selection: $selectedTask) {
+                    // Reorder is flat-only and manual-sort-only; when flat,
+                    // `rows` preserves `tasks`' order so the move indices
+                    // line up.
+                    ForEach(rows) { row in
+                        TaskRow(task: row.task, indentLevel: row.depth)
+                            .tag(row.task)
+                            .moveDisabled(hasNesting || !manualOrderActive)
+                    }
+                    .onMove { source, destination in
+                        handleMove(tasks: tasks, from: source, to: destination)
+                    }
                 }
                 .listStyle(.inset)
-                .dropDestination(for: String.self) { droppedIds, location in
-                    guard let draggedIdStr = droppedIds.first,
-                          let draggedId = Int64(draggedIdStr) else { return false }
-                    handleDrop(taskId: draggedId, in: tasks, at: location)
-                    return true
-                }
             }
         }
         .searchable(text: $appState.searchQuery, prompt: "Filter tasks")
@@ -158,31 +164,7 @@ struct MacTaskListView: View {
             }
 
             ToolbarItem(placement: .primaryAction) {
-                Menu {
-                    ForEach(SortOrder.allCases, id: \.self) { order in
-                        Button {
-                            if sortOrder == order {
-                                sortAscending.toggle()
-                            } else {
-                                sortOrder = order
-                                sortAscending = true
-                            }
-                        } label: {
-                            HStack {
-                                Text(order.label)
-                                if sortOrder == order {
-                                    Image(systemName: sortAscending ? "chevron.up" : "chevron.down")
-                                }
-                            }
-                        }
-                    }
-                } label: {
-                    Image(systemName: "arrow.up.arrow.down")
-                }
-                .help("Sort tasks")
-                .accessibilityLabel(sortAscending
-                    ? String(localized: "Sort by \(sortOrder.label), ascending")
-                    : String(localized: "Sort by \(sortOrder.label), descending"))
+                TaskSortMenu(scope: sortScope)
             }
 
             ToolbarItem(placement: .primaryAction) {
@@ -236,32 +218,10 @@ struct MacTaskListView: View {
         currentIds.isEmpty ? tasks : tasks.filter { !currentIds.contains($0.id) }
     }
 
-    private func handleDrop(taskId: Int64, in tasks: [VTask], at location: CGPoint) {
-        guard let task = tasks.first(where: { $0.id == taskId }) else { return }
-
-        // Estimate the target index based on list position
-        // Use a simple approach: calculate position as midpoint between neighbors
-        let estimatedRowHeight: CGFloat = 60
-        let targetIndex = min(max(Int(location.y / estimatedRowHeight), 0), tasks.count - 1)
-
-        let newPosition: Double
-        if tasks.count <= 1 {
-            newPosition = 0
-        } else if targetIndex == 0 {
-            newPosition = (tasks[0].position ?? 0) - 1
-        } else if targetIndex >= tasks.count - 1 {
-            newPosition = (tasks[tasks.count - 1].position ?? Double(tasks.count)) + 1
-        } else {
-            let before = tasks[targetIndex].position ?? Double(targetIndex)
-            let after = tasks[targetIndex + 1].position ?? Double(targetIndex + 1)
-            newPosition = (before + after) / 2
-        }
-
-        // Default view ID; ideally this would come from the project's default view
-        let viewId: Int64 = 0
-
+    private func handleMove(tasks: [VTask], from source: IndexSet, to destination: Int) {
+        guard let move = TaskPositioning.move(tasks, fromOffsets: source, toOffset: destination) else { return }
         Task {
-            await appState.moveTask(task, toPosition: newPosition, viewId: viewId)
+            await appState.moveTask(move.task, toPosition: move.position, newOrder: move.reordered)
         }
     }
 
@@ -277,19 +237,7 @@ struct MacTaskListView: View {
             tasks = tasks.filter { $0.title.lowercased().contains(query) }
         }
 
-        tasks.sort { a, b in
-            let result: Bool = switch sortOrder {
-            case .dueDate:
-                (a.effectiveDueDate ?? .distantFuture) < (b.effectiveDueDate ?? .distantFuture)
-            case .priority:
-                a.priority > b.priority
-            case .title:
-                a.title.localizedCompare(b.title) == .orderedAscending
-            }
-            return sortAscending ? result : !result
-        }
-
-        return tasks
+        return sortPreference.apply(to: tasks)
     }
 
     private var emptyStateIcon: String {

--- a/mDone/Views/Projects/ProjectBoardView.swift
+++ b/mDone/Views/Projects/ProjectBoardView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 /// A Kanban board for a project: one column per bucket, with the tasks in each
-/// column shown as cards. Tasks can be moved between columns via a card's
-/// context menu. Driven by the project's *kanban* view (`project.kanbanViewId`).
+/// column shown as cards. Cards can be dragged up and down a column and into
+/// another one; a card's context menu also offers "Move to" for columns that
+/// are off screen. Driven by the project's *kanban* view (`project.kanbanViewId`).
 struct ProjectBoardView: View {
     @Environment(AppState.self) private var appState
     let project: Project
@@ -16,6 +17,12 @@ struct ProjectBoardView: View {
     #else
     private let columnWidth: CGFloat = 300
     #endif
+
+    /// Dragging is off on a board whose columns are filled by filters: the
+    /// server has no bucket rows to move a task between there.
+    private var canDrag: Bool {
+        project.boardAllowsManualPlacement
+    }
 
     var body: some View {
         Group {
@@ -33,7 +40,11 @@ struct ProjectBoardView: View {
                                 bucket: bucket,
                                 otherBuckets: buckets.filter { $0.id != bucket.id },
                                 project: project,
-                                onChanged: { await reload() }
+                                canDrag: canDrag,
+                                onChanged: { await reload() },
+                                onDrop: { taskId, index in
+                                    handleDrop(taskId: taskId, into: bucket, at: index)
+                                }
                             )
                             .frame(width: columnWidth)
                         }
@@ -54,10 +65,82 @@ struct ProjectBoardView: View {
     }
 
     private func reload() async {
-        if !hasLoaded { isLoading = true }
+        if !hasLoaded {
+            isLoading = true
+        }
         buckets = await appState.fetchBuckets(project: project)
         isLoading = false
         hasLoaded = true
+    }
+
+    /// Lands a dragged card in `bucket` before the card at `index` among the
+    /// column's visible cards (`nil` appends). The board updates on the spot
+    /// so the card stays put, then the move is sent and the board reloaded so
+    /// the server's order wins either way. Returns `false` for a drop that
+    /// cannot be placed, which lets the drag animate back.
+    @discardableResult
+    private func handleDrop(taskId: Int64, into bucket: Bucket, at index: Int?) -> Bool {
+        guard canDrag,
+              let sourceIndex = buckets.firstIndex(where: { ($0.tasks ?? []).contains { $0.id == taskId } }),
+              let task = buckets[sourceIndex].tasks?.first(where: { $0.id == taskId }),
+              let targetIndex = buckets.firstIndex(where: { $0.id == bucket.id })
+        else { return false }
+
+        let visible = buckets[targetIndex].activeTasks
+        let others = visible.filter { $0.id != taskId }
+        var insertAt = min(index ?? others.count, others.count)
+        if let current = visible.firstIndex(where: { $0.id == taskId }) {
+            // Same column: an index counted with the card still in place
+            // shifts by one once the card is taken out.
+            if current < insertAt {
+                insertAt -= 1
+            }
+            if current == insertAt {
+                return true
+            }
+        }
+
+        let position = TaskPositioning.position(forInserting: task, at: insertAt, into: others)
+
+        var moved = task
+        moved.bucketId = bucket.id
+        moved.position = position
+        buckets[sourceIndex].tasks?.removeAll { $0.id == taskId }
+        var targetTasks = buckets[targetIndex].tasks ?? []
+        // `tasks` also holds hidden done tasks, so map the visible slot back
+        // to a slot in the full array: just before the visible card that
+        // now follows, or at the end.
+        if insertAt < others.count, let anchor = targetTasks.firstIndex(where: { $0.id == others[insertAt].id }) {
+            targetTasks.insert(moved, at: anchor)
+        } else {
+            targetTasks.append(moved)
+        }
+        buckets[targetIndex].tasks = targetTasks
+
+        Task {
+            await appState.placeTask(task, inBucket: bucket.id, at: position, in: project)
+            await reload()
+        }
+        return true
+    }
+}
+
+/// What a dragged card carries: its task id behind a prefix, so a stray
+/// text drop from elsewhere is ignored rather than parsed as an id.
+enum BoardDragPayload {
+    private static let prefix = "mdone-task:"
+
+    static func encode(_ taskId: Int64) -> String {
+        prefix + String(taskId)
+    }
+
+    static func taskId(from items: [String]) -> Int64? {
+        for item in items where item.hasPrefix(prefix) {
+            if let id = Int64(item.dropFirst(prefix.count)) {
+                return id
+            }
+        }
+        return nil
     }
 }
 
@@ -66,7 +149,13 @@ private struct BoardColumn: View {
     let bucket: Bucket
     let otherBuckets: [Bucket]
     let project: Project
+    let canDrag: Bool
     let onChanged: () async -> Void
+    /// Called with the dragged task's id and the visible index to insert
+    /// before (`nil` appends). Returns whether the drop was accepted.
+    let onDrop: (Int64, Int?) -> Bool
+
+    @State private var isTargeted = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -82,12 +171,16 @@ private struct BoardColumn: View {
             } else {
                 ScrollView(.vertical, showsIndicators: false) {
                     VStack(spacing: 8) {
-                        ForEach(tasks) { task in
+                        ForEach(Array(tasks.enumerated()), id: \.element.id) { index, task in
                             BoardTaskCard(
                                 task: task,
                                 otherBuckets: otherBuckets,
                                 project: project,
-                                onChanged: onChanged
+                                canDrag: canDrag,
+                                onChanged: onChanged,
+                                onDrop: { taskId, before in
+                                    onDrop(taskId, before ? index : index + 1)
+                                }
                             )
                         }
                     }
@@ -97,6 +190,21 @@ private struct BoardColumn: View {
         }
         .padding(8)
         .background(columnBackground, in: RoundedRectangle(cornerRadius: 12))
+        .overlay {
+            if isTargeted {
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(Color.accentColor, lineWidth: 2)
+            }
+        }
+        // Dropping on the column itself (its header, the gap below the last
+        // card, an empty column) appends. A drop on a card is taken by the
+        // card's own destination first.
+        .dropDestination(for: String.self) { items, _ in
+            guard canDrag, let taskId = BoardDragPayload.taskId(from: items) else { return false }
+            return onDrop(taskId, nil)
+        } isTargeted: { targeted in
+            isTargeted = canDrag && targeted
+        }
     }
 
     private var header: some View {
@@ -137,7 +245,9 @@ private struct BoardColumn: View {
 }
 
 /// A compact task card on the board. Opens detail on tap (iOS); offers a "Move
-/// to" submenu and a done toggle via its context menu.
+/// to" submenu and a done toggle via its context menu. Draggable, and a drop
+/// target for other cards: the top half of the card means "put it above me",
+/// the bottom half "below me".
 private struct BoardTaskCard: View {
     @Environment(AppState.self) private var appState
     #if os(iOS)
@@ -148,9 +258,15 @@ private struct BoardTaskCard: View {
     let task: VTask
     let otherBuckets: [Bucket]
     let project: Project
+    let canDrag: Bool
     let onChanged: () async -> Void
+    /// Called with the dragged task's id and whether it should land before
+    /// (`true`) or after this card.
+    let onDrop: (Int64, Bool) -> Bool
 
     @State private var showDetail = false
+    @State private var isTargeted = false
+    @State private var height: CGFloat = 0
 
     var body: some View {
         card
@@ -176,8 +292,10 @@ private struct BoardTaskCard: View {
                         await onChanged()
                     }
                 } label: {
-                    Label(task.done ? "Mark Incomplete" : "Mark Done",
-                          systemImage: task.done ? "arrow.uturn.backward" : "checkmark")
+                    Label(
+                        task.done ? "Mark Incomplete" : "Mark Done",
+                        systemImage: task.done ? "arrow.uturn.backward" : "checkmark"
+                    )
                 }
 
                 if !otherBuckets.isEmpty {
@@ -195,6 +313,20 @@ private struct BoardTaskCard: View {
                         Label("Move to", systemImage: "arrow.right.square")
                     }
                 }
+            }
+            .modifier(BoardDragModifier(task: task, enabled: canDrag))
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.height
+            } action: { newHeight in
+                height = newHeight
+            }
+            .dropDestination(for: String.self) { items, location in
+                guard canDrag, let taskId = BoardDragPayload.taskId(from: items), taskId != task.id else {
+                    return false
+                }
+                return onDrop(taskId, location.y < height / 2)
+            } isTargeted: { targeted in
+                isTargeted = canDrag && targeted
             }
     }
 
@@ -238,6 +370,12 @@ private struct BoardTaskCard: View {
         }
         .padding(10)
         .background(cardBackground, in: RoundedRectangle(cornerRadius: 10))
+        .overlay {
+            if isTargeted {
+                RoundedRectangle(cornerRadius: 10)
+                    .strokeBorder(Color.accentColor, lineWidth: 2)
+            }
+        }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
     }
@@ -274,5 +412,27 @@ private struct BoardTaskCard: View {
         #else
         Color(.controlBackgroundColor)
         #endif
+    }
+}
+
+/// Makes a card draggable, carrying its task id, with a compact title as
+/// the drag preview. Applied only while the board allows placement.
+private struct BoardDragModifier: ViewModifier {
+    let task: VTask
+    let enabled: Bool
+
+    func body(content: Content) -> some View {
+        if enabled {
+            content.draggable(BoardDragPayload.encode(task.id)) {
+                Text(task.title)
+                    .font(.subheadline)
+                    .lineLimit(2)
+                    .padding(10)
+                    .frame(width: 240, alignment: .leading)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+            }
+        } else {
+            content
+        }
     }
 }

--- a/mDone/Views/Tasks/SmartListSection.swift
+++ b/mDone/Views/Tasks/SmartListSection.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 
+/// One dated section of the Inbox (Overdue, Today, Tomorrow, ...). These
+/// sections are defined by date and span every project, so they cannot be
+/// reordered by hand: a task's position lives in its own project's list
+/// view, and nothing dropped here could ever be shown here. Manual order is
+/// a project list feature (`TaskListScreen`, `MacTaskListView`).
 struct SmartListSection: View {
-    @Environment(AppState.self) private var appState
     let title: String
     let tasks: [VTask]
     let accentColor: Color
@@ -10,22 +14,14 @@ struct SmartListSection: View {
 
     var body: some View {
         let rows = TaskNesting.rows(for: tasks)
-        let hasNesting = rows.contains { $0.depth > 0 }
         Section {
             // One ForEach for both flat and nested display, so a row's
             // identity survives the list gaining/losing nesting; otherwise a
             // detail sheet presented from a row gets torn down the moment its
-            // task's first subtask is linked. Reorder stays flat-only (nested
-            // visual order doesn't match Vikunja's flat position order);
-            // when flat, `rows` preserves `tasks`' order so `handleMove`
-            // indices line up.
+            // task's first subtask is linked.
             ForEach(rows) { row in
                 TaskRow(task: row.task, showsProgress: showsProgress, indentLevel: row.depth)
                     .tag(row.task)
-                    .moveDisabled(hasNesting)
-            }
-            .onMove { source, destination in
-                handleMove(from: source, to: destination)
             }
         } header: {
             HStack {
@@ -48,34 +44,6 @@ struct SmartListSection: View {
             .accessibilityElement(children: .combine)
             .accessibilityLabel(String(localized: "\(title), \(tasks.count) tasks"))
             .accessibilityAddTraits(.isHeader)
-        }
-    }
-
-    private func handleMove(from source: IndexSet, to destination: Int) {
-        var reordered = tasks
-        reordered.move(fromOffsets: source, toOffset: destination)
-
-        guard let movedIndex = source.first else { return }
-        let task = tasks[movedIndex]
-
-        let actualDestination = movedIndex < destination ? destination - 1 : destination
-        let newPosition: Double
-        if reordered.count <= 1 {
-            newPosition = 0
-        } else if actualDestination == 0 {
-            newPosition = (reordered[1].position ?? 1) - 1
-        } else if actualDestination >= reordered.count - 1 {
-            newPosition = (reordered[reordered.count - 2].position ?? Double(reordered.count - 2)) + 1
-        } else {
-            let before = reordered[actualDestination - 1].position ?? Double(actualDestination - 1)
-            let after = reordered[actualDestination + 1].position ?? Double(actualDestination + 1)
-            newPosition = (before + after) / 2
-        }
-
-        let viewId: Int64 = 0
-
-        Task {
-            await appState.moveTask(task, toPosition: newPosition, viewId: viewId)
         }
     }
 }

--- a/mDone/Views/Tasks/TaskListScreen.swift
+++ b/mDone/Views/Tasks/TaskListScreen.swift
@@ -10,8 +10,6 @@ struct TaskListScreen: View {
     /// When true, hides the quick-add bar — used for archived (read-only) projects.
     var readOnly: Bool = false
     @State private var showAdvancedFilter = false
-    @State private var sortOrder: SortOrder = .dueDate
-    @State private var sortAscending: Bool = true
     @AppStorage("calmMode") private var calmMode = false
     #if os(iOS)
     @State private var showBoard = false
@@ -38,18 +36,18 @@ struct TaskListScreen: View {
         #endif
     }
 
-    enum SortOrder: String, CaseIterable {
-        case dueDate = "Due Date"
-        case priority = "Priority"
-        case title = "Title"
+    private var sortScope: TaskSortScope {
+        projectFilter.map { .project($0.id) } ?? .inbox
+    }
 
-        var label: String {
-            switch self {
-            case .dueDate: String(localized: "Due Date")
-            case .priority: String(localized: "Priority")
-            case .title: String(localized: "Title")
-            }
-        }
+    private var sortPreference: TaskSortPreference {
+        appState.sortPreference(for: sortScope)
+    }
+
+    /// Rows can only be dragged when the list shows the server's order;
+    /// under any other sort the drop would be sorted straight back.
+    private var manualOrderActive: Bool {
+        projectFilter != nil && sortPreference.order == .manual
     }
 
     var body: some View {
@@ -71,17 +69,17 @@ struct TaskListScreen: View {
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif
-                .toolbar { toolbarContent }
-                .sheet(isPresented: $showAdvancedFilter) {
-                    TaskFilterSheet { filterString in
-                        Task { await appState.applyAdvancedFilter(filterString) }
-                    }
+            .toolbar { toolbarContent }
+            .sheet(isPresented: $showAdvancedFilter) {
+                TaskFilterSheet { filterString in
+                    Task { await appState.applyAdvancedFilter(filterString) }
                 }
-                .overlay {
-                    if appState.isLoading, appState.tasks.isEmpty {
-                        LoadingOverlay()
-                    }
+            }
+            .overlay {
+                if appState.isLoading, appState.tasks.isEmpty {
+                    LoadingOverlay()
                 }
+            }
     }
 
     /// The list (or board) alone on iPhone; on iPad with room, the same beside
@@ -181,12 +179,12 @@ struct TaskListScreen: View {
                                 // row identity survives the list gaining/losing
                                 // nesting (else a presented detail sheet gets
                                 // dismissed when the first subtask is linked).
-                                // Reorder is flat-only; when flat, `rows`
-                                // preserves `projectTasks`' order so the move
-                                // indices line up.
+                                // Reorder is flat-only and manual-sort-only;
+                                // when flat, `rows` preserves `projectTasks`'
+                                // order so the move indices line up.
                                 ForEach(rows) { row in
                                     TaskRow(task: row.task, readOnly: readOnly, indentLevel: row.depth)
-                                        .moveDisabled(readOnly || hasNesting)
+                                        .moveDisabled(readOnly || hasNesting || !manualOrderActive)
                                 }
                                 .onMove { source, destination in
                                     handleMove(tasks: projectTasks, from: source, to: destination)
@@ -247,30 +245,7 @@ struct TaskListScreen: View {
             }
 
             ToolbarItem(placement: .primaryAction) {
-                Menu {
-                    ForEach(SortOrder.allCases, id: \.self) { order in
-                        Button {
-                            if sortOrder == order {
-                                sortAscending.toggle()
-                            } else {
-                                sortOrder = order
-                                sortAscending = true
-                            }
-                        } label: {
-                            HStack {
-                                Text(order.label)
-                                if sortOrder == order {
-                                    Image(systemName: sortAscending ? "chevron.up" : "chevron.down")
-                                }
-                            }
-                        }
-                    }
-                } label: {
-                    Image(systemName: "arrow.up.arrow.down")
-                }
-                .accessibilityLabel(sortAscending
-                    ? String(localized: "Sort by \(sortOrder.label), ascending")
-                    : String(localized: "Sort by \(sortOrder.label), descending"))
+                TaskSortMenu(scope: sortScope)
             }
         }
     }
@@ -441,46 +416,13 @@ struct TaskListScreen: View {
     }
 
     private func sorted(_ tasks: [VTask]) -> [VTask] {
-        tasks.sorted { a, b in
-            let result: Bool = switch sortOrder {
-            case .dueDate:
-                (a.effectiveDueDate ?? .distantFuture) < (b.effectiveDueDate ?? .distantFuture)
-            case .priority:
-                a.priority > b.priority
-            case .title:
-                a.title.localizedCompare(b.title) == .orderedAscending
-            }
-            return sortAscending ? result : !result
-        }
+        sortPreference.apply(to: tasks)
     }
 
     private func handleMove(tasks: [VTask], from source: IndexSet, to destination: Int) {
-        var reordered = tasks
-        reordered.move(fromOffsets: source, toOffset: destination)
-
-        guard let movedIndex = source.first else { return }
-        let task = tasks[movedIndex]
-
-        // Calculate the new position as midpoint between neighbors
-        let actualDestination = movedIndex < destination ? destination - 1 : destination
-        let newPosition: Double
-        if reordered.count <= 1 {
-            newPosition = 0
-        } else if actualDestination == 0 {
-            newPosition = (reordered[1].position ?? 1) - 1
-        } else if actualDestination >= reordered.count - 1 {
-            newPosition = (reordered[reordered.count - 2].position ?? Double(reordered.count - 2)) + 1
-        } else {
-            let before = reordered[actualDestination - 1].position ?? Double(actualDestination - 1)
-            let after = reordered[actualDestination + 1].position ?? Double(actualDestination + 1)
-            newPosition = (before + after) / 2
-        }
-
-        // Default view ID; ideally this would come from the project's default view
-        let viewId: Int64 = 0
-
+        guard let move = TaskPositioning.move(tasks, fromOffsets: source, toOffset: destination) else { return }
         Task {
-            await appState.moveTask(task, toPosition: newPosition, viewId: viewId)
+            await appState.moveTask(move.task, toPosition: move.position, newOrder: move.reordered)
         }
     }
 

--- a/mDoneIntegrationTests/VikunjaAPIContractTests.swift
+++ b/mDoneIntegrationTests/VikunjaAPIContractTests.swift
@@ -252,4 +252,63 @@ final class VikunjaAPIContractTests: VikunjaIntegrationCase {
         let landed = after.first { ($0.tasks ?? []).contains { task in task.id == created.id } }
         XCTAssertEqual(landed?.id, destination.id, "Task did not land in the destination bucket")
     }
+
+    // MARK: - Manual order (issue #183)
+
+    /// Dragging the last task of a project list to the top: the position
+    /// endpoint takes the list view's id, and the list view reads back in the
+    /// new order. The starting order is read, not assumed: v2.4.0 lists a
+    /// fresh project's tasks newest first. The number sent is what
+    /// `TaskPositioning` produces for "drop at the top", so a server that
+    /// started repairing such values differently would show up here.
+    func testTaskPositionReordersTheListView() async throws {
+        for title in ["first", "second", "third"] {
+            try await makeTask(TaskCreateRequest(title: title))
+        }
+        let listViewId = try await viewId(kind: "list")
+
+        let before = try await tasks.fetchProjectTasks(projectId: scratchProject.id, viewId: listViewId)
+        XCTAssertEqual(before.count, 3)
+        XCTAssertTrue(before.allSatisfy { ($0.position ?? 0) > 0 }, "view tasks must carry positions")
+
+        let move = try XCTUnwrap(TaskPositioning.move(before, fromOffsets: [before.count - 1], toOffset: 0))
+        try await tasks.updatePosition(taskId: move.task.id, position: move.position, viewId: listViewId)
+
+        let after = try await tasks.fetchProjectTasks(projectId: scratchProject.id, viewId: listViewId)
+        XCTAssertEqual(after.map(\.id), move.reordered.map(\.id), "list view did not honour the position")
+    }
+
+    /// Positions are per view: a position sent with the kanban view's id
+    /// reorders the cards inside their bucket and leaves the list view alone.
+    func testTaskPositionOnTheKanbanViewReordersCardsWithinABucket() async throws {
+        for title in ["first card", "second card"] {
+            try await makeTask(TaskCreateRequest(title: title))
+        }
+        let kanbanViewId = try await viewId(kind: "kanban")
+        let listViewId = try await viewId(kind: "list")
+
+        func cardOrder() async throws -> [VTask] {
+            let buckets = try await projects.fetchBuckets(projectId: scratchProject.id, viewId: kanbanViewId)
+            let bucket = try XCTUnwrap(buckets.first { !$0.activeTasks.isEmpty }, "no bucket holds the cards")
+            return bucket.activeTasks
+        }
+
+        let listBefore = try await tasks.fetchProjectTasks(projectId: scratchProject.id, viewId: listViewId)
+        let cards = try await cardOrder()
+        XCTAssertEqual(cards.count, 2, "both cards should sit in the default bucket")
+        let last = try XCTUnwrap(cards.last)
+
+        let position = TaskPositioning.position(forInserting: last, at: 0, into: cards)
+        try await tasks.updatePosition(taskId: last.id, position: position, viewId: kanbanViewId)
+
+        let reordered = try await cardOrder()
+        XCTAssertEqual(
+            reordered.map(\.id),
+            [last.id] + cards.dropLast().map(\.id),
+            "kanban view did not honour the position"
+        )
+
+        let listAfter = try await tasks.fetchProjectTasks(projectId: scratchProject.id, viewId: listViewId)
+        XCTAssertEqual(listAfter.map(\.id), listBefore.map(\.id), "a kanban position leaked into the list view")
+    }
 }

--- a/mDoneTests/TaskPositioningTests.swift
+++ b/mDoneTests/TaskPositioningTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import mDone
+
+/// `TaskPositioning` turns a drag into the `position` Vikunja needs. The
+/// rules mirror the web app's `calculateItemPosition`, so these pin the same
+/// numbers the web app would send for the same drop.
+final class TaskPositioningTests: XCTestCase {
+    private func task(_ id: Int64, position: Double?) -> VTask {
+        var task = VTask(id: id, title: "Task \(id)", done: false, priority: 0, projectId: 1)
+        task.position = position
+        return task
+    }
+
+    // MARK: - position(between:and:)
+
+    func testMidpointBetweenNeighbours() {
+        XCTAssertEqual(TaskPositioning.position(between: 100, and: 200), 150)
+    }
+
+    func testTopOfListIsHalfTheFirstPosition() {
+        XCTAssertEqual(TaskPositioning.position(between: nil, and: 200), 100)
+    }
+
+    func testBottomOfListLeavesTheEndGap() {
+        XCTAssertEqual(TaskPositioning.position(between: 100, and: nil), 100 + 65536)
+    }
+
+    func testEmptyListIsZero() {
+        XCTAssertEqual(TaskPositioning.position(between: nil, and: nil), 0)
+    }
+
+    func testTiedNeighboursNudgeAboveTheLowerOne() {
+        XCTAssertEqual(TaskPositioning.position(between: 100, and: 100), 100.01)
+    }
+
+    // MARK: - move(_:fromOffsets:toOffset:)
+
+    func testMoveDownLandsBetweenTheNewNeighbours() throws {
+        let tasks = [task(1, position: 100), task(2, position: 200), task(3, position: 300), task(4, position: 400)]
+
+        // SwiftUI reports "drop after row 3" as destination 3 (pre-move indexing).
+        let move = try XCTUnwrap(TaskPositioning.move(tasks, fromOffsets: [0], toOffset: 3))
+
+        XCTAssertEqual(move.task.id, 1)
+        XCTAssertEqual(move.reordered.map(\.id), [2, 3, 1, 4])
+        XCTAssertEqual(move.position, 350)
+    }
+
+    func testMoveUpLandsBetweenTheNewNeighbours() throws {
+        let tasks = [task(1, position: 100), task(2, position: 200), task(3, position: 300)]
+
+        let move = try XCTUnwrap(TaskPositioning.move(tasks, fromOffsets: [2], toOffset: 1))
+
+        XCTAssertEqual(move.task.id, 3)
+        XCTAssertEqual(move.reordered.map(\.id), [1, 3, 2])
+        XCTAssertEqual(move.position, 150)
+    }
+
+    func testMoveToTopHalvesTheFirstPosition() throws {
+        let tasks = [task(1, position: 100), task(2, position: 200), task(3, position: 300)]
+
+        let move = try XCTUnwrap(TaskPositioning.move(tasks, fromOffsets: [2], toOffset: 0))
+
+        XCTAssertEqual(move.reordered.map(\.id), [3, 1, 2])
+        XCTAssertEqual(move.position, 50)
+    }
+
+    func testMoveToBottomAddsTheEndGap() throws {
+        let tasks = [task(1, position: 100), task(2, position: 200), task(3, position: 300)]
+
+        let move = try XCTUnwrap(TaskPositioning.move(tasks, fromOffsets: [0], toOffset: 3))
+
+        XCTAssertEqual(move.reordered.map(\.id), [2, 3, 1])
+        XCTAssertEqual(move.position, 300 + 65536)
+    }
+
+    func testDropInPlaceIsNoMove() {
+        let tasks = [task(1, position: 100), task(2, position: 200)]
+        XCTAssertNil(TaskPositioning.move(tasks, fromOffsets: [0], toOffset: 0))
+        XCTAssertNil(TaskPositioning.move(tasks, fromOffsets: [0], toOffset: 1), "dropping just below itself")
+    }
+
+    func testMultiRowSelectionIsIgnored() {
+        let tasks = [task(1, position: 100), task(2, position: 200), task(3, position: 300)]
+        XCTAssertNil(TaskPositioning.move(tasks, fromOffsets: [0, 1], toOffset: 3))
+    }
+
+    func testOutOfRangeSourceIsIgnored() {
+        XCTAssertNil(TaskPositioning.move([task(1, position: 100)], fromOffsets: [4], toOffset: 0))
+    }
+
+    /// A neighbour never fetched through a view has no position, which the
+    /// server would report as 0. Treat it that way rather than crashing or
+    /// inventing an index-based number.
+    func testMissingNeighbourPositionCountsAsZero() throws {
+        let tasks = [task(1, position: nil), task(2, position: 200)]
+
+        let move = try XCTUnwrap(TaskPositioning.move(tasks, fromOffsets: [1], toOffset: 0))
+
+        // Landed at the top with task 1 (position 0) below: 0 / 2.
+        XCTAssertEqual(move.position, 0)
+    }
+
+    // MARK: - position(forInserting:at:into:)
+
+    func testInsertIntoEmptyColumnIsZero() {
+        XCTAssertEqual(TaskPositioning.position(forInserting: task(9, position: nil), at: 0, into: []), 0)
+    }
+
+    func testInsertAtTopOfColumn() {
+        let column = [task(1, position: 100), task(2, position: 200)]
+        XCTAssertEqual(TaskPositioning.position(forInserting: task(9, position: nil), at: 0, into: column), 50)
+    }
+
+    func testInsertBetweenCards() {
+        let column = [task(1, position: 100), task(2, position: 200)]
+        XCTAssertEqual(TaskPositioning.position(forInserting: task(9, position: nil), at: 1, into: column), 150)
+    }
+
+    func testInsertPastTheEndAppends() {
+        let column = [task(1, position: 100), task(2, position: 200)]
+        XCTAssertEqual(
+            TaskPositioning.position(forInserting: task(9, position: nil), at: 99, into: column),
+            200 + 65536
+        )
+    }
+
+    /// The column passed in may still hold the card being moved (same-column
+    /// drag); it must not count as its own neighbour.
+    func testInsertIgnoresTheMovedCardAlreadyInTheColumn() {
+        let moving = task(2, position: 200)
+        let column = [task(1, position: 100), moving, task(3, position: 300)]
+        XCTAssertEqual(TaskPositioning.position(forInserting: moving, at: 0, into: column), 50)
+        XCTAssertEqual(TaskPositioning.position(forInserting: moving, at: 2, into: column), 300 + 65536)
+    }
+}

--- a/mDoneTests/TaskReorderTests.swift
+++ b/mDoneTests/TaskReorderTests.swift
@@ -1,0 +1,321 @@
+import SwiftData
+import XCTest
+@testable import mDone
+
+/// Dragging a task to a new place (issue #183): the list must show the drop
+/// straight away, send the position to the right view, take the server's
+/// order back afterwards, and put things back if the request fails.
+@MainActor
+final class TaskReorderTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    // MARK: - Fixtures
+
+    private let project = Project(
+        id: 7,
+        title: "Work",
+        views: [
+            ProjectView(id: 100, title: "List", projectId: 7, viewKind: "list"),
+            ProjectView(id: 200, title: "Kanban", projectId: 7, viewKind: "kanban", bucketConfigurationMode: "manual"),
+        ]
+    )
+
+    private func task(_ id: Int64, position: Double, bucketId: Int64? = nil) -> VTask {
+        var task = VTask(id: id, title: "Task \(id)", done: false, priority: 0, projectId: 7)
+        task.position = position
+        task.bucketId = bucketId
+        return task
+    }
+
+    private func makeAppState() async -> AppState {
+        let client = MockURLProtocol.mockClient()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        let state = AppState(taskService: TaskService(apiClient: client))
+        state.projects = [project]
+        state.tasks = [task(1, position: 100), task(2, position: 200), task(3, position: 300)]
+        state.projectTaskCache[7] = state.tasks
+        return state
+    }
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([
+            CachedTask.self, CachedProject.self, CachedLabel.self, PendingOperation.self, FocusRecord.self,
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    private static func viewTasksJSON(ids: [Int64]) -> Data {
+        let objects: [[String: Any]] = ids.enumerated().map { index, id in
+            [
+                "id": id, "title": "Task \(id)", "done": false, "priority": 0,
+                "project_id": 7, "position": Double(index + 1) * 1000,
+            ]
+        }
+        return (try? JSONSerialization.data(withJSONObject: objects)) ?? Data()
+    }
+
+    private static func body(of request: URLRequest) throws -> [String: Any] {
+        let data = try XCTUnwrap(MockURLProtocol.bodyData(from: request) ?? request.httpBody)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    // MARK: - List reorder
+
+    func testMoveTaskSendsPositionToTheListViewAndShowsTheDropAtOnce() async throws {
+        let state = await makeAppState()
+        let moved = state.tasks[2]
+        let newOrder = [moved, state.tasks[0], state.tasks[1]]
+
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 200, url: request.url)
+            if request.httpMethod == "POST" {
+                return (response, Data())
+            }
+            // The refetch answers with the same order the user made.
+            return (response, Self.viewTasksJSON(ids: [3, 1, 2]))
+        }
+
+        let ok = await state.moveTask(moved, toPosition: 50, newOrder: newOrder)
+
+        XCTAssertTrue(ok)
+        let post = try XCTUnwrap(MockURLProtocol.capturedRequests.first { $0.httpMethod == "POST" })
+        XCTAssertEqual(post.url?.path, "/api/v1/tasks/3/position")
+        let body = try Self.body(of: post)
+        XCTAssertEqual(body["position"] as? Double, 50)
+        XCTAssertEqual(body["project_view_id"] as? Int, 100, "positions belong to the list view")
+        XCTAssertEqual(state.tasksForProject(7).map(\.id), [3, 1, 2])
+    }
+
+    /// Vikunja may repair the position it was sent (collisions, values under
+    /// 0.01), so the order shown afterwards is the server's, not the client's.
+    func testMoveTaskTakesTheServersOrderAfterTheRefetch() async {
+        let state = await makeAppState()
+        let moved = state.tasks[2]
+
+        MockURLProtocol.requestHandler = { request in
+            let response = MockURLProtocol.makeResponse(statusCode: 200, url: request.url)
+            if request.httpMethod == "POST" {
+                return (response, Data())
+            }
+            return (response, Self.viewTasksJSON(ids: [1, 3, 2]))
+        }
+
+        await state.moveTask(moved, toPosition: 50, newOrder: [moved, state.tasks[0], state.tasks[1]])
+
+        XCTAssertEqual(state.tasksForProject(7).map(\.id), [1, 3, 2])
+        XCTAssertEqual(
+            MockURLProtocol.capturedRequests.filter { $0.httpMethod == "GET" }.first?.url?.path,
+            "/api/v1/projects/7/views/100/tasks"
+        )
+    }
+
+    func testMoveTaskRestoresTheOldOrderWhenTheServerRefuses() async {
+        let state = await makeAppState()
+        let moved = state.tasks[2]
+
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 500, url: request.url), Data())
+        }
+
+        let ok = await state.moveTask(moved, toPosition: 50, newOrder: [moved, state.tasks[0], state.tasks[1]])
+
+        XCTAssertFalse(ok)
+        XCTAssertEqual(state.tasksForProject(7).map(\.id), [1, 2, 3], "the drop must not stick")
+        XCTAssertNotNil(state.errorMessage)
+        XCTAssertTrue(MockURLProtocol.capturedRequests.allSatisfy { $0.httpMethod == "POST" }, "no refetch on failure")
+    }
+
+    func testMoveTaskWithoutAListViewDoesNothing() async {
+        let state = await makeAppState()
+        state.projects = [Project(id: 7, title: "No views")]
+
+        MockURLProtocol.requestHandler = { _ in
+            XCTFail("Nothing to send without a view id")
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: nil), Data())
+        }
+
+        let ok = await state.moveTask(state.tasks[0], toPosition: 50)
+        XCTAssertFalse(ok)
+        XCTAssertTrue(MockURLProtocol.capturedRequests.isEmpty)
+    }
+
+    /// A position replayed later against a list that has moved on would land
+    /// the task somewhere random, so reordering is refused offline instead
+    /// of queued.
+    func testMoveTaskOfflineIsRefusedNotQueued() async throws {
+        let container = try makeContainer()
+        let client = MockURLProtocol.mockClient()
+        await client.configure(serverURL: "https://mock.vikunja.io", token: "test-token")
+        let sync = SyncService(
+            taskService: TaskService(apiClient: client),
+            projectService: ProjectService(apiClient: client),
+            modelContainer: container,
+            apiClient: client
+        )
+        let state = AppState(taskService: TaskService(apiClient: client))
+        state.configureSyncService(sync, networkMonitor: NetworkMonitor(stubbedConnection: false))
+        state.projects = [project]
+        state.tasks = [task(1, position: 100), task(2, position: 200)]
+        state.projectTaskCache[7] = state.tasks
+
+        MockURLProtocol.requestHandler = { _ in
+            XCTFail("Offline reorder must not hit the network")
+            return (MockURLProtocol.makeResponse(statusCode: 200, url: nil), Data())
+        }
+
+        let ok = await state.moveTask(state.tasks[1], toPosition: 50, newOrder: [state.tasks[1], state.tasks[0]])
+
+        XCTAssertFalse(ok)
+        XCTAssertEqual(state.tasksForProject(7).map(\.id), [1, 2])
+        guard case .networkUnavailable = state.activeError else {
+            return XCTFail("expected the offline error, got \(String(describing: state.activeError))")
+        }
+        XCTAssertTrue(MockURLProtocol.capturedRequests.isEmpty)
+        XCTAssertEqual(try container.mainContext.fetch(FetchDescriptor<PendingOperation>()).count, 0)
+    }
+
+    // MARK: - Board placement
+
+    func testPlaceTaskInSameBucketOnlySendsThePosition() async throws {
+        let state = await makeAppState()
+        let card = task(1, position: 100, bucketId: 5)
+
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data())
+        }
+
+        let ok = await state.placeTask(card, inBucket: 5, at: 250, in: project)
+
+        XCTAssertTrue(ok)
+        XCTAssertEqual(MockURLProtocol.capturedRequests.map { $0.url?.path }, ["/api/v1/tasks/1/position"])
+        let body = try Self.body(of: MockURLProtocol.capturedRequests[0])
+        XCTAssertEqual(body["position"] as? Double, 250)
+        XCTAssertEqual(body["project_view_id"] as? Int, 200, "board positions belong to the kanban view")
+    }
+
+    func testPlaceTaskInAnotherBucketMovesItThenPositionsIt() async {
+        let state = await makeAppState()
+        let card = task(1, position: 100, bucketId: 5)
+        state.tasks = [card]
+
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 200, url: request.url), Data())
+        }
+
+        let ok = await state.placeTask(card, inBucket: 6, at: 250, in: project)
+
+        XCTAssertTrue(ok)
+        XCTAssertEqual(
+            MockURLProtocol.capturedRequests.map { $0.url?.path },
+            ["/api/v1/projects/7/views/200/buckets/6/tasks", "/api/v1/tasks/1/position"]
+        )
+        XCTAssertEqual(state.tasks.first?.bucketId, 6)
+    }
+
+    func testPlaceTaskStopsWhenTheBucketMoveFails() async {
+        let state = await makeAppState()
+        let card = task(1, position: 100, bucketId: 5)
+        state.tasks = [card]
+
+        MockURLProtocol.requestHandler = { request in
+            (MockURLProtocol.makeResponse(statusCode: 403, url: request.url), Data())
+        }
+
+        let ok = await state.placeTask(card, inBucket: 6, at: 250, in: project)
+
+        XCTAssertFalse(ok)
+        XCTAssertEqual(MockURLProtocol.capturedRequests.count, 1, "no position write after a failed move")
+        XCTAssertEqual(state.tasks.first?.bucketId, 5)
+    }
+
+    func testPlaceTaskWithoutAKanbanViewDoesNothing() async {
+        let state = await makeAppState()
+        let listOnly = Project(
+            id: 7,
+            title: "Work",
+            views: [ProjectView(id: 100, title: "List", projectId: 7, viewKind: "list")]
+        )
+
+        let ok = await state.placeTask(task(1, position: 100, bucketId: 5), inBucket: 6, at: 1, in: listOnly)
+
+        XCTAssertFalse(ok)
+        XCTAssertTrue(MockURLProtocol.capturedRequests.isEmpty)
+    }
+
+    // MARK: - Filter-mode boards
+
+    func testBoardAllowsPlacementUnlessBucketsComeFromFilters() {
+        XCTAssertTrue(project.boardAllowsManualPlacement)
+
+        let filtered = Project(
+            id: 7,
+            title: "Work",
+            views: [ProjectView(
+                id: 200,
+                title: "Kanban",
+                projectId: 7,
+                viewKind: "kanban",
+                bucketConfigurationMode: "filter"
+            )]
+        )
+        XCTAssertFalse(filtered.boardAllowsManualPlacement)
+
+        // Older servers report no mode at all; that is a plain manual board.
+        let unspecified = Project(
+            id: 7,
+            title: "Work",
+            views: [ProjectView(id: 200, title: "Kanban", projectId: 7, viewKind: "kanban")]
+        )
+        XCTAssertTrue(unspecified.boardAllowsManualPlacement)
+    }
+
+    // MARK: - Board state
+
+    /// The board keeps its buckets in `@State`, and SwiftUI drops an update
+    /// whose new value equals the old. Bucket equality therefore has to see a
+    /// reordered column as a different value, or a drag lands on the server
+    /// and never on screen.
+    func testBucketEqualitySeesAReorderedColumn() {
+        let first = task(1, position: 100, bucketId: 5)
+        let second = task(2, position: 200, bucketId: 5)
+        let before = Bucket(id: 5, title: "To-Do", tasks: [first, second])
+        let after = Bucket(id: 5, title: "To-Do", tasks: [second, first])
+
+        XCTAssertNotEqual(before, after)
+        XCTAssertEqual(before, Bucket(id: 5, title: "To-Do", tasks: [first, second]))
+    }
+
+    // MARK: - Drag payload
+
+    func testBoardDragPayloadRoundTripsAndIgnoresStrayText() {
+        XCTAssertEqual(BoardDragPayload.taskId(from: [BoardDragPayload.encode(42)]), 42)
+        XCTAssertNil(BoardDragPayload.taskId(from: ["42"]))
+        XCTAssertNil(BoardDragPayload.taskId(from: ["mdone-task:forty-two"]))
+        XCTAssertNil(BoardDragPayload.taskId(from: []))
+    }
+
+    // MARK: - Sort preference through AppState
+
+    func testSortPreferenceIsStoredPerListAndReadBack() {
+        let state = AppState()
+        let scope = TaskSortScope.project(Int64.random(in: 100_000 ... 999_999))
+        defer { UserDefaults.standard.removeObject(forKey: scope.storageKey) }
+
+        XCTAssertEqual(state.sortPreference(for: scope), .default)
+
+        state.setSortPreference(TaskSortPreference(order: .manual, ascending: true), for: scope)
+
+        XCTAssertEqual(state.sortPreference(for: scope).order, .manual)
+        XCTAssertEqual(TaskSortPreference.load(for: scope).order, .manual, "written through to UserDefaults")
+        XCTAssertEqual(AppState().sortPreference(for: scope).order, .manual, "a fresh AppState reads it back")
+    }
+}

--- a/mDoneTests/TaskReorderTests.swift
+++ b/mDoneTests/TaskReorderTests.swift
@@ -276,6 +276,15 @@ final class TaskReorderTests: XCTestCase {
             views: [ProjectView(id: 200, title: "Kanban", projectId: 7, viewKind: "kanban")]
         )
         XCTAssertTrue(unspecified.boardAllowsManualPlacement)
+
+        // No kanban view at all: nothing to drag on.
+        let listOnly = Project(
+            id: 7,
+            title: "Work",
+            views: [ProjectView(id: 100, title: "List", projectId: 7, viewKind: "list")]
+        )
+        XCTAssertFalse(listOnly.boardAllowsManualPlacement)
+        XCTAssertFalse(Project(id: 7, title: "Work").boardAllowsManualPlacement)
     }
 
     // MARK: - Board state

--- a/mDoneTests/TaskSortOrderTests.swift
+++ b/mDoneTests/TaskSortOrderTests.swift
@@ -127,6 +127,19 @@ final class TaskSortOrderTests: XCTestCase {
         XCTAssertEqual(TaskSortPreference.load(for: .project(7), defaults: defaults), .default)
         XCTAssertNil(TaskSortPreference(storedValue: ""))
         XCTAssertNil(TaskSortPreference(storedValue: "sideways:asc"))
+        XCTAssertNil(TaskSortPreference(storedValue: "dueDate:sideways"), "only asc and desc are directions")
+    }
+
+    /// A comparator that negates its result for descending is not a strict
+    /// weak ordering: equal elements would sort "before" each other both
+    /// ways. Ties must compare false in both directions.
+    func testDescendingComparatorKeepsTiesStable() {
+        let tied = (1 ... 6).map { task(Int64($0), priority: 3) }
+        XCTAssertEqual(TaskSortOrder.priority.apply(to: tied, ascending: false).map(\.id), [1, 2, 3, 4, 5, 6])
+        XCTAssertEqual(TaskSortOrder.priority.apply(to: tied, ascending: true).map(\.id), [1, 2, 3, 4, 5, 6])
+
+        let mixed = [task(1, priority: 1), task(2, priority: 5), task(3, priority: 1), task(4, priority: 5)]
+        XCTAssertEqual(TaskSortOrder.priority.apply(to: mixed, ascending: false).map(\.id), [1, 3, 2, 4])
     }
 
     func testStoredValueFormat() {

--- a/mDoneTests/TaskSortOrderTests.swift
+++ b/mDoneTests/TaskSortOrderTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import mDone
+
+/// The sort menu's model: which orders each list offers, what a tap does,
+/// how the choice is stored, and that Manual leaves the server's order alone.
+final class TaskSortOrderTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private let suiteName = "TaskSortOrderTests"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    private func task(_ id: Int64, title: String = "", due: Date? = nil, priority: Int64 = 0) -> VTask {
+        var task = VTask(id: id, title: title, done: false, priority: priority, projectId: 1)
+        task.dueDate = due
+        return task
+    }
+
+    // MARK: - Ordering
+
+    func testManualKeepsTheGivenOrder() {
+        let tasks = [task(3, title: "c"), task(1, title: "a"), task(2, title: "b")]
+        XCTAssertEqual(TaskSortOrder.manual.apply(to: tasks).map(\.id), [3, 1, 2])
+        XCTAssertEqual(TaskSortOrder.manual.apply(to: tasks, ascending: false).map(\.id), [3, 1, 2])
+    }
+
+    func testDueDateSortsSoonestFirstAndUndatedLast() {
+        let now = Date()
+        let tasks = [
+            task(1, due: now.addingTimeInterval(7200)),
+            task(2),
+            task(3, due: now),
+        ]
+        XCTAssertEqual(TaskSortOrder.dueDate.apply(to: tasks).map(\.id), [3, 1, 2])
+        XCTAssertEqual(TaskSortOrder.dueDate.apply(to: tasks, ascending: false).map(\.id), [2, 1, 3])
+    }
+
+    func testPrioritySortsHighestFirst() {
+        let tasks = [task(1, priority: 1), task(2, priority: 5), task(3, priority: 3)]
+        XCTAssertEqual(TaskSortOrder.priority.apply(to: tasks).map(\.id), [2, 3, 1])
+    }
+
+    func testTitleSortsAlphabetically() {
+        let tasks = [task(1, title: "banana"), task(2, title: "Apple"), task(3, title: "cherry")]
+        XCTAssertEqual(TaskSortOrder.title.apply(to: tasks).map(\.id), [2, 1, 3])
+    }
+
+    func testOnlyManualHasNoDirection() {
+        XCTAssertFalse(TaskSortOrder.manual.supportsDirection)
+        XCTAssertTrue(TaskSortOrder.dueDate.supportsDirection)
+        XCTAssertTrue(TaskSortOrder.priority.supportsDirection)
+        XCTAssertTrue(TaskSortOrder.title.supportsDirection)
+    }
+
+    // MARK: - Scope
+
+    func testInboxDoesNotOfferManual() {
+        XCTAssertFalse(TaskSortScope.inbox.allowsManual)
+        XCTAssertEqual(TaskSortScope.inbox.availableOrders, [.dueDate, .priority, .title])
+    }
+
+    func testProjectOffersManual() {
+        XCTAssertTrue(TaskSortScope.project(7).allowsManual)
+        XCTAssertEqual(TaskSortScope.project(7).availableOrders, [.manual, .dueDate, .priority, .title])
+    }
+
+    func testEachProjectHasItsOwnStorageKey() {
+        XCTAssertNotEqual(TaskSortScope.project(1).storageKey, TaskSortScope.project(2).storageKey)
+        XCTAssertNotEqual(TaskSortScope.project(1).storageKey, TaskSortScope.inbox.storageKey)
+    }
+
+    // MARK: - Selecting in the menu
+
+    func testSelectingAnotherOrderStartsAscending() {
+        let preference = TaskSortPreference(order: .dueDate, ascending: false)
+        XCTAssertEqual(preference.selecting(.title), TaskSortPreference(order: .title, ascending: true))
+    }
+
+    func testSelectingTheCurrentOrderFlipsDirection() {
+        let preference = TaskSortPreference(order: .dueDate, ascending: true)
+        XCTAssertEqual(preference.selecting(.dueDate), TaskSortPreference(order: .dueDate, ascending: false))
+    }
+
+    func testSelectingManualTwiceStaysManual() {
+        let preference = TaskSortPreference(order: .manual, ascending: true)
+        XCTAssertEqual(preference.selecting(.manual), preference)
+    }
+
+    // MARK: - Persistence
+
+    func testDefaultIsDueDateAscending() {
+        XCTAssertEqual(TaskSortPreference.default, TaskSortPreference(order: .dueDate, ascending: true))
+        XCTAssertEqual(TaskSortPreference.load(for: .project(7), defaults: defaults), .default)
+    }
+
+    func testSaveThenLoadRoundTrips() {
+        let preference = TaskSortPreference(order: .title, ascending: false)
+        preference.save(for: .project(7), defaults: defaults)
+
+        XCTAssertEqual(TaskSortPreference.load(for: .project(7), defaults: defaults), preference)
+        XCTAssertEqual(TaskSortPreference.load(for: .project(8), defaults: defaults), .default, "other project")
+    }
+
+    func testManualRoundTrips() {
+        TaskSortPreference(order: .manual, ascending: true).save(for: .project(7), defaults: defaults)
+        XCTAssertEqual(TaskSortPreference.load(for: .project(7), defaults: defaults).order, .manual)
+    }
+
+    /// A stored Manual choice on a list that cannot show it (the Inbox) falls
+    /// back rather than leaving the list unsorted.
+    func testManualStoredForInboxFallsBackToDefault() {
+        TaskSortPreference(order: .manual, ascending: true).save(for: .inbox, defaults: defaults)
+        XCTAssertEqual(TaskSortPreference.load(for: .inbox, defaults: defaults), .default)
+    }
+
+    func testGarbageInDefaultsFallsBackToDefault() {
+        defaults.set("what", forKey: TaskSortScope.project(7).storageKey)
+        XCTAssertEqual(TaskSortPreference.load(for: .project(7), defaults: defaults), .default)
+        XCTAssertNil(TaskSortPreference(storedValue: ""))
+        XCTAssertNil(TaskSortPreference(storedValue: "sideways:asc"))
+    }
+
+    func testStoredValueFormat() {
+        XCTAssertEqual(TaskSortPreference(order: .priority, ascending: false).storedValue, "priority:desc")
+        XCTAssertEqual(
+            TaskSortPreference(storedValue: "priority:desc"),
+            TaskSortPreference(order: .priority, ascending: false)
+        )
+        XCTAssertEqual(TaskSortPreference(storedValue: "manual"), TaskSortPreference(order: .manual, ascending: true))
+    }
+}


### PR DESCRIPTION
## Summary

Dragging a task in a project list was saved to the server but never shown: every list re-sorted by due date, priority or title, and no sort mode showed the server's positions (the "acts like it will work" half of #183). The Kanban board had no drag at all.

Reordering is now a sort mode. Projects gain **Manual**, which shows the server's per-view order and is the only mode where rows can be dragged, the same rule as Vikunja's own list view. Due dates and positions stay independent: a task due tomorrow can sit below one due next month, and a drag never touches a due date. The sort choice is stored per project and for the Inbox. The Inbox keeps its date sections and never offers Manual, since a position written from a cross-project section could never be shown there.

- `TaskSortOrder` / `TaskSortPreference` replace the duplicated iOS and Mac sort enums; the menu is one shared `TaskSortMenu`.
- `TaskPositioning` mirrors the web app's `calculateItemPosition` and replaces three hand-rolled copies, including the Mac drop handler that guessed the target row from a fixed 60pt height (now native `onMove`).
- `AppState.moveTask` shows the drop at once, posts the position to the list view, refetches so the server's (possibly repaired) positions win, reverts on failure, and refuses to queue a reorder offline rather than replaying a stale position later.
- Kanban cards drag within a column and across columns: top half of a card means above it, bottom half below, empty column space appends. `placeTask` does the bucket move then the position write on the kanban view. Boards whose columns come from filters disable drag, as the web app does. "Move to" stays for off-screen columns.
- `Bucket` now has synthesised equality. With id-only equality SwiftUI skipped the `@State` update after a reorder, so the board reloaded correctly but never moved on screen.
- `docs/vikunja-api-inventory.md` notes the server's position repair behaviour.

## Related Issues

Fixes #183

## Testing

- `mDoneTests` on iPhone 17: 754 passed. `mDoneMacTests`: 712 passed. New: `TaskSortOrderTests`, `TaskPositioningTests`, `TaskReorderTests` (optimistic reorder, revert on failure, offline refusal, board placement call order, filter-mode boards, `Bucket` equality).
- `mDoneIntegrationTests` against the local Docker Vikunja v2.4.0: 16 passed, including two new position round-trips (list view, and kanban view leaving the list view untouched).
- Live in the simulator against the same server: Manual sort menu, list drag to the top, same-column and cross-column board drags, each confirmed on screen and by reading the view back from the API. Vikunja 2.4.0 stored a different position than the one sent for the list drop, which is why the refetch exists.
- Not exercised live: the Mac drag itself (standard `List` reorder, same `AppState` path) and iPad.

## Checklist

- [x] Builds on iOS and macOS
- [x] Tests pass
- [x] Ran `swiftlint lint --quiet` and `swiftformat .`
- [x] No breaking changes (or described in summary above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
