### PR TITLE
release: 1.17.0 build 69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Checklists written inside a task's description now work in mDone. Vikunja's web editor lets you put a list of checkboxes in a description, for the steps of a task that is not one and done. Those used to show up as plain bullets with no sign of what was ticked. The description preview now shows each item with a checkbox you can tap to tick or untick, saved straight away as in the web app, with a "2 of 3 done" line and progress bar above it. Task rows and Kanban cards carry a matching count. Works on iPhone, iPad and Mac. Checkboxes in a repeating task still reset when the task is marked done, since that is the server's doing (#200).
+
 ## [1.16.0] - 2026-09-11
 
 ### Added

--- a/mDone/Services/DescriptionChecklist.swift
+++ b/mDone/Services/DescriptionChecklist.swift
@@ -1,0 +1,301 @@
+import Foundation
+
+/// Read and toggle the checklists Vikunja keeps inside a task description.
+///
+/// Vikunja's description editor (Tiptap) stores a checklist as a task list:
+///
+/// ```html
+/// <ul data-type="taskList">
+///   <li data-checked="true" data-type="taskItem">
+///     <label><input type="checkbox" checked="checked"><span></span></label>
+///     <div><p>Johnny</p></div>
+///   </li>
+///   <li data-checked="false" data-type="taskItem">
+///     <label><input type="checkbox"><span></span></label>
+///     <div><p>Atlas</p></div>
+///   </li>
+/// </ul>
+/// ```
+///
+/// There is no separate API for the items: ticking one is a task update that
+/// sends the description back with `data-checked` flipped. `data-checked` is
+/// the attribute Vikunja's editor and its repeat-reset read; the `checked`
+/// attribute on the input is kept in step so the markup stays the shape the
+/// web app writes. The web app's card badge counts these attributes too, so
+/// the counts here match what it shows (issue #200).
+///
+/// Everything here is pure string work over the raw HTML: nothing else in the
+/// description is touched, so text the user wrote around the list survives a
+/// toggle byte for byte.
+struct DescriptionChecklist: Equatable {
+    struct Item: Identifiable, Equatable {
+        /// Position of the item in the description, counting every task item
+        /// in document order. Stable for the lifetime of one description
+        /// string, which is what `toggling(itemAt:in:)` keys on.
+        let id: Int
+        let text: String
+        let isChecked: Bool
+    }
+
+    let items: [Item]
+
+    var doneCount: Int {
+        items.filter(\.isChecked).count
+    }
+
+    var totalCount: Int {
+        items.count
+    }
+
+    var isComplete: Bool {
+        !items.isEmpty && doneCount == totalCount
+    }
+
+    /// Completed fraction, 0...1, for a progress bar. Zero when empty.
+    var fraction: Double {
+        guard totalCount > 0 else { return 0 }
+        return Double(doneCount) / Double(totalCount)
+    }
+
+    // MARK: - Parsing
+
+    /// The checklist items in `html`, or `nil` when the description has none.
+    static func parse(_ html: String?) -> DescriptionChecklist? {
+        guard let html, hasChecklist(html) else { return nil }
+        let items = itemMatches(in: html).enumerated().map { index, match in
+            Item(id: index, text: match.text, isChecked: match.isChecked)
+        }
+        return items.isEmpty ? nil : DescriptionChecklist(items: items)
+    }
+
+    /// Cheap pre-check so lists of tasks without checklists never pay for a
+    /// regex scan.
+    static func hasChecklist(_ html: String) -> Bool {
+        html.contains("data-checked=")
+    }
+
+    // MARK: - Toggling
+
+    /// `html` with item `index` flipped, or `nil` when there is no such item.
+    static func toggling(itemAt index: Int, in html: String) -> String? {
+        let matches = itemMatches(in: html)
+        guard matches.indices.contains(index) else { return nil }
+        return setting(matches[index], checked: !matches[index].isChecked, in: html)
+    }
+
+    /// `html` with item `index` set to `checked`, or `nil` when there is no
+    /// such item. A no-op returns the input unchanged.
+    static func setting(itemAt index: Int, checked: Bool, in html: String) -> String? {
+        let matches = itemMatches(in: html)
+        guard matches.indices.contains(index) else { return nil }
+        return setting(matches[index], checked: checked, in: html)
+    }
+
+    // MARK: - Segments
+
+    /// A description split into the runs of ordinary HTML and the checklists
+    /// between them, so a view can render the prose with the rich-text
+    /// renderer and the checklists as native toggles. Item ids are the same
+    /// document-order indices `parse` assigns, so a toggle from a segment
+    /// maps straight back to `toggling(itemAt:in:)`.
+    enum Segment: Equatable {
+        case html(String)
+        case checklist([Item])
+    }
+
+    static func segments(of html: String) -> [Segment] {
+        guard hasChecklist(html), let listRegex = taskListOpenRegex else { return [.html(html)] }
+        let matches = itemMatches(in: html)
+        let nsHTML = html as NSString
+        var segments: [Segment] = []
+        var cursor = 0
+        var searchFrom = 0
+
+        while let open = listRegex.firstMatch(
+            in: html, range: NSRange(location: searchFrom, length: nsHTML.length - searchFrom)
+        ) {
+            let listStart = open.range.location
+            let listEnd = closingListEnd(in: nsHTML, openingAt: open.range)
+            let listRange = NSRange(location: listStart, length: listEnd - listStart)
+            let itemsInList = matches.enumerated().compactMap { index, match -> Item? in
+                guard NSLocationInRange(match.openTagRange.location, listRange) else { return nil }
+                return Item(id: index, text: match.text, isChecked: match.isChecked)
+            }
+
+            if itemsInList.isEmpty {
+                // A task list with nothing in it, or one whose markup we do
+                // not recognise: leave it to the rich-text renderer.
+                searchFrom = listEnd
+                continue
+            }
+
+            let before = nsHTML.substring(with: NSRange(location: cursor, length: listStart - cursor))
+            if !before.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                segments.append(.html(before))
+            }
+            segments.append(.checklist(itemsInList))
+            cursor = listEnd
+            searchFrom = listEnd
+        }
+
+        let tail = nsHTML.substring(from: cursor)
+        if !tail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            segments.append(.html(tail))
+        }
+        return segments.isEmpty ? [.html(html)] : segments
+    }
+
+    // MARK: - Internals
+
+    private struct ItemMatch {
+        /// The `<li ...>` opening tag.
+        let openTagRange: NSRange
+        /// From the end of the opening tag to the start of the next `<li` or
+        /// `</li>`, whichever comes first. Nested lists therefore contribute
+        /// their own flat items rather than being swallowed by the parent.
+        let bodyRange: NSRange
+        let isChecked: Bool
+        let text: String
+    }
+
+    /// An `<li>` carrying `data-checked`. Attribute order is not fixed, so
+    /// the tag is matched as a whole and the attribute read from it.
+    private static let itemOpenRegex = try? NSRegularExpression(
+        pattern: #"<li\b[^>]*\bdata-checked\s*=\s*"(true|false)"[^>]*>"#,
+        options: [.caseInsensitive]
+    )
+    private static let taskListOpenRegex = try? NSRegularExpression(
+        pattern: #"<ul\b[^>]*\bdata-type\s*=\s*"taskList"[^>]*>"#,
+        options: [.caseInsensitive]
+    )
+    private static let listBoundaryRegex = try? NSRegularExpression(
+        pattern: #"<ul\b[^>]*>|</ul\s*>"#,
+        options: [.caseInsensitive]
+    )
+    private static let itemBoundaryRegex = try? NSRegularExpression(
+        pattern: #"<li\b|</li\s*>"#,
+        options: [.caseInsensitive]
+    )
+    private static let checkboxRegex = try? NSRegularExpression(
+        pattern: #"<input\b[^>]*\btype\s*=\s*"checkbox"[^>]*>"#,
+        options: [.caseInsensitive]
+    )
+    private static let checkedAttributeRegex = try? NSRegularExpression(
+        pattern: #"\s+checked(\s*=\s*("[^"]*"|'[^']*'|[^\s>/]+))?"#,
+        options: [.caseInsensitive]
+    )
+    private static let dataCheckedRegex = try? NSRegularExpression(
+        pattern: #"\bdata-checked\s*=\s*"(true|false)""#,
+        options: [.caseInsensitive]
+    )
+    private static let tagRegex = try? NSRegularExpression(pattern: #"<[^>]+>"#)
+
+    private static func itemMatches(in html: String) -> [ItemMatch] {
+        guard let itemOpenRegex, let itemBoundaryRegex else { return [] }
+        let nsHTML = html as NSString
+        let full = NSRange(location: 0, length: nsHTML.length)
+        return itemOpenRegex.matches(in: html, range: full).map { match in
+            let openTag = match.range
+            let isChecked = nsHTML.substring(with: match.range(at: 1)).lowercased() == "true"
+            let bodyStart = openTag.location + openTag.length
+            let searchRange = NSRange(location: bodyStart, length: nsHTML.length - bodyStart)
+            let bodyEnd = itemBoundaryRegex.firstMatch(in: html, range: searchRange)?.range.location ?? nsHTML.length
+            let bodyRange = NSRange(location: bodyStart, length: bodyEnd - bodyStart)
+            return ItemMatch(
+                openTagRange: openTag,
+                bodyRange: bodyRange,
+                isChecked: isChecked,
+                text: plainText(of: nsHTML.substring(with: bodyRange))
+            )
+        }
+    }
+
+    /// The end offset of the `</ul>` that closes the task list opened at
+    /// `open`, counting nested lists. Falls back to the end of the string
+    /// for unbalanced markup.
+    private static func closingListEnd(in nsHTML: NSString, openingAt open: NSRange) -> Int {
+        guard let listBoundaryRegex else { return nsHTML.length }
+        var depth = 1
+        var position = open.location + open.length
+        while position < nsHTML.length {
+            let range = NSRange(location: position, length: nsHTML.length - position)
+            guard let boundary = listBoundaryRegex.firstMatch(in: nsHTML as String, range: range) else { break }
+            let token = nsHTML.substring(with: boundary.range)
+            depth += token.hasPrefix("</") ? -1 : 1
+            position = boundary.range.location + boundary.range.length
+            if depth == 0 {
+                return position
+            }
+        }
+        return nsHTML.length
+    }
+
+    private static func setting(_ item: ItemMatch, checked: Bool, in html: String) -> String {
+        guard item.isChecked != checked,
+              let dataCheckedRegex, let checkboxRegex, let checkedAttributeRegex
+        else { return html }
+        let nsHTML = html as NSString
+        let result = NSMutableString(string: html)
+
+        // Body first, so the opening tag's offsets are still valid after.
+        if let checkbox = checkboxRegex.firstMatch(in: html, range: item.bodyRange) {
+            let tag = NSMutableString(string: nsHTML.substring(with: checkbox.range))
+            let tagRange = NSRange(location: 0, length: tag.length)
+            checkedAttributeRegex.replaceMatches(in: tag, range: tagRange, withTemplate: "")
+            if checked {
+                // Re-insert before the closing `>` or `/>`, with the single
+                // space the web app's serialiser would put there.
+                let selfClosing = tag.hasSuffix("/>")
+                var body = (tag as String).dropLast(selfClosing ? 2 : 1)
+                while body.last?.isWhitespace == true {
+                    body = body.dropLast()
+                }
+                tag.setString(body + " checked=\"checked\"" + (selfClosing ? " />" : ">"))
+            }
+            result.replaceCharacters(in: checkbox.range, with: tag as String)
+        }
+
+        let openTag = NSMutableString(string: nsHTML.substring(with: item.openTagRange))
+        dataCheckedRegex.replaceMatches(
+            in: openTag,
+            range: NSRange(location: 0, length: openTag.length),
+            withTemplate: "data-checked=\"\(checked ? "true" : "false")\""
+        )
+        result.replaceCharacters(in: item.openTagRange, with: openTag as String)
+        return result as String
+    }
+
+    /// The item's label: tags removed, entities decoded, whitespace collapsed.
+    private static func plainText(of fragment: String) -> String {
+        var text = fragment
+        if let tagRegex {
+            text = tagRegex.stringByReplacingMatches(
+                in: text, range: NSRange(text.startIndex..., in: text), withTemplate: " "
+            )
+        }
+        text = decodeEntities(text)
+        return text.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+    }
+
+    private static func decodeEntities(_ text: String) -> String {
+        guard text.contains("&") else { return text }
+        var result = text
+        for (entity, character) in [
+            ("&nbsp;", " "), ("&lt;", "<"), ("&gt;", ">"), ("&quot;", "\""), ("&#39;", "'"), ("&apos;", "'"),
+        ] {
+            result = result.replacingOccurrences(of: entity, with: character)
+        }
+        // Last, so `&amp;lt;` decodes to `&lt;` and not to `<`.
+        return result.replacingOccurrences(of: "&amp;", with: "&")
+    }
+}
+
+extension VTask {
+    /// Completed/total counts across the checklist items in the description,
+    /// matching the badge Vikunja's web app puts on a card. `nil` when the
+    /// description has no checklist.
+    var checklistCounts: (done: Int, total: Int)? {
+        guard let checklist = DescriptionChecklist.parse(description) else { return nil }
+        return (checklist.doneCount, checklist.totalCount)
+    }
+}

