### PR TITLE
ci: halve the CodeQL build and skip it for non-code changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,6 +53,10 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
+      # The generic simulator destination builds a universal binary (arm64 +
+      # x86_64), which doubles the number of swift-frontend invocations the
+      # CodeQL tracer has to intercept and extract. CodeQL sees the same source
+      # either way, so build the runner's own architecture only.
       - name: Build Swift
         if: matrix.build-mode == 'manual'
         run: |
@@ -63,6 +67,8 @@ jobs:
             -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath build \
             CODE_SIGNING_ALLOWED=NO \
+            ONLY_ACTIVE_ARCH=YES \
+            ARCHS=arm64 \
             build
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,9 +35,12 @@ on:
     - cron: "27 4 * * 1"
 
 # A new push to a PR cancels the analysis still running for its previous
-# commit, so superseded runs stop tying up the three-core macOS runner.
+# commit, so superseded runs stop tying up the three-core macOS runner. The
+# event name is part of the group because scheduled runs and push-to-main
+# runs share refs/heads/main: without it, a push landing during the weekly
+# run would cancel it.
 concurrency:
-  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  group: codeql-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,13 +10,35 @@ name: "CodeQL"
 # configurations conflict. The `actions` language is included here so disabling
 # default setup does not lose the (already-passing) Actions analysis.
 
+# Only the Swift sources, the project definition, and the workflows themselves
+# can change what CodeQL finds, so PRs and pushes that touch nothing else
+# (docs, website, localisation, tests, changelog) skip the run. The weekly
+# schedule still analyses everything regardless of what changed.
 on:
   push:
     branches: [main]
+    paths:
+      - "mDone/**"
+      - "mDoneShared/**"
+      - "mDoneWidgets/**"
+      - "project.yml"
+      - ".github/workflows/**"
   pull_request:
     branches: [main]
+    paths:
+      - "mDone/**"
+      - "mDoneShared/**"
+      - "mDoneWidgets/**"
+      - "project.yml"
+      - ".github/workflows/**"
   schedule:
     - cron: "27 4 * * 1"
+
+# A new push to a PR cancels the analysis still running for its previous
+# commit, so superseded runs stop tying up the three-core macOS runner.
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:


### PR DESCRIPTION
## Summary

The CodeQL workflow took about 30 minutes per run, and 27 of those minutes were the `xcodebuild` step running under CodeQL's Swift tracer. Two changes, one commit each:

1. **Build one architecture.** `generic/platform=iOS Simulator` builds a universal arm64 + x86_64 binary, so the tracer intercepted and extracted every Swift file twice (246 `SwiftCompile` tasks for 123 files). The build now passes `ONLY_ACTIVE_ARCH=YES ARCHS=arm64`. CodeQL sees the same source either way; this should roughly halve the build step.
2. **Run it less often.** Push and PR triggers get a `paths` filter covering `mDone/`, `mDoneShared/`, `mDoneWidgets/`, `project.yml` and `.github/workflows/`, so docs, website, localisation, test and changelog-only PRs skip the job. A `concurrency` group cancels a PR's previous in-progress run when a new commit lands. The weekly scheduled run is unchanged and still analyses everything.

Main has no required status checks, so PRs that skip CodeQL remain mergeable.

## Related Issues

None.

## Testing

Step timings were read from run 34275484697 (PR #182) and compared against the untraced iOS Tests workflow, which builds and runs the whole `mDoneTests` suite in about 6.5 minutes on the same runner class. The YAML parses. This PR touches `.github/workflows/`, so it triggers CodeQL itself; its run is the first measurement of the new build time.

## Checklist

- [x] Builds on iOS and macOS (no source changes)
- [x] Tests pass (no source changes)
- [x] Ran `swiftlint lint --quiet` and `swiftformat .` (no Swift changes)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
