### PR TITLE
ci: prune merged and abandoned branches every week

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -1,0 +1,111 @@
+name: Stale Branches
+
+# Prunes remote branches nobody needs any more. Runs every Monday and on
+# demand. A branch is deleted when it is not main, not protected, has no
+# open pull request, and either:
+#   * its pull request was merged (the work is on main, so the branch is
+#     only clutter; GitHub keeps the "Restore branch" button on the PR), or
+#   * it is already fully contained in main, or
+#   * its last commit is older than `days` (GitHub's own "stale" cut-off is
+#     90 days), whatever its PR state.
+# Asset branches are always kept: the repo uses `screenshots/*` and `*-assets`
+# branches (and orphan branches with no merge base with main) to hold review
+# screenshots that issues and PRs link to, and deleting them would break
+# those images. A manual run can be a dry run, which only reports.
+on:
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report what would be deleted without deleting anything
+        type: boolean
+        default: false
+      days:
+        description: Delete unmerged branches whose last commit is older than this many days
+        type: string
+        default: '90'
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  prune:
+    name: Delete merged and abandoned branches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Prune branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ inputs.dry_run == true && 'true' || 'false' }}
+          DAYS: ${{ inputs.days || '90' }}
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+          owner="${repo%%/*}"
+          default_branch=$(gh api "repos/$repo" --jq .default_branch)
+          cutoff=$(( $(date +%s) - DAYS * 86400 ))
+
+          # Branch names that currently have an open PR, and ones whose PR was merged.
+          # Only PRs whose head lives in this repo count: a fork's branch name is not ours.
+          gh pr list --repo "$repo" --state open --limit 1000 \
+            --json headRefName,headRepositoryOwner \
+            --jq ".[] | select(.headRepositoryOwner.login == \"$owner\") | .headRefName" \
+            | sort -u > open.txt
+          gh pr list --repo "$repo" --state merged --limit 1000 \
+            --json headRefName,headRepositoryOwner \
+            --jq ".[] | select(.headRepositoryOwner.login == \"$owner\") | .headRefName" \
+            | sort -u > merged.txt
+          gh api --paginate "repos/$repo/branches?per_page=100" \
+            --jq '.[] | select(.protected) | .name' | sort -u > protected.txt
+
+          {
+            echo "## Stale branch prune"
+            echo
+            [ "$DRY_RUN" = true ] && echo "**Dry run:** nothing was deleted." && echo
+            echo "| Branch | Last commit | Action | Reason |"
+            echo "|---|---|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          git for-each-ref --format='%(refname) %(committerdate:unix) %(committerdate:short)' refs/remotes/origin \
+          | sed 's|^refs/remotes/origin/||' \
+          | while read -r branch ts date; do
+              case "$branch" in HEAD|"$default_branch") continue ;; esac
+
+              action=keep; reason=
+              if grep -qxF "$branch" protected.txt; then
+                reason="protected"
+              elif grep -qxF "$branch" open.txt; then
+                reason="open pull request"
+              elif [[ "$branch" == screenshots/* || "$branch" == *-assets ]]; then
+                reason="asset branch"
+              elif ! git merge-base "origin/$default_branch" "origin/$branch" >/dev/null 2>&1; then
+                reason="orphan branch (assets)"
+              elif grep -qxF "$branch" merged.txt; then
+                action=delete; reason="pull request merged"
+              elif git merge-base --is-ancestor "origin/$branch" "origin/$default_branch"; then
+                action=delete; reason="fully merged into $default_branch"
+              elif [ "$ts" -lt "$cutoff" ]; then
+                action=delete; reason="no commits in $DAYS days"
+              else
+                reason="active, no PR"
+              fi
+
+              if [ "$action" = delete ]; then
+                if [ "$DRY_RUN" = true ]; then
+                  echo "would delete $branch ($reason)"
+                else
+                  echo "deleting $branch ($reason)"
+                  git push origin --delete "$branch"
+                fi
+                echo "| \`$branch\` | $date | delete | $reason |" >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "| \`$branch\` | $date | keep | $reason |" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            done

--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -50,17 +50,24 @@ jobs:
           repo="$GITHUB_REPOSITORY"
           owner="${repo%%/*}"
           default_branch=$(gh api "repos/$repo" --jq .default_branch)
+
+          # The days input is free text: refuse anything but a non-negative integer,
+          # otherwise a typo like "-1" would put the cutoff in the future and mark
+          # every branch stale.
+          if ! [[ "$DAYS" =~ ^[0-9]+$ ]]; then
+            echo "days must be a non-negative integer, got '$DAYS'" >&2
+            exit 1
+          fi
           cutoff=$(( $(date +%s) - DAYS * 86400 ))
 
-          # Branch names that currently have an open PR, and ones whose PR was merged.
-          # Only PRs whose head lives in this repo count: a fork's branch name is not ours.
-          gh pr list --repo "$repo" --state open --limit 1000 \
-            --json headRefName,headRepositoryOwner \
-            --jq ".[] | select(.headRepositoryOwner.login == \"$owner\") | .headRefName" \
+          # Branches with an open PR, and "branch sha" pairs for every merged PR head.
+          # Paginated, so the lists are complete however many PRs the repo has. Only
+          # PRs whose head lives in this repo count: a fork's branch name is not ours.
+          gh api --paginate "repos/$repo/pulls?state=open&per_page=100" \
+            --jq ".[] | select(.head.repo.owner.login == \"$owner\") | .head.ref" \
             | sort -u > open.txt
-          gh pr list --repo "$repo" --state merged --limit 1000 \
-            --json headRefName,headRepositoryOwner \
-            --jq ".[] | select(.headRepositoryOwner.login == \"$owner\") | .headRefName" \
+          gh api --paginate "repos/$repo/pulls?state=closed&per_page=100" \
+            --jq ".[] | select(.merged_at != null and .head.repo.owner.login == \"$owner\") | \"\(.head.ref) \(.head.sha)\"" \
             | sort -u > merged.txt
           gh api --paginate "repos/$repo/branches?per_page=100" \
             --jq '.[] | select(.protected) | .name' | sort -u > protected.txt
@@ -73,9 +80,9 @@ jobs:
             echo "|---|---|---|---|"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          git for-each-ref --format='%(refname) %(committerdate:unix) %(committerdate:short)' refs/remotes/origin \
+          git for-each-ref --format='%(refname) %(objectname) %(committerdate:unix) %(committerdate:short)' refs/remotes/origin \
           | sed 's|^refs/remotes/origin/||' \
-          | while read -r branch ts date; do
+          | while read -r branch sha ts date; do
               case "$branch" in HEAD|"$default_branch") continue ;; esac
 
               action=keep; reason=
@@ -87,7 +94,9 @@ jobs:
                 reason="asset branch"
               elif ! git merge-base "origin/$default_branch" "origin/$branch" >/dev/null 2>&1; then
                 reason="orphan branch (assets)"
-              elif grep -qxF "$branch" merged.txt; then
+              elif grep -qxF "$branch $sha" merged.txt; then
+                # Only when the tip is exactly the merged PR's head. A branch reused or
+                # pushed to after its PR merged falls through to the checks below.
                 action=delete; reason="pull request merged"
               elif git merge-base --is-ancestor "origin/$branch" "origin/$default_branch"; then
                 action=delete; reason="fully merged into $default_branch"
@@ -97,13 +106,19 @@ jobs:
                 reason="active, no PR"
               fi
 
-              if [ "$action" = delete ]; then
-                if [ "$DRY_RUN" = true ]; then
-                  echo "would delete $branch ($reason)"
-                else
-                  echo "deleting $branch ($reason)"
-                  git push origin --delete "$branch"
+              if [ "$action" = delete ] && [ "$DRY_RUN" != true ]; then
+                # The snapshot above may be minutes old. Re-check for a PR opened since,
+                # and delete with a lease so a push since the snapshot makes the delete
+                # fail rather than discard the new commits.
+                if [ "$(gh api "repos/$repo/pulls?state=open&head=$owner:$branch&per_page=1" --jq length)" != 0 ]; then
+                  action=keep; reason="open pull request (opened during run)"
+                elif ! git push --force-with-lease="refs/heads/$branch:$sha" origin ":refs/heads/$branch"; then
+                  action=keep; reason="changed during run, left alone"
                 fi
+              fi
+
+              if [ "$action" = delete ]; then
+                if [ "$DRY_RUN" = true ]; then echo "would delete $branch ($reason)"; else echo "deleted $branch ($reason)"; fi
                 echo "| \`$branch\` | $date | delete | $reason |" >> "$GITHUB_STEP_SUMMARY"
               else
                 echo "| \`$branch\` | $date | keep | $reason |" >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ Log in with `devuser` / `devpassword`. `./scripts/reset-dev-vikunja.sh` nukes an
 - `.github/workflows/vikunja-integration.yml` runs `mDoneIntegrationTests` nightly (and on demand) against a real Vikunja server: the latest release plus the pinned version the API inventory was verified against. It runs the native macOS release binary straight on the runner, never Docker, because the hosted arm64 macOS runners cannot boot a Linux VM. It never runs on a PR and cannot block a merge.
 - `.github/workflows/codeql.yml` runs CodeQL (build-only, so it uses `generic/platform=iOS Simulator`); `.github/workflows/deploy-pages.yml` publishes `website/`.
 - `.github/workflows/github-release.yml` runs on every push to `main`. It reads `MARKETING_VERSION` from `project.yml` and, when `CHANGELOG.md` has a stamped `## [<version>] - <date>` section and no `v<version>` tag exists, tags the commit and publishes a GitHub Release with that section as its notes. Stamping the changelog is therefore what makes a version appear under Releases; a build-number-only bump for a TestFlight build does not.
+- `.github/workflows/stale-branches.yml` runs every Monday (and on demand, with a dry-run option) and deletes remote branches that have a merged PR, are fully contained in `main`, or have had no commits in 90 days. Branches with an open PR are never touched. `screenshots/*`, `*-assets` and orphan branches are kept because issues and PRs link to the images on them; use one of those names for anything else that should survive the prune.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/stale-branches.yml`, which runs every Monday (and on demand) and deletes remote branches that have a merged PR, are fully contained in `main`, or have had no commits in 90 days.
- Never touches a branch with an open PR, a protected branch, or the asset branches (`screenshots/*`, `*-assets`, orphans) that issues and PRs embed screenshots from.
- Manual runs take a `dry_run` flag that only writes the report, and a `days` override. Every run writes a keep/delete table to the job summary.
- Documents the rule in `CLAUDE.md` so the naming convention for branches that should survive is written down.

Alongside this PR, 72 already-merged or superseded branches were deleted by hand and the repo setting "Automatically delete head branches" was switched on, so PR branches now vanish at merge time and the weekly job only has to catch the rest.

## Test plan

- [x] Ran the script body locally in dry-run mode against the live remote: the three surviving branches (`issue-99-assets`, `screenshots/issue-56`, the open-PR branch for #196) all came back as keep.
- [x] Ran it with `days=0` to confirm the age rule alone cannot reach the open-PR or asset branches.
- [ ] After merge, trigger the workflow manually with `dry_run` on and check the job summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)