--- a/mDone/Views/Mac/MacTaskDetailView.swift
+++ b/mDone/Views/Mac/MacTaskDetailView.swift
@@ -75,10 +75,11 @@ struct MacTaskDetailView: View {
                                 .italic()
                                 .frame(minHeight: 100, alignment: .topLeading)
                         } else {
+                            if let checklist = DescriptionChecklist.parse(descriptionText) {
+                                ChecklistSummaryView(checklist: checklist)
+                            }
                             ScrollView {
-                                Text(RichTextRenderer.render(descriptionText))
-                                    .font(.body)
-                                    .textSelection(.enabled)
+                                RichDescriptionView(html: descriptionText, onToggle: toggleChecklistItem)
                                     .frame(maxWidth: .infinity, alignment: .topLeading)
                             }
                             .frame(minHeight: 100, maxHeight: 200)
@@ -234,6 +235,18 @@ struct MacTaskDetailView: View {
             isShowingDescriptionPreview = !newDescription.isEmpty
             estimateSeconds = newTask.estimatedSeconds
             percentDone = newTask.percentDone ?? 0
+        }
+    }
+
+    /// Ticks or unticks one checklist item and saves the description straight
+    /// away, the way the web app does. Only the description is sent; the
+    /// rest of the form waits for Save.
+    private func toggleChecklistItem(_ index: Int) {
+        guard let updated = DescriptionChecklist.toggling(itemAt: index, in: descriptionText) else { return }
+        descriptionText = updated
+        let composed = EstimateMarker.apply(estimateSeconds, to: updated) ?? ""
+        Task { @MainActor in
+            await appState.updateTask(id: task.id, request: TaskUpdateRequest(description: composed))
         }
     }
 

--- a/mDone/Views/Projects/ProjectBoardView.swift
+++ b/mDone/Views/Projects/ProjectBoardView.swift
@@ -349,7 +349,7 @@ private struct BoardTaskCard: View {
             }
             .fixedSize(horizontal: false, vertical: true)
 
-            if task.effectiveDueDate != nil || (task.labels?.isEmpty == false) {
+            if task.effectiveDueDate != nil || task.checklistCounts != nil || (task.labels?.isEmpty == false) {
                 HStack(spacing: 8) {
                     if let dueDate = task.effectiveDueDate {
                         HStack(spacing: 4) {
@@ -358,6 +358,11 @@ private struct BoardTaskCard: View {
                         }
                         .font(.caption2)
                         .foregroundStyle(task.isOverdue ? .red : .secondary)
+                    }
+
+                    if let counts = task.checklistCounts {
+                        ChecklistCountBadge(done: counts.done, total: counts.total)
+                            .font(.caption2)
                     }
 
                     if let labels = task.labels, !labels.isEmpty {
@@ -392,6 +397,9 @@ private struct BoardTaskCard: View {
                 parts.append(String(localized: "overdue"))
             }
             parts.append(String(localized: "due \(due.formatted(date: .abbreviated, time: .omitted))"))
+        }
+        if let counts = task.checklistCounts {
+            parts.append(String(localized: "\(counts.done) of \(counts.total) checklist items done"))
         }
         return parts.joined(separator: ", ")
     }

--- a/mDone/Views/Tasks/DescriptionChecklistView.swift
+++ b/mDone/Views/Tasks/DescriptionChecklistView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+/// The description preview: prose through the rich-text renderer, and any
+/// checklist in it as native rows that can be ticked in place (issue #200).
+///
+/// `onToggle` receives the item's document-order index, the one
+/// `DescriptionChecklist.toggling(itemAt:in:)` expects. Pass `nil` for a
+/// read-only preview.
+///
+/// The rendered segments live in `@State` and are refreshed by a task when
+/// the HTML changes, never computed in `body`. The HTML import behind
+/// `RichTextRenderer` pumps a nested run loop, which inside a SwiftUI update
+/// either traps ("setting value during update", when it runs in a `ForEach`
+/// closure) or silently loses the update (the ticks stayed stale after a
+/// toggle while the summary beside them redrew). The first render happens
+/// in `init`, the way the detail views always rendered on creation, so the
+/// preview does not flash empty.
+struct RichDescriptionView: View {
+    let html: String
+    var onToggle: ((Int) -> Void)?
+
+    @State private var rendered: [Rendered]
+    @State private var renderedHTML: String
+
+    init(html: String, onToggle: ((Int) -> Void)? = nil) {
+        self.html = html
+        self.onToggle = onToggle
+        _rendered = State(initialValue: Self.render(html))
+        _renderedHTML = State(initialValue: html)
+    }
+
+    private struct Rendered: Identifiable {
+        enum Content {
+            case text(AttributedString)
+            case checklist([DescriptionChecklist.Item])
+        }
+
+        let id: Int
+        let content: Content
+    }
+
+    private static func render(_ html: String) -> [Rendered] {
+        DescriptionChecklist.segments(of: html).enumerated().map { index, segment in
+            switch segment {
+            case let .html(fragment):
+                Rendered(id: index, content: .text(RichTextRenderer.render(fragment)))
+            case let .checklist(items):
+                Rendered(id: index, content: .checklist(items))
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(rendered) { segment in
+                switch segment.content {
+                case let .text(attributed):
+                    Text(attributed)
+                        .font(.body)
+                        .textSelection(.enabled)
+                case let .checklist(items):
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(items) { item in
+                            ChecklistItemRow(item: item) {
+                                onToggle?(item.id)
+                            }
+                            .disabled(onToggle == nil)
+                        }
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .task(id: html) {
+            guard html != renderedHTML else { return }
+            rendered = Self.render(html)
+            renderedHTML = html
+        }
+    }
+}
+
+private struct ChecklistItemRow: View {
+    let item: DescriptionChecklist.Item
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Image(systemName: item.isChecked ? "checkmark.circle.fill" : "circle")
+                    .font(.body)
+                    .foregroundStyle(item.isChecked ? Color.accentColor : Color.secondary)
+                    .accessibilityHidden(true)
+                Text(item.text)
+                    .font(.body)
+                    .strikethrough(item.isChecked)
+                    .foregroundStyle(item.isChecked ? Color.secondary : Color.primary)
+                    .multilineTextAlignment(.leading)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(item.text)
+        .accessibilityValue(item.isChecked ? Text("Done") : Text("Not done"))
+        .accessibilityAddTraits(item.isChecked ? .isSelected : [])
+        .accessibilityHint("Double tap to toggle")
+    }
+}
+
+/// "2 of 3 done" with a thin progress bar, the same summary Vikunja's web
+/// app shows above a description with a checklist.
+struct ChecklistSummaryView: View {
+    let checklist: DescriptionChecklist
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("\(checklist.doneCount) of \(checklist.totalCount) done")
+                .font(.caption)
+                .monospacedDigit()
+                .foregroundStyle(checklist.isComplete ? Color.green : Color.secondary)
+            ProgressView(value: checklist.fraction)
+                .tint(checklist.isComplete ? .green : .accentColor)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Checklist")
+        .accessibilityValue("\(checklist.doneCount) of \(checklist.totalCount) done")
+    }
+}
+
+/// The compact "2/3" badge task rows and Kanban cards show for a task whose
+/// description holds a checklist.
+struct ChecklistCountBadge: View {
+    let done: Int
+    let total: Int
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "checkmark.square")
+            Text("\(done)/\(total)")
+                .monospacedDigit()
+        }
+        .foregroundStyle(done == total ? Color.green : Color.secondary)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(done) of \(total) checklist items done")
+    }
+}

--- a/mDone/Views/Tasks/TaskDetailSheet.swift
+++ b/mDone/Views/Tasks/TaskDetailSheet.swift
@@ -166,9 +166,10 @@ struct TaskDetailSheet: View {
                                 .foregroundStyle(.secondary)
                                 .italic()
                         } else {
-                            Text(RichTextRenderer.render(description))
-                                .font(.body)
-                                .textSelection(.enabled)
+                            if let checklist = DescriptionChecklist.parse(description) {
+                                ChecklistSummaryView(checklist: checklist)
+                            }
+                            RichDescriptionView(html: description, onToggle: toggleChecklistItem)
                         }
                     } else {
                         TextEditor(text: $description)
@@ -297,6 +298,20 @@ struct TaskDetailSheet: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This action cannot be undone.")
+        }
+    }
+
+    /// Ticks or unticks one checklist item in the description and saves that
+    /// straight away, the way the web app does, so a tick survives Cancel.
+    /// The rest of the form stays unsaved until Save: the request carries
+    /// only the description, and `updateTask` fills the other fields in
+    /// from the task as the server last had it.
+    private func toggleChecklistItem(_ index: Int) {
+        guard let updated = DescriptionChecklist.toggling(itemAt: index, in: description) else { return }
+        description = updated
+        let composed = EstimateMarker.apply(estimateSeconds, to: updated) ?? ""
+        Task { @MainActor in
+            await appState.updateTask(id: task.id, request: TaskUpdateRequest(description: composed))
         }
     }
 

--- a/mDone/Views/Tasks/TaskRow.swift
+++ b/mDone/Views/Tasks/TaskRow.swift
@@ -271,6 +271,11 @@ struct TaskRow: View {
                         .foregroundStyle(counts.done == counts.total ? Color.green : Color.secondary)
                     }
 
+                    if let counts = task.checklistCounts {
+                        ChecklistCountBadge(done: counts.done, total: counts.total)
+                            .font(density.metadataFont)
+                    }
+
                     if let labels = task.labels, !labels.isEmpty {
                         HStack(spacing: 4) {
                             ForEach(labels.prefix(3)) { label in
@@ -319,6 +324,9 @@ struct TaskRow: View {
         }
         if let counts = task.subtaskCounts {
             parts.append("\(counts.done) of \(counts.total) subtasks done")
+        }
+        if let counts = task.checklistCounts {
+            parts.append("\(counts.done) of \(counts.total) checklist items done")
         }
         if task.priority > 0 {
             parts.append("priority \(task.priorityLevel.label)")

--- a/mDoneTests/DescriptionChecklistTests.swift
+++ b/mDoneTests/DescriptionChecklistTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+@testable import mDone
+
+final class DescriptionChecklistTests: XCTestCase {
+    /// Exactly what Vikunja's Tiptap editor writes for the screenshot in
+    /// issue #200: two ticked names and one still open.
+    private let vikunjaHTML = """
+    <ul data-type="taskList"><li data-checked="true" data-type="taskItem"><label><input type="checkbox" checked="checked"><span></span></label><div><p>Johnny</p></div></li><li data-checked="true" data-type="taskItem"><label><input type="checkbox" checked="checked"><span></span></label><div><p>Steven</p></div></li><li data-checked="false" data-type="taskItem"><label><input type="checkbox"><span></span></label><div><p>Atlas</p></div></li></ul>
+    """
+
+    // MARK: - parse
+
+    func testParseReadsVikunjaTaskList() throws {
+        let checklist = try XCTUnwrap(DescriptionChecklist.parse(vikunjaHTML))
+        XCTAssertEqual(checklist.items.map(\.text), ["Johnny", "Steven", "Atlas"])
+        XCTAssertEqual(checklist.items.map(\.isChecked), [true, true, false])
+        XCTAssertEqual(checklist.items.map(\.id), [0, 1, 2])
+        XCTAssertEqual(checklist.doneCount, 2)
+        XCTAssertEqual(checklist.totalCount, 3)
+        XCTAssertFalse(checklist.isComplete)
+        XCTAssertEqual(checklist.fraction, 2.0 / 3.0, accuracy: 0.0001)
+    }
+
+    func testParseReturnsNilWithoutChecklist() {
+        XCTAssertNil(DescriptionChecklist.parse(nil))
+        XCTAssertNil(DescriptionChecklist.parse(""))
+        XCTAssertNil(DescriptionChecklist.parse("<p>Plain description</p>"))
+        XCTAssertNil(DescriptionChecklist.parse("<ul><li>Ordinary bullet</li></ul>"))
+        XCTAssertNil(DescriptionChecklist.parse("- [ ] markdown checkbox is not a Tiptap task item"))
+    }
+
+    func testParseAcceptsAnyAttributeOrder() throws {
+        let html = #"<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><p>Only</p></li></ul>"#
+        let checklist = try XCTUnwrap(DescriptionChecklist.parse(html))
+        XCTAssertEqual(checklist.items.count, 1)
+        XCTAssertEqual(checklist.items[0].text, "Only")
+        XCTAssertFalse(checklist.items[0].isChecked)
+    }
+
+    func testParseStripsInlineMarkupAndDecodesEntities() throws {
+        let html = #"<ul data-type="taskList"><li data-checked="false"><div><p>Pay <strong>Tom &amp; Jerry</strong>&nbsp;&lt;today&gt;</p></div></li></ul>"#
+        let checklist = try XCTUnwrap(DescriptionChecklist.parse(html))
+        XCTAssertEqual(checklist.items[0].text, "Pay Tom & Jerry <today>")
+    }
+
+    func testParseFlattensNestedItems() throws {
+        let html = """
+        <ul data-type="taskList"><li data-checked="false"><p>Parent</p><ul data-type="taskList"><li data-checked="true"><p>Child</p></li></ul></li></ul>
+        """
+        let checklist = try XCTUnwrap(DescriptionChecklist.parse(html))
+        XCTAssertEqual(checklist.items.map(\.text), ["Parent", "Child"])
+        XCTAssertEqual(checklist.items.map(\.isChecked), [false, true])
+    }
+
+    func testParseIsCompleteWhenEveryItemIsChecked() throws {
+        let html = #"<ul data-type="taskList"><li data-checked="true"><p>A</p></li><li data-checked="true"><p>B</p></li></ul>"#
+        let checklist = try XCTUnwrap(DescriptionChecklist.parse(html))
+        XCTAssertTrue(checklist.isComplete)
+        XCTAssertEqual(checklist.fraction, 1)
+    }
+
+    // MARK: - toggling
+
+    func testTogglingTicksAnOpenItem() throws {
+        let updated = try XCTUnwrap(DescriptionChecklist.toggling(itemAt: 2, in: vikunjaHTML))
+        let checklist = try XCTUnwrap(DescriptionChecklist.parse(updated))
+        XCTAssertEqual(checklist.items.map(\.isChecked), [true, true, true])
+        // The input is kept in step with the li so the markup stays the shape the web app writes.
+        XCTAssertTrue(
+            updated
+                .contains(
+                    #"<li data-checked="true" data-type="taskItem"><label><input type="checkbox" checked="checked"><span></span></label><div><p>Atlas</p></div></li>"#
+                ),
+            updated
+        )
+    }
+
+    func testTogglingUnticksACheckedItem() throws {
+        let updated = try XCTUnwrap(DescriptionChecklist.toggling(itemAt: 0, in: vikunjaHTML))
+        let checklist = try XCTUnwrap(DescriptionChecklist.parse(updated))
+        XCTAssertEqual(checklist.items.map(\.isChecked), [false, true, false])
+        XCTAssertTrue(
+            updated
+                .contains(
+                    #"<li data-checked="false" data-type="taskItem"><label><input type="checkbox"><span></span></label><div><p>Johnny</p></div></li>"#
+                ),
+            updated
+        )
+    }
+
+    func testTogglingLeavesEverythingElseUntouched() throws {
+        let html = "<p>Before &amp; after</p>\n" + vikunjaHTML + "\n<p>Tail with <em>emphasis</em></p>"
+        let updated = try XCTUnwrap(DescriptionChecklist.toggling(itemAt: 2, in: html))
+        XCTAssertTrue(updated.hasPrefix("<p>Before &amp; after</p>\n"))
+        XCTAssertTrue(updated.hasSuffix("\n<p>Tail with <em>emphasis</em></p>"))
+        // Toggling back restores the exact original bytes.
+        XCTAssertEqual(DescriptionChecklist.toggling(itemAt: 2, in: updated), html)
+    }
+
+    func testTogglingHandlesBareCheckedAttributeAndSelfClosingInput() throws {
+        let html = #"<ul data-type="taskList"><li data-checked="true"><label><input checked type="checkbox" /></label><p>X</p></li></ul>"#
+        let updated = try XCTUnwrap(DescriptionChecklist.toggling(itemAt: 0, in: html))
+        XCTAssertEqual(
+            updated,
+            #"<ul data-type="taskList"><li data-checked="false"><label><input type="checkbox" /></label><p>X</p></li></ul>"#
+        )
+        let reticked = try XCTUnwrap(DescriptionChecklist.toggling(itemAt: 0, in: updated))
+        XCTAssertEqual(
+            reticked,
+            #"<ul data-type="taskList"><li data-checked="true"><label><input type="checkbox" checked="checked" /></label><p>X</p></li></ul>"#
+        )
+    }
+
+    func testTogglingOnlyTouchesTheChosenItemsCheckbox() throws {
+        // Each item's checkbox lives in its own body, so ticking the second item must not tick the first's input.
+        let html = #"<ul data-type="taskList"><li data-checked="false"><input type="checkbox"><p>A</p></li><li data-checked="false"><input type="checkbox"><p>B</p></li></ul>"#
+        let updated = try XCTUnwrap(DescriptionChecklist.toggling(itemAt: 1, in: html))
+        XCTAssertEqual(
+            updated,
+            #"<ul data-type="taskList"><li data-checked="false"><input type="checkbox"><p>A</p></li><li data-checked="true"><input type="checkbox" checked="checked"><p>B</p></li></ul>"#
+        )
+    }
+
+    func testTogglingOutOfRangeReturnsNil() {
+        XCTAssertNil(DescriptionChecklist.toggling(itemAt: 3, in: vikunjaHTML))
+        XCTAssertNil(DescriptionChecklist.toggling(itemAt: 0, in: "<p>nothing</p>"))
+    }
+
+    func testSettingToTheCurrentStateIsANoOp() {
+        XCTAssertEqual(DescriptionChecklist.setting(itemAt: 0, checked: true, in: vikunjaHTML), vikunjaHTML)
+        XCTAssertNil(DescriptionChecklist.setting(itemAt: 9, checked: true, in: vikunjaHTML))
+    }
+
+    // MARK: - segments
+
+    func testSegmentsSplitProseAroundTheChecklist() {
+        let html = "<p>Chase these:</p>" + vikunjaHTML + "<p>Then pay.</p>"
+        let segments = DescriptionChecklist.segments(of: html)
+        XCTAssertEqual(segments.count, 3)
+        XCTAssertEqual(segments[0], .html("<p>Chase these:</p>"))
+        guard case let .checklist(items) = segments[1]
+        else { return XCTFail("Expected a checklist, got \(segments[1])") }
+        XCTAssertEqual(items.map(\.id), [0, 1, 2])
+        XCTAssertEqual(items.map(\.text), ["Johnny", "Steven", "Atlas"])
+        XCTAssertEqual(segments[2], .html("<p>Then pay.</p>"))
+    }
+
+    func testSegmentsKeepDocumentOrderIdsAcrossTwoLists() {
+        let first = #"<ul data-type="taskList"><li data-checked="false"><p>A</p></li></ul>"#
+        let second = #"<ul data-type="taskList"><li data-checked="true"><p>B</p></li><li data-checked="false"><p>C</p></li></ul>"#
+        let segments = DescriptionChecklist.segments(of: first + "<p>gap</p>" + second)
+        XCTAssertEqual(segments.count, 3)
+        guard case let .checklist(firstItems) = segments[0],
+              case let .checklist(secondItems) = segments[2]
+        else { return XCTFail("Expected checklists at both ends, got \(segments)") }
+        XCTAssertEqual(firstItems.map(\.id), [0])
+        XCTAssertEqual(secondItems.map(\.id), [1, 2])
+        XCTAssertEqual(secondItems.map(\.text), ["B", "C"])
+    }
+
+    func testSegmentsTreatANestedListAsOneChecklist() {
+        let html = """
+        <ul data-type="taskList"><li data-checked="false"><p>Parent</p><ul data-type="taskList"><li data-checked="true"><p>Child</p></li></ul></li></ul><p>after</p>
+        """
+        let segments = DescriptionChecklist.segments(of: html)
+        XCTAssertEqual(segments.count, 2)
+        guard case let .checklist(items) = segments[0]
+        else { return XCTFail("Expected a checklist, got \(segments[0])") }
+        XCTAssertEqual(items.map(\.text), ["Parent", "Child"])
+        XCTAssertEqual(segments[1], .html("<p>after</p>"))
+    }
+
+    func testSegmentsWithoutChecklistIsTheWholeDescription() {
+        XCTAssertEqual(DescriptionChecklist.segments(of: "<p>Plain</p>"), [.html("<p>Plain</p>")])
+        XCTAssertEqual(DescriptionChecklist.segments(of: "Just text"), [.html("Just text")])
+    }
+
+    // MARK: - VTask
+
+    func testTaskChecklistCounts() {
+        var task = VTask(id: 1, title: "Bills", description: vikunjaHTML, done: false, priority: 0, projectId: 1)
+        XCTAssertEqual(task.checklistCounts?.done, 2)
+        XCTAssertEqual(task.checklistCounts?.total, 3)
+        task.description = "<p>No list</p>"
+        XCTAssertNil(task.checklistCounts)
+        task.description = nil
+        XCTAssertNil(task.checklistCounts)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -23,8 +23,8 @@ settings:
     # not feature-related — see PR "decisions".
     PRODUCT_NAME: "$(TARGET_NAME)"
     SWIFT_VERSION: "5.9"
-    MARKETING_VERSION: "1.16.0"
-    CURRENT_PROJECT_VERSION: "68"
+    MARKETING_VERSION: "1.17.0"
+    CURRENT_PROJECT_VERSION: "69"
     DEVELOPMENT_TEAM: "Z62E7MGREE"
     CODE_SIGN_IDENTITY: "Apple Development"
     CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
Bumps `project.yml` to 1.17.0 build 69 for the TestFlight cut carrying #201 (checklists inside descriptions, #200). New version rather than another 1.16.0 build because 1.16.0 build 68 is waiting for App Store review with a What's New that does not mention checklists. No changelog stamp: the entry stays under Unreleased until this ships.

Stacked on #201; merge that first and this reduces to the one-line bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)